### PR TITLE
Phosphor Example Tweaks

### DIFF
--- a/plugins/phosphor/src/App.tsx
+++ b/plugins/phosphor/src/App.tsx
@@ -73,7 +73,6 @@ const fuse = new Fuse(icons, {
     "categories",
   ],
   threshold: 0.2, // Tweak this to what feels like the right number of results
-  // shouldSort: false,
   useExtendedSearch: true,
 });
 
@@ -94,15 +93,15 @@ function IconGrid(props: any) {
       const { Icon } = entry;
 
       const svg = renderToStaticMarkup(
-        <Icon size={32} color={"black"} weight={weight} />,
+        <Icon size={32} color={"black"} weight={weight} />
       );
 
       await framer.addSVG({
         svg,
-        name: "test.svg",
+        name: "Icon",
       });
     },
-    [weight],
+    [weight]
   );
 
   if (filteredIcons.length === 0) {
@@ -122,8 +121,9 @@ function IconGrid(props: any) {
           <Draggable
             data={() => ({
               type: "svg",
+              name: "Icon",
               svg: renderToStaticMarkup(
-                <Icon size={32} color={"black"} weight={weight} />,
+                <Icon size={32} color={"black"} weight={weight} />
               ),
             })}
             key={entry.name}

--- a/plugins/phosphor/src/main.tsx
+++ b/plugins/phosphor/src/main.tsx
@@ -11,7 +11,7 @@ if (!root) {
 }
 
 void framer.showUI({
-  position: "top left",
+  position: "top right",
   width: 240,
   height: 445,
   resizable: true,


### PR DESCRIPTION
### Description

**Before**, `Draggable` did not pass a `name`, and the `onClick` insertion still had a "test" name. Also, this is probably personal preference, but I think top right > top left as a default place.

<img width="251" alt="image" src="https://github.com/framer/plugins/assets/869934/2b0e11d1-4dc8-42ee-93a3-2072c36ac944">


**After**:

<img width="251" alt="image" src="https://github.com/framer/plugins/assets/869934/d1e437a0-2e3e-46d1-a785-a2aaaa768aeb">




