### PR TITLE
Handle Google Sheets authentication errors in more places

### DIFF
--- a/plugins/google-sheets/src/App.tsx
+++ b/plugins/google-sheets/src/App.tsx
@@ -50,8 +50,16 @@ export function AuthenticatedApp({ pluginContext, setContext }: AuthenticatedApp
     const [sheetTitle, setSheetTitle] = useState<string | null>(
         pluginContext.type === "update" ? pluginContext.sheetTitle : null
     )
-    const { isError: isUserInfoError } = useFetchUserInfo()
-    const { data: sheet, isPending: isSheetPending } = useSheetQuery(spreadsheetId ?? "", sheetTitle ?? "")
+    const [isSelectSheetError, setIsSelectSheetError] = useState(false)
+
+    const {
+        isError: isUserInfoError
+    } = useFetchUserInfo()
+
+    const {
+        data: sheet,
+        isPending: isSheetPending,
+    } = useSheetQuery(spreadsheetId ?? "", sheetTitle ?? "")
 
     const syncMutation = useSyncSheetMutation({
         onSuccess: result => {
@@ -66,14 +74,14 @@ export function AuthenticatedApp({ pluginContext, setContext }: AuthenticatedApp
     })
 
     useEffect(() => {
-        if (isUserInfoError) {
+        if (isUserInfoError || isSelectSheetError) {
             setContext({
                 type: "no-sheet-access",
                 sheetName: "",
                 sheetUrl: ""
             })
         }
-    }, [isUserInfoError, setContext])
+    }, [isUserInfoError, isSelectSheetError, setContext])
 
     useLayoutEffect(() => {
         framer.showUI({
@@ -85,6 +93,7 @@ export function AuthenticatedApp({ pluginContext, setContext }: AuthenticatedApp
     if (!spreadsheetId || !sheetTitle) {
         return (
             <SelectSheetPage
+                onError={() => setIsSelectSheetError(true)}
                 onSheetSelected={(selectedSpreadsheetId, selectedSheetTitle) => {
                     setSpreadsheetId(selectedSpreadsheetId)
                     setSheetTitle(selectedSheetTitle)

--- a/plugins/google-sheets/src/auth.ts
+++ b/plugins/google-sheets/src/auth.ts
@@ -77,10 +77,14 @@ class Auth {
         return this.tokens.get()
     }
 
-    async fetchTokens(readKey: string) {
+    async fetchTokens(readKey: string): Promise<Tokens | undefined> {
         const res = await fetch(`${this.AUTH_URI}/poll?readKey=${readKey}`, {
             method: "POST",
         })
+
+        if (res.status === 404) {
+            return
+        }
 
         if (res.status !== 200) {
             throw new Error("Failed to fetch tokens")

--- a/plugins/google-sheets/src/pages/Authenticate.tsx
+++ b/plugins/google-sheets/src/pages/Authenticate.tsx
@@ -29,13 +29,16 @@ export function Authenticate({ onAuthenticated }: AuthenticationProps) {
         }
 
         return new Promise(
-            resolve =>
+            (resolve, reject) =>
                 (pollInterval.current = setInterval(
                     () =>
                         auth.fetchTokens(readKey).then(tokens => {
+                            // Tokens have no been received yet.
+                            if (!tokens) return
+
                             clearInterval(pollInterval.current)
                             resolve(tokens)
-                        }),
+                        }).catch(reject),
                     10_000
                 ))
         )

--- a/plugins/google-sheets/src/pages/NoSpreadsheetAccess.tsx
+++ b/plugins/google-sheets/src/pages/NoSpreadsheetAccess.tsx
@@ -51,9 +51,11 @@ export function NoSpreadsheetAccess({ context, setContext }: Props) {
                 <Button variant="secondary" className="w-auto flex-1" onClick={handleRetryClick} isLoading={isRetrying}>
                     Retry
                 </Button>
-                <Button className="w-auto flex-1 !bg-[#15C43E] text-white hover:bg-[#15C43E]" onClick={handleViewClick}>
-                    View Sheet
-                </Button>
+                {context.sheetUrl &&
+                    <Button className="w-auto flex-1 !bg-[#15C43E] text-white hover:bg-[#15C43E]" onClick={handleViewClick}>
+                        View Sheet
+                    </Button>
+                }
             </div>
         </div>
     )

--- a/plugins/google-sheets/src/pages/SelectSheet.tsx
+++ b/plugins/google-sheets/src/pages/SelectSheet.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { framer } from "framer-plugin"
 import { useSpreadsheetInfoQuery } from "../sheets"
 import { Hero } from "../components/Hero"
@@ -7,14 +7,21 @@ type InputChangeEvent = React.ChangeEvent<HTMLInputElement>
 type SelectChangeEvent = React.ChangeEvent<HTMLSelectElement>
 
 interface Props {
+    onError: () => void
     onSheetSelected: (spreadsheetId: string, sheetId: string) => void
 }
 
-export function SelectSheetPage({ onSheetSelected }: Props) {
+export function SelectSheetPage({ onError, onSheetSelected }: Props) {
     const [selectedSpreadsheetId, setSelectedSpreadsheetId] = useState("")
     const [selectedSheetId, setSelectedSheetId] = useState("")
 
-    const { data: spreadsheetInfo, isFetching: isFetchingSheets } = useSpreadsheetInfoQuery(selectedSpreadsheetId)
+    const { data: spreadsheetInfo, isFetching: isFetchingSheets, isError: isSpreadSheetInfoError } = useSpreadsheetInfoQuery(selectedSpreadsheetId)
+
+    useEffect(() => {
+        if (isSpreadSheetInfoError) {
+            onError()
+        }
+    }, [isSpreadSheetInfoError, onError])
 
     const handleSheetSelect = (e: SelectChangeEvent) => {
         setSelectedSheetId(e.target.value)


### PR DESCRIPTION
### Description

- Show an error when selecting a sheet fails
- Show an error when opening the manage modal and user info fails. This check is used to see if the user is logged in but has not selected a sheet.

### Testing

ℹ️ To log out without using the plugin, delete the third party connection Framer in your Google account here: https://myaccount.google.com/connections

- [ ] Error is shown when pasting a Google Sheets URL but the user is logged out
  - [ ] Open the Google Sheets plugin and authente with Google
  - [ ] Delete "Framer Sheets Plugin" from your [Google third party connections](https://myaccount.google.com/connections)
  - [ ] Go back to Framer with the plugin still open
  - [ ] Paste in a valid Google Sheets URL
  - [ ] Ensure the logout or retry error modal shows
- [ ] Error is shown when clicking "Manage" on a collection but the user is logged out
  - [ ] Create a new managed collection using the Google Sheets plugin and authenticating with Google
  - [ ] Delete "Framer Sheets Plugin" from your [Google third party connections](https://myaccount.google.com/connections)
  - [ ] Go back to Framer
  - [ ] Click "Manage" on the collection
  - [ ] Ensure the logout or retry error modal shows