### PR TITLE
Search Console date range select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4285,6 +4285,12 @@
                 "node": ">= 12"
             }
         },
+        "node_modules/compute-scroll-into-view": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
+            "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg==",
+            "license": "MIT"
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4745,6 +4751,28 @@
         "node_modules/doodles": {
             "resolved": "plugins/doodles",
             "link": true
+        },
+        "node_modules/downshift": {
+            "version": "9.0.8",
+            "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.0.8.tgz",
+            "integrity": "sha512-59BWD7+hSUQIM1DeNPLirNNnZIO9qMdIK5GQ/Uo8q34gT4B78RBlb9dhzgnh0HfQTJj4T/JKYD8KoLAlMWnTsA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.24.5",
+                "compute-scroll-into-view": "^3.1.0",
+                "prop-types": "^15.8.1",
+                "react-is": "18.2.0",
+                "tslib": "^2.6.2"
+            },
+            "peerDependencies": {
+                "react": ">=16.12.0"
+            }
+        },
+        "node_modules/downshift/node_modules/react-is": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+            "license": "MIT"
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
@@ -10001,6 +10029,7 @@
                 "@ataverascrespo/react18-ts-textfit": "^1.0.0",
                 "@triozer/framer-toolbox": "^0.1.14",
                 "aveta": "^1.4.1",
+                "downshift": "^9.0.8",
                 "framer-plugin": "^1.0.0",
                 "react": "^18",
                 "react-dom": "^18",

--- a/plugins/google-search-console/package.json
+++ b/plugins/google-search-console/package.json
@@ -13,6 +13,7 @@
     "@ataverascrespo/react18-ts-textfit": "^1.0.0",
     "@triozer/framer-toolbox": "^0.1.14",
     "aveta": "^1.4.1",
+    "downshift": "^9.0.8",
     "framer-plugin": "^1.0.0",
     "react": "^18",
     "react-dom": "^18",

