### PR TITLE
Add support for references to cms export

### DIFF
--- a/plugins/cms-export/src/csv.ts
+++ b/plugins/cms-export/src/csv.ts
@@ -59,6 +59,7 @@ export function getDataForCSV(fields: CollectionField[], items: CollectionItem[]
                     continue
                 }
 
+                case "collectionReference":
                 case "formattedText": {
                     if (typeof value !== "string") {
                         columns.push("")
@@ -66,6 +67,16 @@ export function getDataForCSV(fields: CollectionField[], items: CollectionItem[]
                     }
 
                     columns.push(`${value}`)
+                    continue
+                }
+
+                case "multiCollectionReference": {
+                    if (!Array.isArray(value) || value.some(v => typeof v !== "string")) {
+                        columns.push("")
+                        continue
+                    }
+
+                    columns.push(`${value.join(",")}`)
                     continue
                 }
 
@@ -93,12 +104,14 @@ export function getDataForCSV(fields: CollectionField[], items: CollectionItem[]
                 case "boolean":
                 case "date":
                 case "link":
-                case "number":
+                case "number": {
                     columns.push(`${value}`)
                     continue
+                }
 
-                default:
+                default: {
                     assertNever(field)
+                }
             }
         }
 


### PR DESCRIPTION
### Description

This PR adds support for collection references to CMS Export.

This depends on https://github.com/framer/FramerStudio/pull/19215, which adds support for references to plugins.

### Testing

- [ ] See https://github.com/framer/FramerStudio/pull/19215