### PR TITLE
Fix Google Sheets link import

### DIFF
--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -68,16 +68,18 @@ const inferFieldType = (cellValue: CellValue): CollectionFieldType => {
     if (typeof cellValue === "number") return "number"
 
     if (typeof cellValue === "string") {
-        if (/^\d{1,2}\/\d{1,2}\/\d{4}/.test(cellValue)) return "date"
+        const cellValueLowered = cellValue.toLowerCase()
 
-        if (/^#[0-9A-Fa-f]{6}$/.test(cellValue)) return "color"
+        if (/^\d{1,2}\/\d{1,2}\/\d{4}/.test(cellValueLowered)) return "date"
 
-        if (/<[a-z][\s\S]*>/i.test(cellValue)) return "formattedText"
+        if (/^#[0-9a-f]{6}$/.test(cellValueLowered)) return "color"
+
+        if (/<[a-z][\s\S]*>/i.test(cellValueLowered)) return "formattedText"
 
         try {
-            new URL(cellValue)
+            new URL(cellValueLowered)
 
-            if (/\.(jpeg|jpg|gif|png)$/.test(cellValue)) return "image"
+            if (/\.(gif|jpe?g|png|apng|svg|webp)$/i.test(cellValueLowered)) return "image"
 
             return "link"
         } catch (e) {

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -72,11 +72,17 @@ const inferFieldType = (cellValue: CellValue): CollectionFieldType => {
 
         if (/^#[0-9A-Fa-f]{6}$/.test(cellValue)) return "color"
 
-        if (/\.(jpeg|jpg|gif|png)$/.test(cellValue)) return "image"
-
-        if (/^(https?:\/\/)?([a-zA-Z0-9.-]+)\.([a-zA-Z]{2,6})([/\w .-]*)*\/?$/.test(cellValue)) return "link"
-
         if (/<[a-z][\s\S]*>/i.test(cellValue)) return "formattedText"
+
+        try {
+            new URL(cellValue)
+
+            if (/\.(jpeg|jpg|gif|png)$/.test(cellValue)) return "image"
+
+            return "link"
+        } catch (e) {
+            return "string"
+        }
     }
 
     return "string"


### PR DESCRIPTION
### Description

This PR fixes an issue with Google Sheets link import functionality.

### Testing

- [ ] Create a test spreadsheet containing:
  - Column for ID
  - Column for Links (URLs)
- [ ] Import the spreadsheet using the plugin
- [ ] Verify that:
  - Links are properly detected and imported
  - Error handling works as expected for invalid URLs