### PR TITLE
Fix Search Console not resizing

### DIFF
--- a/plugins/google-search-console/src/App.tsx
+++ b/plugins/google-search-console/src/App.tsx
@@ -9,7 +9,7 @@ import { AuthContext, useGoogleToken } from './auth';
 import CriticalError from './screens/CriticalError';
 import SiteView from './screens/SiteView';
 import Loading from './components/Loading';
-import { PLUGIN_WIDTH, SMALL_HEIGHT } from './constants';
+import { LARGE_HEIGHT, PLUGIN_WIDTH, SMALL_HEIGHT } from './constants';
 import NeedsPublish from './screens/NeedsPublish';
 
 framer.showUI({
@@ -116,6 +116,13 @@ export function App() {
 
   const ref = useRef<HTMLDivElement>(null)
 
+  useEffect(() => {
+    if (!tokens?.access_token) {
+      framer.showUI({ width: PLUGIN_WIDTH, height: SMALL_HEIGHT })
+    } else {
+      framer.showUI({ width: PLUGIN_WIDTH, height: LARGE_HEIGHT })
+    }
+  }, [tokens?.access_token]);
 
   return (
       <main key={tokens?.access_token || 'logout'} ref={ref}>

--- a/plugins/google-search-console/src/App.tsx
+++ b/plugins/google-search-console/src/App.tsx
@@ -128,8 +128,6 @@ export function App() {
       <main key={tokens?.access_token || 'logout'} ref={ref}>
         <ErrorBoundary
           FallbackComponent={(e) => {
-            // logout();
-
             return (
               <GoogleLogin
                 loading={loading}
@@ -144,12 +142,6 @@ export function App() {
           resetKeys={[tokens?.access_token]}
         >
           <AuthContext.Provider value={tokens}>
-            {/* <button
-          type="button"
-          onClick={() => refresh(tokens?.refresh_token as string)}
-        >
-          Debug: Refresh token
-        </button> */}
             {isReady ? (
               tokens?.access_token ? (
                 <AppLoadSite

--- a/plugins/google-search-console/src/constants.ts
+++ b/plugins/google-search-console/src/constants.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_WIDTH = 260;
+export const PLUGIN_WIDTH = 300;
 export const SMALL_HEIGHT = 300;
 export const LARGE_HEIGHT = 600;

--- a/plugins/google-search-console/src/screens/GoogleLogin.tsx
+++ b/plugins/google-search-console/src/screens/GoogleLogin.tsx
@@ -27,7 +27,7 @@ export default function GoogleLogin({
           </p>
         </div>
       </div>
-      <button type="button" onClick={login}>
+      <button type="button" onClick={login} disabled={loading}>
         {loading ? "Loading..." : "Log In"}
       </button>
     </div>

--- a/plugins/hubspot/src/App.tsx
+++ b/plugins/hubspot/src/App.tsx
@@ -26,6 +26,12 @@ const usePluginResizeObserver = (ref: React.RefObject<HTMLDivElement>) => {
             height,
         })
     }, [width, height])
+
+    useEffect(() => {
+        if (!tokens?.access_token) {
+          resize('short');
+        }
+      }, [resize, tokens?.access_token]);
 }
 
 export function App() {


### PR DESCRIPTION
### Description

- Resize plugin window using `framer.showUI` API instead of `@triozer/framer-toolbox`. It was being done manually anyway, so there's no need to use that abstraction
- Disable login in button when loading
- Make the plugin width slightly wider to accommodate [big stats](https://framer-team.slack.com/archives/C06FEPVRM52/p1726732784276299)

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [ ] Search Console plugin changes sized when logging in and out
- [ ] Login button is disabled when loading