### PR TITLE
Prevent infinite rerender of CMS Export plugin

### DIFF
--- a/plugins/cms-export/src/PreviewTable.tsx
+++ b/plugins/cms-export/src/PreviewTable.tsx
@@ -55,7 +55,7 @@ export function PreviewTable({ collection }: Props) {
         return () => {
             window.removeEventListener("resize", resize)
         }
-    }, [collection, previewCSV])
+    }, [collection])
 
     if (!previewCSV?.length) return null
 


### PR DESCRIPTION
### Description

Prevents an infinite rerender that was caused by this `useEffect` having an unnecessary dependency on `previewCSV`, which itself is being rewritten every time the hook runs.

### Testing

- [ ] Plugin still works like before
