### PR TITLE
Export CSV rows without spaces after commas

### DIFF
--- a/plugins/export-csv/src/csv.ts
+++ b/plugins/export-csv/src/csv.ts
@@ -114,7 +114,7 @@ export async function exportCollectionAsCSV(collection: Collection, filename: st
                 .map(column => {
                     return `"${escapeCell(column)}"`
                 })
-                .join(", ")
+                .join(",")
         })
         .join("\n")
 


### PR DESCRIPTION
### Description

Framer's CSV import feature does not support importing CSV files with spaces after commas. However, the Export CSV plugin exports collections with spaces after commas, resulting in CSV files that can't be imported back into Framer after exporting them.

This pull request removes the extra space added after commas, making the plugin export valid CSV files that can be imported back into the CMS without errors or missing fields due to extra spaces.

### Testing

1. Export a CMS collection with the current version of the CMS Export plugin.
2. Import the CSV file into Framer with the Import button.
3. Importing fails due to spaces after commas in CSV file.
4. Export a CMS collection with the CMS Export plugin with this PR applied.
5. Import the CSV file into Framer with the Import button.
6. Importing is successful because CSV is properly formatted.