### PR TITLE
Prevent exporting CMS reference fields

### DIFF
--- a/plugins/cms-export/src/csv.ts
+++ b/plugins/cms-export/src/csv.ts
@@ -29,9 +29,10 @@ function escapeCell(value: string) {
 
 export function getDataForCSV(fields: CollectionField[], items: CollectionItem[]): Rows {
     const rows: Rows = []
+    const supportedFields = fields.filter(field => field.type !== "unsupported")
 
     // Add header row.
-    rows.push(fields.map(field => field.name))
+    rows.push(supportedFields.map(field => field.name))
 
     // Add slug header to the start.
     rows[0].unshift("Slug")
@@ -43,7 +44,7 @@ export function getDataForCSV(fields: CollectionField[], items: CollectionItem[]
         // Add the slug cell.
         columns.push(item.slug)
 
-        for (const field of fields) {
+        for (const field of supportedFields) {
             const value = item.fieldData[field.id]
 
             switch (field.type) {
@@ -85,10 +86,6 @@ export function getDataForCSV(fields: CollectionField[], items: CollectionItem[]
                 case "link":
                 case "number":
                     columns.push(`${value}`)
-                    continue
-
-                case "unsupported":
-                    columns.push("")
                     continue
 
                 default:


### PR DESCRIPTION
### Description

The current CMS export plugin makes a CSV where reference fields are included, but the values are all blank. The problem with this is the CSV import will set each item's reference field value to blank.

The basic solution to this is to adjust the CMS export plugin to ignore reference fields, ie: don't include them in the CSV export.

This is a stepping stone towards properly supporting references in CSV exports, see: https://github.com/framer/company/issues/30409

### Testing

- [ ] Be in a project with the collection references experiement enabled
- [ ] Create the sample collection
- [ ] Export each collection to CSV using this plugin
- [ ] The CSV data should not contain any columns for fields which are single or multi reference
