### PR TITLE
Reuse refresh token when Google authentication expires

### DIFF
--- a/plugins/google-sheets/framer.json
+++ b/plugins/google-sheets/framer.json
@@ -1,6 +1,6 @@
 {
     "id": "fa488a",
-    "name": "Sheets",
+    "name": "Google Sheets",
     "modes": ["configureManagedCollection", "syncManagedCollection"],
     "icon": "/sheets.svg"
 }


### PR DESCRIPTION
### Description

Turns out Google refresh tokens [never expire unless](https://stackoverflow.com/a/8954103) the user invokes access. So if a new refresh token is not provided, reuse the existing one stored in local storage.

### Testing

Unless you want to wait 2 hours, 1 hour for the initial expiry, another for the refresh, clone the code and edit the [`expiresIn`](https://github.com/framer/plugins/blob/0e610277c229ea7cf353f740ac12576392902c32/plugins/google-sheets/src/auth.ts#L127) to be 10 seconds.

- [ ] Login with Google and wait for token to expire. Reopen the plugin multiple times and ensure you are still loggedin
- [ ] Ensure the login flow is triggered when the refresh token has been lost (delete it from local storage)