### PR TITLE
Support images in Notion and general improvements

### DIFF
--- a/plugins/notion/src/App.tsx
+++ b/plugins/notion/src/App.tsx
@@ -22,6 +22,9 @@ export function AuthenticatedApp({ context }: AppProps) {
         framer.showUI({
             width: databaseConfig ? 360 : 325,
             height: databaseConfig ? 425 : 370,
+            // Only allow resizing when mapping fields as the default size could not be enough.
+            // This will keep the given dimensions in the Splash Screen.
+            resizable: Boolean(databaseConfig),
         })
     }, [databaseConfig])
 

--- a/plugins/notion/src/App.tsx
+++ b/plugins/notion/src/App.tsx
@@ -19,9 +19,13 @@ export function AuthenticatedApp({ context }: AppProps) {
     )
 
     useEffect(() => {
+        const width = databaseConfig ? 360 : 325
+        const height = databaseConfig ? 425 : 370
         framer.showUI({
-            width: databaseConfig ? 360 : 325,
-            height: databaseConfig ? 425 : 370,
+            width,
+            height,
+            minWidth: width,
+            minHeight: height,
             // Only allow resizing when mapping fields as the default size could not be enough.
             // This will keep the given dimensions in the Splash Screen.
             resizable: Boolean(databaseConfig),

--- a/plugins/notion/src/App.tsx
+++ b/plugins/notion/src/App.tsx
@@ -20,7 +20,7 @@ export function AuthenticatedApp({ context }: AppProps) {
 
     useEffect(() => {
         framer.showUI({
-            width: databaseConfig ? 450 : 325,
+            width: databaseConfig ? 360 : 325,
             height: databaseConfig ? 425 : 370,
         })
     }, [databaseConfig])
@@ -30,7 +30,7 @@ export function AuthenticatedApp({ context }: AppProps) {
             logSyncResult(result)
 
             if (result.status === "success") {
-                // framer.closePlugin("Synchronization successful")
+                framer.closePlugin("Synchronization successful")
                 return
             }
         },

--- a/plugins/notion/src/App.tsx
+++ b/plugins/notion/src/App.tsx
@@ -20,7 +20,7 @@ export function AuthenticatedApp({ context }: AppProps) {
 
     useEffect(() => {
         framer.showUI({
-            width: databaseConfig ? 340 : 325,
+            width: databaseConfig ? 450 : 325,
             height: databaseConfig ? 425 : 370,
         })
     }, [databaseConfig])
@@ -30,7 +30,7 @@ export function AuthenticatedApp({ context }: AppProps) {
             logSyncResult(result)
 
             if (result.status === "success") {
-                framer.closePlugin("Synchronization successful")
+                // framer.closePlugin("Synchronization successful")
                 return
             }
         },

--- a/plugins/notion/src/App.tsx
+++ b/plugins/notion/src/App.tsx
@@ -29,6 +29,9 @@ export function AuthenticatedApp({ context }: AppProps) {
     }, [databaseConfig])
 
     const synchronizeMutation = useSynchronizeDatabaseMutation(databaseConfig, {
+        onError(error) {
+            framer.notify(error.message, { variant: "error" })
+        },
         onSuccess(result) {
             logSyncResult(result)
 
@@ -48,7 +51,6 @@ export function AuthenticatedApp({ context }: AppProps) {
             database={databaseConfig}
             pluginContext={context}
             onSubmit={synchronizeMutation.mutate}
-            error={synchronizeMutation.error}
             isLoading={synchronizeMutation.isPending}
         />
     )

--- a/plugins/notion/src/MapFields.tsx
+++ b/plugins/notion/src/MapFields.tsx
@@ -326,7 +326,7 @@ export function MapDatabaseFields({
                 <div className="tailwind-hell-escape-hatch-gradient-bottom" />
                 {error && <span className="text-red-500">{error.message}</span>}
 
-                <Button variant="primary" isLoading={isLoading} disabled={!slugFieldId} className="w-full ">
+                <Button variant="primary" isLoading={isLoading} disabled={!slugFieldId} className="w-full">
                     Import from {title.trim() ? title : "Untitled"}
                 </Button>
             </div>

--- a/plugins/notion/src/MapFields.tsx
+++ b/plugins/notion/src/MapFields.tsx
@@ -24,16 +24,9 @@ import { CheckboxTextfield } from "./components/CheckboxTexfield"
 
 function getSortedProperties(database: GetDatabaseResponse): NotionProperty[] {
     return getNotionProperties(database).sort((propertyA, propertyB) => {
-        // Properties that are not supported in the Plugin are displayed at the bottom of the list.
-        if (isSupportedNotionProperty(propertyA) && isSupportedNotionProperty(propertyB)) {
-            return -1
-        } else if (isSupportedNotionProperty(propertyA)) {
-            return -1
-        } else if (!isSupportedNotionProperty(propertyB)) {
-            return 1
-        }
-
-        return 0
+        const a = isSupportedNotionProperty(propertyA) ? -1 : 0
+        const b = isSupportedNotionProperty(propertyB) ? -1 : 0
+        return a - b
     })
 }
 

--- a/plugins/notion/src/MapFields.tsx
+++ b/plugins/notion/src/MapFields.tsx
@@ -279,28 +279,29 @@ export function MapDatabaseFields({
                                     <input
                                         type="text"
                                         className={classNames("w-full", isUnsupported && "opacity-50")}
-                                        disabled={disabledFieldIds.has(property.id)}
+                                        disabled={isUnsupported || disabledFieldIds.has(property.id)}
                                         placeholder={property.name}
-                                        value={
-                                            isUnsupported
-                                                ? "Unsupported Field"
-                                                : (fieldNameOverrides[property.id] ?? "")
-                                        }
+                                        value={isUnsupported ? "Unsupported" : (fieldNameOverrides[property.id] ?? "")}
                                         onChange={e => {
                                             handleFieldNameChange(property.id, e.target.value)
                                         }}
                                     ></input>
                                     <select
-                                        className="w-auto"
+                                        className="w-full"
                                         onChange={event =>
                                             handleFieldTypeChange(
                                                 property.id,
                                                 event.target.value as ManagedCollectionField["type"]
                                             )
                                         }
-                                        value={fieldTypeByFieldId[property.id]}
+                                        disabled={isUnsupported}
+                                        value={isUnsupported ? "unsupported" : fieldTypeByFieldId[property.id]}
                                     >
-                                        {isUnsupported && <option disabled>Unsupported</option>}
+                                        {isUnsupported && (
+                                            <option value="unsupported" disabled>
+                                                Unsupported
+                                            </option>
+                                        )}
                                         {fieldOptions?.map(fieldOption => (
                                             <option key={fieldOption} value={fieldOption}>
                                                 {labelByFieldTypeOption[fieldOption]}
@@ -314,8 +315,8 @@ export function MapDatabaseFields({
                 </div>
             </div>
 
-            <div className="tailwind-hell-escape-hatch-gradient-bottom" />
             <div className="left-0 bottom-0 pb-[15px] w-full flex justify-between sticky bg-primary pt-4 border-t border-divider border-opacity-20 items-center max-w-full">
+                <div className="tailwind-hell-escape-hatch-gradient-bottom" />
                 {error && <span className="text-red-500">{error.message}</span>}
 
                 <Button variant="primary" isLoading={isLoading} disabled={!slugFieldId} className="w-full ">

--- a/plugins/notion/src/components/CheckboxTexfield.tsx
+++ b/plugins/notion/src/components/CheckboxTexfield.tsx
@@ -19,12 +19,11 @@ export function CheckboxTextfield({ value, disabled, checked: initialChecked, on
     }
 
     return (
-        <div
+        <label
             className={classNames(
                 "flex bg-tertiary rounded-[8px] items-center pl-[10px]",
                 disabled && "opacity-50 cursor-default"
             )}
-            onClick={toggle}
             role="button"
         >
             <input
@@ -40,6 +39,6 @@ export function CheckboxTextfield({ value, disabled, checked: initialChecked, on
                 disabled
                 value={value}
             />
-        </div>
+        </label>
     )
 }

--- a/plugins/notion/src/components/CheckboxTexfield.tsx
+++ b/plugins/notion/src/components/CheckboxTexfield.tsx
@@ -12,14 +12,21 @@ export function CheckboxTextfield({ value, disabled, checked: initialChecked, on
     const [checked, setChecked] = useState(initialChecked)
 
     const toggle = () => {
-      if (disabled) return
+        if (disabled) return
 
-      setChecked(!checked)
-      onChange()
+        setChecked(!checked)
+        onChange()
     }
 
     return (
-        <div className={classNames("flex bg-tertiary rounded-[8px] items-center pl-[10px]", disabled && "opacity-50 cursor-default")} onClick={toggle} role="button">
+        <div
+            className={classNames(
+                "flex bg-tertiary rounded-[8px] items-center pl-[10px]",
+                disabled && "opacity-50 cursor-default"
+            )}
+            onClick={toggle}
+            role="button"
+        >
             <input
                 className="tailwind-hell-escape-hatch-checkbox"
                 type="checkbox"
@@ -27,7 +34,12 @@ export function CheckboxTextfield({ value, disabled, checked: initialChecked, on
                 checked={checked}
                 onChange={toggle}
             />
-            <input className="bg-transparent w-full shrink pointer-events-none select-none" type="text" disabled value={value} />
+            <input
+                className="bg-transparent w-full shrink pointer-events-none select-none"
+                type="text"
+                disabled
+                value={value}
+            />
         </div>
     )
 }

--- a/plugins/notion/src/main.tsx
+++ b/plugins/notion/src/main.tsx
@@ -67,7 +67,7 @@ async function runPlugin() {
 
             const result = await synchronizeDatabase(pluginContext.database, {
                 onProgress: () => {
-                    // TODO: Update toast maybe?
+                    // TODO: Progress indicator.
                 },
                 fields: pluginContext.collectionFields,
                 ignoredFieldIds: pluginContext.ignoredFieldIds,

--- a/plugins/notion/src/main.tsx
+++ b/plugins/notion/src/main.tsx
@@ -66,6 +66,9 @@ async function runPlugin() {
             assert(pluginContext.slugFieldId)
 
             const result = await synchronizeDatabase(pluginContext.database, {
+                onProgress: () => {
+                    // TODO: Update toast maybe?
+                },
                 fields: pluginContext.collectionFields,
                 ignoredFieldIds: pluginContext.ignoredFieldIds,
                 lastSyncedTime: pluginContext.lastSyncedTime,

--- a/plugins/notion/src/notion.ts
+++ b/plugins/notion/src/notion.ts
@@ -852,7 +852,7 @@ interface PaginatedList<T> {
 
 /**
  * Copied from:
- * https://github.com/makenotion/notion-sdk-js/blob/main/src/helpers.ts#L47
+ * https://github.com/makenotion/notion-sdk-js/blob/7950edc034d3007b0612b80d3f424baef89746d9/src/helpers.ts#L47
  * Notion has a bug where pagination returns the same page cursor when fetching
  * another page in some rare cases. This results in the same pages being fetched
  * over and over, resulting in infinite loop. This function is modified to keep

--- a/plugins/notion/src/notion.ts
+++ b/plugins/notion/src/notion.ts
@@ -666,13 +666,11 @@ export async function synchronizeDatabase(
 
 export function useSynchronizeDatabaseMutation(
     database: GetDatabaseResponse | null,
-    { onSuccess }: { onSuccess?: (result: SynchronizeResult) => void } = {}
+    { onSuccess, onError }: { onSuccess?: (result: SynchronizeResult) => void; onError?: (error: Error) => void } = {}
 ) {
     return useMutation({
-        onError(error) {
-            framer.closePlugin("Failed to synchronize with Notion: " + error.message, { variant: "error" })
-        },
         onSuccess,
+        onError,
         mutationFn: async (options: SynchronizeMutationOptions): Promise<SynchronizeResult> => {
             assert(database)
 

--- a/plugins/notion/src/notion.ts
+++ b/plugins/notion/src/notion.ts
@@ -541,7 +541,6 @@ async function processAllItems(
     fieldsByKey: FieldsById,
     slugFieldId: string,
     lastSyncedDate: string | null,
-    hasFieldChanges: boolean,
     onProgress: OnProgressHandler
 ) {
     const seenItemIds = new Set<string>()
@@ -565,7 +564,7 @@ async function processAllItems(
         limit(async () => {
             seenItemIds.add(item.id)
 
-            if (!hasFieldChanges && isUnchangedSinceLastSync(item.last_edited_time, lastSyncedDate)) {
+            if (isUnchangedSinceLastSync(item.last_edited_time, lastSyncedDate)) {
                 status.info.push({
                     message: `Skipping. last updated: ${formatDate(item.last_edited_time)}, last synced: ${formatDate(lastSyncedDate!)}`,
                     url: item.url,
@@ -596,7 +595,7 @@ async function processAllItems(
     }
 }
 
-function hasFieldConfigurationChanged(a: ManagedCollectionField[], b: ManagedCollectionField[]) {
+export function hasFieldConfigurationChanged(a: ManagedCollectionField[], b: ManagedCollectionField[]) {
     if (a.length !== b.length) return true
 
     for (let i = 0; i < a.length; i++) {
@@ -618,8 +617,6 @@ export async function synchronizeDatabase(
     assert(notion)
 
     const collection = await framer.getManagedCollection()
-    const hasChangedFields = hasFieldConfigurationChanged(fields, await collection.getFields())
-
     await collection.setFields(fields)
 
     const fieldsById = new Map<string, ManagedCollectionField>()
@@ -637,7 +634,6 @@ export async function synchronizeDatabase(
         fieldsById,
         slugFieldId,
         lastSyncedTime,
-        hasChangedFields,
         onProgress
     )
 

--- a/plugins/notion/src/utils.ts
+++ b/plugins/notion/src/utils.ts
@@ -78,3 +78,7 @@ export function generateRandomId() {
 
     return id
 }
+
+export function assertNever(x: never, error?: unknown): never {
+    throw error || new Error((x as unknown) ? `Unexpected value: ${x}` : "Application entered invalid state")
+}

--- a/plugins/notion/tailwind.config.js
+++ b/plugins/notion/tailwind.config.js
@@ -23,7 +23,7 @@ export default {
                 divider: "var(--framer-color-divider)",
             },
             gridTemplateColumns: {
-                fieldPicker: `1fr 8px 1fr`,
+                fieldPicker: `1fr 8px 1fr 1fr`,
             },
             fontSize: {
                 md: "12px",


### PR DESCRIPTION
### Description

- Supports Images and Files when a Notion database has a "Files and Media" column
- Allows you to switch between File or Image for that column
- Will pick only the first item in the media column. CMS arrays alter.
- Allow switching between Rich Text and Regular text for content fields
- Fix a bug where Notion would paginate endlessly because the next cursor would match the current cursor.
- Display errors as toasts instead of inline in the UI

### Testing

- [ ] Create a Notion database
  - [ ] Add a column "Files and Media"
  - [ ] Upload some images to the database and fill in other columns
  - [ ] Launch Notion & select the database
  - [ ] Notice you can select "File" or "Image" for the media column
  - [ ] It synchronizes with the selected file type