--- a/plugins/google-search-console/src/App.css
+++ b/plugins/google-search-console/src/App.css
@@ -582,3 +582,73 @@ body[data-framer-theme='dark'] .chart-tooltip-wrapper {
 .recharts-cartesian-axis-ticks {
   font-variant-numeric: tabular-nums !important;
 }
+
+.date-range-header {
+  text-align: right;
+  margin-bottom: 1em;
+}
+
+.select-container {
+  position: relative;
+  padding-top: 1px;
+}
+
+.select-button {
+  display: inline-block;
+  padding: 0.5em 1em;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.select-button:focus {
+  outline: none;
+}
+
+.select-button:focus-visible {
+  outline: 2px solid var(--framer-color-tint);
+  outline-offset: -1px;
+}
+
+.select-button:hover,
+.select-button:focus-visible,
+.select-container--open .select-button {
+  border-color: rgba(0, 0, 0, 0.2);
+}
+
+.select-button--arrow {
+  display: inline-block;
+  margin-left: 0.25em;
+}
+
+.select-options {
+  position: absolute;
+  background-color: #fff;
+  right: 0;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 0.5em;
+  text-align: left;
+  border-radius: 4px;
+  margin-top: 4px;
+  display: none;
+  z-index: 100;
+}
+
+.select-container--open .select-options {
+  display: block;
+}
+
+.select-option {
+  display: block;
+  padding: 0.5em 2em 0.5em 1em;
+  border-radius: 4px;
+}
+
+.select-option--highlighted {
+  background-color: rgba(0, 0, 0, 0.025);
+}
+
+.select-option--selected {
+  font-weight: 600;
+}

--- a/plugins/google-search-console/src/App.css
+++ b/plugins/google-search-console/src/App.css
@@ -601,6 +601,10 @@ body[data-framer-theme='dark'] .chart-tooltip-wrapper {
   border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
+body[data-framer-theme='dark'] .select-button {
+  background: var(--framer-color-bg-secondary);
+}
+
 .select-button:focus {
   outline: none;
 }
@@ -623,10 +627,10 @@ body[data-framer-theme='dark'] .chart-tooltip-wrapper {
 
 .select-options {
   position: absolute;
-  background-color: #fff;
+  background-color: var(--framer-color-bg, #fff);
   right: 0;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--framer-color-bg-tertiary);
   padding: 0.5em;
   text-align: left;
   border-radius: 4px;
@@ -647,6 +651,10 @@ body[data-framer-theme='dark'] .chart-tooltip-wrapper {
 
 .select-option--highlighted {
   background-color: rgba(0, 0, 0, 0.025);
+}
+
+body[data-framer-theme='dark'] .select-option--highlighted {
+  background: var(--framer-color-bg-secondary);
 }
 
 .select-option--selected {

--- a/plugins/google-search-console/src/components/Select.tsx
+++ b/plugins/google-search-console/src/components/Select.tsx
@@ -1,0 +1,79 @@
+import { useSelect, UseSelectSelectedItemChange } from 'downshift';
+
+export interface SelectOption {
+  id: number | string;
+  title: string;
+}
+
+interface SelectProps {
+  selected: SelectOption;
+  options: SelectOption[];
+  onChange: (changes: UseSelectSelectedItemChange<SelectOption>) => void;
+}
+
+function itemToString(item: SelectOption | null) {
+  return item ? item.title : '';
+}
+
+export default function Select({
+  selected: selectedItem,
+  options,
+  onChange,
+}: SelectProps) {
+  const {
+    isOpen,
+    getToggleButtonProps,
+    getMenuProps,
+    highlightedIndex,
+    getItemProps,
+  } = useSelect({
+    items: options,
+    itemToString,
+    selectedItem,
+    onSelectedItemChange: onChange,
+  });
+
+  return (
+    <div
+      className={[
+        'select-container',
+        isOpen ? 'select-container--open' : undefined,
+      ].join(' ')}
+    >
+      <div className="w-72 flex flex-col gap-1">
+        <div className="select-button" {...getToggleButtonProps()}>
+          <span>{selectedItem ? selectedItem.title : 'Select a range'}</span>
+          <span className="select-button--arrow">
+            {isOpen ? <>&#8593;</> : <>&#8595;</>}
+          </span>
+        </div>
+      </div>
+      <ul
+        // className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
+        //   !isOpen && 'hidden'
+        // }`}
+        className="select-options"
+        {...getMenuProps()}
+      >
+        {isOpen &&
+          options.map((item, index) => (
+            <li
+              className={[
+                'select-option',
+                highlightedIndex === index
+                  ? 'select-option--highlighted'
+                  : undefined,
+                selectedItem.id === item.id
+                  ? 'select-option--selected'
+                  : undefined,
+              ].join(' ')}
+              key={item.id}
+              {...getItemProps({ item, index })}
+            >
+              <span>{item.title}</span>
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+}

--- a/plugins/google-search-console/src/hooks.ts
+++ b/plugins/google-search-console/src/hooks.ts
@@ -194,20 +194,23 @@ function randomIntFromInterval(min: number, max: number) {
   return Math.floor(min + Math.random() * (max - min + 1));
 }
 
-export function useMockPerformanceResults(): {
+export function useMockPerformanceResults(
+  siteUrl: string,
+  dates: string[],
+): {
   dailyPerformance: GoogleQueryResult;
   queryPerformance: GoogleQueryResult;
 } {
   const getRandomData = (): number[][] => {
     const savedData = window.localStorage.getItem(
-      'searchConsoleRandomChartData',
+      `searchConsoleRandomChartData_${dates.length}`,
     ) as string;
 
     if (savedData) {
       return JSON.parse(savedData);
     }
 
-    const randomDataGen = [...new Array(14)].map(() => {
+    const randomDataGen = [...new Array(dates.length)].map(() => {
       const clicks = randomIntFromInterval(1000, 3000);
       const impressions = clicks + randomIntFromInterval(1000, 3000);
 

--- a/plugins/google-search-console/src/screens/SiteHasIndexedSitemap.tsx
+++ b/plugins/google-search-console/src/screens/SiteHasIndexedSitemap.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import sitemapper from 'sitemap-urls';
 import { useErrorBoundary } from 'react-error-boundary';
 import { GoogleInspectionResult, SiteWithGoogleSite } from '../types';
@@ -16,6 +16,7 @@ import indexNone from '../images/IndexNone.svg';
 import indexAdded from '../images/IndexAdded.svg';
 import InlineSpinner from '../components/InlineSpinner';
 import { mockUrls } from '../mocks';
+import { SelectOption } from '../components/Select';
 
 interface URLRowProps {
   url: string;
@@ -133,7 +134,29 @@ function URLStatuses({ urls, googleSiteUrl }: URLStatusesProps) {
   );
 }
 
-const dates = getDateRange(14);
+export const rangeOptions: SelectOption[] = [
+  {
+    id: 7,
+    title: 'Last 7 days',
+  },
+  {
+    id: 14,
+    title: 'Last 14 days',
+  },
+  {
+    id: 30,
+    title: 'Last 30 days',
+  },
+  {
+    id: 90,
+    title: 'Last 90 days',
+  },
+];
+
+const defaultRange: SelectOption = {
+  id: 14,
+  title: 'Last 14 days',
+};
 
 const usePerformanceResultsHook = SHOW_MOCK_SITEMAP_DATA
   ? useMockPerformanceResults
@@ -170,6 +193,14 @@ export default function SiteHasIndexedSitemap({
     }
   }, [showBoundary, site.domain]);
 
+  const [selectedRange, setSelectedRange] =
+    useState<SelectOption>(defaultRange);
+
+  const dates = useMemo(
+    () => getDateRange(selectedRange.id as number),
+    [selectedRange.id],
+  );
+
   const performance = usePerformanceResultsHook(site.googleSite.siteUrl, dates);
 
   const resize = useContext(ResizeContext);
@@ -186,6 +217,10 @@ export default function SiteHasIndexedSitemap({
         <Performance
           siteUrl={site.googleSite.siteUrl}
           performance={performance}
+          selectedRange={selectedRange}
+          onRangeChange={(changes) => {
+            setSelectedRange(changes.selectedItem);
+          }}
         />
         <section>
           <URLStatuses urls={urls} googleSiteUrl={site.googleSite.siteUrl} />


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request adds the ability for users to select the date range for their performance metrics in Search Console. The dropdown design is temporary, likely should be updated to match the Framer design system.

<img width="371" alt="Screenshot 2024-10-04 at 2 00 16 pm" src="https://github.com/user-attachments/assets/6b286682-c273-41aa-b816-ebc3668eb9c5">
<img width="350" alt="Screenshot 2024-10-04 at 2 00 24 pm" src="https://github.com/user-attachments/assets/92f56ee0-f006-422b-8dcb-902758712135">
<img width="350" alt="Screenshot 2024-10-04 at 2 00 34 pm" src="https://github.com/user-attachments/assets/118d7e4c-552b-44ba-bed5-02aefe891e15">
<img width="380" alt="Screenshot 2024-10-04 at 2 10 42 pm" src="https://github.com/user-attachments/assets/76b788bf-7761-44a1-8508-3c1fb4077987">