### PR TITLE
Disable undo or redo buttons depending on history size

### DIFF
--- a/plugins/doodles/src/App.tsx
+++ b/plugins/doodles/src/App.tsx
@@ -62,6 +62,10 @@ export function App() {
     l: 50,
   });
 
+  const [isDrawing, setIsDrawing] = useState(false)
+  const [historyIndex, setHistoryIndex] = useState(0)
+  const [historySize, setHistorySize] = useState(0)
+
   const handleStrokeInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value;
     setStrokeInputValue(newValue);
@@ -131,12 +135,26 @@ export function App() {
           strokeWidth={strokeValue}
           strokeColor={`hsl(${strokeColor.h} ${strokeColor.s}% ${strokeColor.l}%)`}
           canvasColor="transparent"
+          withTimestamp
+          onChange={(paths) => setHistoryIndex(paths.length)}
+          onStroke={(props) => {
+            if (historyIndex < historySize) {
+              setHistorySize(historyIndex)
+            }
+
+            if (props.endTimestamp) {
+              setHistorySize((previous) => previous + 1)
+            }
+
+            setIsDrawing(props.endTimestamp === 0)
+          }}
         />
       </div>
       <section className="flex">
         <div className={"row history"}>
           <p>History</p>
           <button
+            disabled={historyIndex === 0}
             onClick={() => {
               if (!canvasRef.current) return;
               canvasRef.current.undo();
@@ -159,6 +177,7 @@ export function App() {
             </svg>
           </button>
           <button
+            disabled={historyIndex === historySize || isDrawing}
             onClick={() => {
               if (!canvasRef.current) return;
               canvasRef.current.redo();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/14340493-0e08-4d07-a0cb-da15cff77943)

### Description

Ensure undo and redo button get disabled when either at the start or end of the history stack. It seems the `react-sketch-canvas` library doesn't give access to the history state, so I had to track that myself.

