### PR TITLE
Add copy CSV to clipboard button

### DIFF
--- a/plugins/export-csv/src/csv.ts
+++ b/plugins/export-csv/src/csv.ts
@@ -102,7 +102,7 @@ export function getDataForCSV(fields: CollectionField[], items: CollectionItem[]
     return rows
 }
 
-export async function exportCollectionAsCSV(collection: Collection, filename: string) {
+export async function convertCollectionToCSV(collection: Collection) {
     const fields = await collection.getFields()
     const items = await collection.getItems()
 
@@ -117,6 +117,12 @@ export async function exportCollectionAsCSV(collection: Collection, filename: st
                 .join(", ")
         })
         .join("\n")
+
+    return csv
+}
+
+export async function exportCollectionAsCSV(collection: Collection, filename: string) {
+    const csv = await convertCollectionToCSV(collection)
 
     const file = new File([csv], `${filename}.csv`, {
         type: "text/csv",


### PR DESCRIPTION
### Description

This pull request adds a button to the Export CSV plugin that copies the CSV text to the clipboard, for cases where you don't need to download it as a file.

<img width="603" alt="image" src="https://github.com/user-attachments/assets/4e825a1d-e0e1-49b8-966b-9629d7e8a77a">