### PR TITLE
Update Notion plugin to managed collection APIs

### DIFF
--- a/plugins/notion/framer.json
+++ b/plugins/notion/framer.json
@@ -1,6 +1,6 @@
 {
     "id": "e00c8d",
     "name": "Notion",
-    "modes": ["configureCollection", "syncCollection"],
+    "modes": ["configureManagedCollection", "syncManagedCollection"],
     "icon": "/notion.png"
 }

--- a/plugins/notion/src/MapFields.tsx
+++ b/plugins/notion/src/MapFields.tsx
@@ -53,9 +53,6 @@ function createFieldConfig(database: GetDatabaseResponse, pluginContext: PluginC
         const property = database.properties[key]
         assert(property)
 
-        // Title is always required in CMS API.
-        if (property.type === "title") continue
-
         result.push({
             field: getCollectionFieldForProperty(property),
             originalFieldName: property.name,
@@ -198,12 +195,6 @@ export function MapDatabaseFields({
                 <div className="grid grid-cols-fieldPicker gap-3 w-full items-center justify-center">
                     <span className="col-start-2 col-span-2">Notion Property</span>
                     <span>Collection Field</span>
-                    <input type="checkbox" readOnly checked={true} className="opacity-50 mx-auto" />
-                    <input type="text" className="w-full opacity-50" disabled value={"Title"} />
-                    <div className="flex items-center justify-center opacity-50">
-                        <IconChevron />
-                    </div>
-                    <input type="text" className={"w-full opacity-50"} disabled={true} placeholder={"Title"}></input>
 
                     {fieldConfig.map(fieldConfig => {
                         const isUnsupported = !fieldConfig.field

--- a/plugins/notion/src/main.tsx
+++ b/plugins/notion/src/main.tsx
@@ -61,7 +61,7 @@ async function runPlugin() {
         const pluginContext = await getPluginContext()
         const mode = framer.mode
 
-        if (mode === "syncCollection" && shouldSyncImmediately(pluginContext)) {
+        if (mode === "syncManagedCollection" && shouldSyncImmediately(pluginContext)) {
             assert(pluginContext.slugFieldId)
 
             const result = await synchronizeDatabase(pluginContext.database, {

--- a/plugins/notion/src/notion.ts
+++ b/plugins/notion/src/notion.ts
@@ -10,7 +10,7 @@ import {
 import pLimit from "p-limit"
 import { GetDatabaseResponse, PageObjectResponse, RichTextItemResponse } from "@notionhq/client/build/src/api-endpoints"
 import { assert, formatDate, isDefined, isString, slugify } from "./utils"
-import { Collection, CollectionField, CollectionItemData, framer, ManagedCollection } from "framer-plugin"
+import { CollectionField, CollectionItemData, framer, ManagedCollection } from "framer-plugin"
 import { useMutation, useQuery } from "@tanstack/react-query"
 import { blocksToHtml, richTextToHTML } from "./blocksToHTML"
 

--- a/plugins/rss-feeds/framer.json
+++ b/plugins/rss-feeds/framer.json
@@ -1,6 +1,6 @@
 {
     "id": "cad64a",
     "name": "RSS Feeds",
-    "modes": ["syncCollection", "configureCollection"],
+    "modes": ["syncManagedCollection", "configureManagedCollection"],
     "icon": "/rss.png"
 }

--- a/plugins/rss-feeds/src/App.tsx
+++ b/plugins/rss-feeds/src/App.tsx
@@ -1,4 +1,4 @@
-import { Collection, CollectionField, CollectionItem, framer } from "framer-plugin"
+import { CollectionField, CollectionItemData, framer, ManagedCollection } from "framer-plugin"
 
 import "./App.css"
 import { useState } from "react"
@@ -15,6 +15,7 @@ interface RSSSource {
 const linkFieldId = "link"
 const dateFieldId = "date"
 const contentFieldId = "content"
+const titleFieldId = "title"
 
 // A key to store the selected RSS source in the plugin data so it can be reused
 export const rssSourceStorageKey = "rssSourceId"
@@ -77,6 +78,11 @@ function parseRSS(xmlDoc: Document) {
 function getCollectionFields(): CollectionField[] {
     return [
         {
+            type: "string",
+            name: "Title",
+            id: titleFieldId,
+        },
+        {
             type: "link",
             id: linkFieldId,
             name: "Link",
@@ -94,7 +100,7 @@ function getCollectionFields(): CollectionField[] {
     ]
 }
 
-export async function importData(collection: Collection, sourceId: string) {
+export async function importData(collection: ManagedCollection, sourceId: string) {
     const rssSource = rssSources.find(source => source.id === sourceId)
     if (!rssSource) throw new Error("Invalid collection source id")
 
@@ -109,7 +115,7 @@ export async function importData(collection: Collection, sourceId: string) {
 
     const unseenItemIds = new Set(await collection.getItemIds())
 
-    const itemsToAdd: CollectionItem[] = []
+    const itemsToAdd: CollectionItemData[] = []
     for (const item of items) {
         // RSS items don't have an ID - we hash the title.
         const id = simpleHash(item.title)
@@ -119,8 +125,8 @@ export async function importData(collection: Collection, sourceId: string) {
         itemsToAdd.push({
             id,
             slug: slugify(item.title),
-            title: item.title,
             fieldData: {
+                [titleFieldId]: item.title,
                 [linkFieldId]: item.link,
                 [dateFieldId]: item.date,
                 [contentFieldId]: item.content,
@@ -139,7 +145,7 @@ export async function importData(collection: Collection, sourceId: string) {
 }
 
 interface Props {
-    collection: Collection
+    collection: ManagedCollection
     initialRssSourceId: string | null
 }
 

--- a/plugins/rss-feeds/src/main.tsx
+++ b/plugins/rss-feeds/src/main.tsx
@@ -7,10 +7,10 @@ import { App, importData } from "./App.tsx"
 
 async function runPlugin() {
     const mode = framer.mode
-    const collection = await framer.getCollection()
+    const collection = await framer.getManagedCollection()
 
     const rssSourceId = await collection.getPluginData("rssSourceId")
-    if (mode === "syncCollection" && rssSourceId) {
+    if (mode === "syncManagedCollection" && rssSourceId) {
         try {
             await importData(collection, rssSourceId)
             await framer.closePlugin()


### PR DESCRIPTION
### Description

Updates the Notion plugin to the next API versions

### Testing


- [ ] Notion sync works
  - [ ] Open the Notion plugin from preview URL
  - [ ] oAuth works
  - [ ] Select a database with several fields
  - [ ] Map fields and field names
  - [ ] Import
  - [ ] It imports the CMS
  - [ ] Click sync button
  - [ ] It syncs the CMS without UI