### PR TITLE
Remove stepper buttons from tab order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
     "packages": {
         "": {
             "name": "plugins",
-            "version": "1.0.0",
             "license": "MIT",
             "workspaces": [
                 "plugins/*"

--- a/plugins/tidyup/src/Stepper.tsx
+++ b/plugins/tidyup/src/Stepper.tsx
@@ -54,13 +54,13 @@ export function Stepper({ value = 0, min = 0, step: stepAmount = 1, onChange }: 
             />
 
             <div className="stepper-controls">
-                <button className="stepper-button" onClick={() => step(-1)}>
+                <button className="stepper-button" tabIndex={-1} onClick={() => step(-1)}>
                     <IconMinus />
                 </button>
 
                 <div className="stepper-divider" />
 
-                <button className="stepper-button" onClick={() => step(1)}>
+                <button className="stepper-button" tabIndex={-1} onClick={() => step(1)}>
                     <IconPlus />
                 </button>
             </div>


### PR DESCRIPTION
**What is this PR doing**
This pull request adjusts the tab order for the Stepper component buttons by setting their `tabIndex` to -1. This change removes the increment and decrement buttons from the keyboard tab sequence, potentially improving navigation for keyboard users.

### Testing
- [ ] Verify tab order behavior
  - [ ] Open a page containing the Stepper component
  - [ ] Use the Tab key to navigate through the page
  - [ ] Confirm that focus skips over the increment and decrement buttons
  - [ ] Verify that focus moves directly from the input field to the next focusable element

- [ ] Check button functionality
  - [ ] Click on the increment and decrement buttons with a mouse
  - [ ] Confirm that the buttons still function correctly when clicked

- [ ] Keyboard accessibility check
  - [ ] Focus on the Stepper input field
  - [ ] Attempt to use arrow keys or other keyboard shortcuts to increment/decrement the value
  - [ ] Note any unexpected behavior or lack of keyboard control
  
  