### PR TITLE
CMS Export: select active collection automatically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5455,6 +5455,15 @@
                 }
             }
         },
+        "node_modules/framer-plugin": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-2.0.2.tgz",
+            "integrity": "sha512-Sm/7D1SisMp5JfDFb4Tb9omgbsqxNFNrOAMgJj6beIFAEPW7saSgc2sAWM00g1J/jdolOPVtD61S6z3EgqJFDg==",
+            "peerDependencies": {
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -9558,7 +9567,7 @@
             "dependencies": {
                 "@tanstack/react-query": "^5.50.1",
                 "classnames": "^2.5.1",
-                "framer-plugin": "^0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "react-error-boundary": "^4.0.13",
@@ -9775,6 +9784,18 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "plugins/airtable/node_modules/vite-plugin-framer": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/vite-plugin-framer/-/vite-plugin-framer-0.0.10.tgz",
+            "integrity": "sha512-BKWzLPfJZNSZGVfcQyB7oppvsXkipwRX8MwHc0nbHmUUK9sOW/tyYm0O8voJYfKnbqy6ccGp2Qd5c/iv+qgoZw==",
+            "dev": true,
+            "dependencies": {
+                "picocolors": "^1.0.0"
+            },
+            "peerDependencies": {
+                "vite": "^5.0.0"
+            }
+        },
         "plugins/ascii": {
             "version": "0.0.0",
             "dependencies": {
@@ -9782,7 +9803,7 @@
                 "@radix-ui/themes": "^3.1.3",
                 "clsx": "^2.1.1",
                 "colorjs.io": "^0.5.2",
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "ogl": "^1.0.8",
                 "react": "^18",
                 "react-dom": "^18",
@@ -9810,19 +9831,10 @@
                 "@rollup/rollup-linux-x64-gnu": "4.9.5"
             }
         },
-        "plugins/ascii/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/cms-export": {
             "version": "0.0.0",
             "dependencies": {
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "vite-plugin-mkcert": "^1"
@@ -10018,21 +10030,12 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "plugins/cms-export/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/color-extract": {
             "version": "0.0.0",
             "dependencies": {
                 "extract-colors": "^4.0.2",
                 "framer-motion": "^11.0.18",
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "vite-plugin-mkcert": "^1"
@@ -10051,21 +10054,12 @@
                 "vite-plugin-framer": "^1.0.1"
             }
         },
-        "plugins/color-extract/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/concentric": {
             "version": "0.0.0",
             "dependencies": {
                 "@radix-ui/react-slider": "^1.1.2",
                 "framer-motion": "^11.0.8",
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "react-slider": "^2.0.6",
@@ -10086,22 +10080,13 @@
                 "vite-plugin-framer": "^1.0.1"
             }
         },
-        "plugins/concentric/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/dither": {
             "version": "0.0.0",
             "dependencies": {
                 "@radix-ui/react-slider": "^1.2.0",
                 "clsx": "^2.1.1",
                 "colorjs.io": "^0.5.2",
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "ogl": "^1.0.8",
                 "react": "^18",
                 "react-dom": "^18",
@@ -10128,15 +10113,6 @@
                 "@rollup/rollup-linux-x64-gnu": "4.9.5"
             }
         },
-        "plugins/dither/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/doodles": {
             "version": "1.0.0",
             "dependencies": {
@@ -10145,7 +10121,7 @@
                 "@uiw/react-color-shade-slider": "^2.1.1",
                 "extract-colors": "^4.0.2",
                 "framer-motion": "^11.0.18",
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-color": "^2.19.3",
                 "react-dom": "^18",
@@ -10167,20 +10143,11 @@
                 "vite-plugin-framer": "^1.0.1"
             }
         },
-        "plugins/doodles/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/flip-image": {
             "version": "0.0.0",
             "dependencies": {
                 "comlink": "^4.4.1",
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "vite-plugin-mkcert": "^1.17.5"
@@ -10197,15 +10164,6 @@
                 "typescript": "^5.4.5",
                 "vite": "^5.2.9",
                 "vite-plugin-framer": "^1.0.1"
-            }
-        },
-        "plugins/flip-image/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
             }
         },
         "plugins/google-search-console": {
@@ -10443,11 +10401,10 @@
             }
         },
         "plugins/google-sheets": {
-            "version": "0.0.0",
             "dependencies": {
                 "@tanstack/react-query": "^5.51.11",
                 "classnames": "^2.5.1",
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "react-error-boundary": "^4.0.13",
@@ -10648,22 +10605,13 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "plugins/google-sheets/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/hubspot": {
             "version": "0.0.0",
             "dependencies": {
                 "@tanstack/react-query": "^5.49.2",
                 "classnames": "^2.5.1",
                 "framer-motion": "^11.2.9",
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "react-error-boundary": "^4.0.13",
@@ -10868,19 +10816,10 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "plugins/hubspot/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/layout-insert": {
             "version": "0.0.0",
             "dependencies": {
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "vite-plugin-mkcert": "^1"
@@ -11076,22 +11015,13 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "plugins/layout-insert/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/notion": {
             "version": "0.0.0",
             "dependencies": {
                 "@notionhq/client": "^2.2.15",
                 "@tanstack/react-query": "^5.29.2",
                 "classnames": "^2.5.1",
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "react-error-boundary": "^4.0.13",
@@ -11296,21 +11226,12 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "plugins/notion/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/phosphor": {
             "version": "0.0.0",
             "dependencies": {
                 "@phosphor-icons/core": "^2.0.8",
                 "@phosphor-icons/react": "^2.0.15",
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "fuse.js": "^7.0.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
@@ -11330,21 +11251,12 @@
                 "vite-plugin-framer": "^1.0.1"
             }
         },
-        "plugins/phosphor/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/photobooth": {
             "version": "0.0.0",
             "dependencies": {
                 "base64-arraybuffer": "^1.0.2",
                 "framer-motion": "^11.0.8",
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "react-webcam": "^7.2.0",
@@ -11364,19 +11276,10 @@
                 "vite-plugin-framer": "^1.0.1"
             }
         },
-        "plugins/photobooth/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/pong": {
             "version": "0.0.0",
             "dependencies": {
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "vite-plugin-mkcert": "^1.17.5"
@@ -11395,19 +11298,10 @@
                 "vite-plugin-framer": "^1.0.1"
             }
         },
-        "plugins/pong/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/renamer": {
             "version": "0.0.0",
             "dependencies": {
-                "framer-plugin": "^1.1.0"
+                "framer-plugin": "^2.0.2"
             },
             "devDependencies": {
                 "@sveltejs/vite-plugin-svelte": "^4.0.0-next.4",
@@ -11423,20 +11317,11 @@
                 "vite-plugin-mkcert": "^1.17.5"
             }
         },
-        "plugins/renamer/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/rss-feeds": {
             "version": "0.0.0",
             "dependencies": {
                 "classnames": "^2.5.1",
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "vite-plugin-mkcert": "^1"
@@ -11637,20 +11522,11 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "plugins/rss-feeds/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/threshold": {
             "version": "0.0.0",
             "dependencies": {
                 "comlink": "^4.4.1",
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "roughjs": "^4.6.6",
@@ -11672,19 +11548,10 @@
                 "vite-plugin-framer": "^1.0.1"
             }
         },
-        "plugins/threshold/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/tidyup": {
             "version": "0.0.0",
             "dependencies": {
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "vite-plugin-mkcert": "^1.17.5"
@@ -11885,22 +11752,13 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "plugins/tidyup/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "plugins/unsplash": {
             "version": "0.0.0",
             "dependencies": {
                 "@tanstack/react-query": "^5.28.6",
                 "blurhash": "^2.0.5",
                 "classnames": "^2.5.1",
-                "framer-plugin": "^1.1.0",
+                "framer-plugin": "^2.0.2",
                 "react": "^18",
                 "react-blurhash": "^0.3.0",
                 "react-dom": "^18",
@@ -12512,15 +12370,6 @@
                 "@esbuild/win32-arm64": "0.20.2",
                 "@esbuild/win32-ia32": "0.20.2",
                 "@esbuild/win32-x64": "0.20.2"
-            }
-        },
-        "plugins/unsplash/node_modules/framer-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-1.1.0.tgz",
-            "integrity": "sha512-ewn6xC5HOE2BB43pCfoC+gDjbZlQpjgYY30UlqZWiF40njiEljh7vvJip9hJireAVsFVZPRtOP45Gqzk3GgSyQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
             }
         },
         "plugins/unsplash/node_modules/vite": {

--- a/plugins/airtable/package.json
+++ b/plugins/airtable/package.json
@@ -12,7 +12,7 @@
     "dependencies": {
         "@tanstack/react-query": "^5.50.1",
         "classnames": "^2.5.1",
-        "framer-plugin": "^0",
+        "framer-plugin": "^2.0.2",
         "react": "^18",
         "react-dom": "^18",
         "react-error-boundary": "^4.0.13",

--- a/plugins/ascii/package.json
+++ b/plugins/ascii/package.json
@@ -17,7 +17,7 @@
         "@radix-ui/themes": "^3.1.3",
         "clsx": "^2.1.1",
         "colorjs.io": "^0.5.2",
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "ogl": "^1.0.8",
         "react": "^18",
         "react-dom": "^18",

--- a/plugins/cms-export/package.json
+++ b/plugins/cms-export/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "framer-plugin": "^1.1.0",
+    "framer-plugin": "^2.0.2",
     "react": "^18",
     "react-dom": "^18",
     "vite-plugin-mkcert": "^1"

--- a/plugins/cms-export/src/App.css
+++ b/plugins/cms-export/src/App.css
@@ -69,21 +69,14 @@
     height: 100%;
 }
 
-.preview-container-layer-a,
-.preview-container-layer-b {
+.preview-container-image,
+.preview-container-table {
     position: absolute;
     inset: 0;
+    opacity: 0;
+    transition: opacity 300ms;
 }
 
-.preview-container-layer-a--hidden {
-    animation: fade-in 300ms forwards reverse linear;
-}
-
-.preview-container-layer-b {
-    animation: fade-in 300ms forwards linear;
-}
-
-@keyframes fade-in {
-    from { opacity: 0; }
-    to { opacity: 1; }
+.visible {
+    opacity: 1;
 }

--- a/plugins/cms-export/src/App.tsx
+++ b/plugins/cms-export/src/App.tsx
@@ -8,6 +8,7 @@ import { PreviewTable } from "./PreviewTable"
 import splashImageSrc from "./assets/splash.png"
 
 export function App() {
+    const [isLoading, setIsLoading] = useState(true)
     const [collections, setCollections] = useState<Collection[]>([])
     const [selectedCollection, setSelectedCollection] = useState<Collection | null>(null)
 
@@ -18,7 +19,11 @@ export function App() {
             resizable: false,
         })
 
-        framer.getCollections().then(setCollections)
+        Promise.all([framer.getCollections(), framer.getActiveCollection()]).then(([collections, activeCollection]) => {
+            setIsLoading(false)
+            setCollections(collections)
+            setSelectedCollection(activeCollection)
+        })
     }, [])
 
     const exportCSV = async () => {
@@ -64,29 +69,32 @@ export function App() {
     return (
         <div className="export-collection">
             <div className="preview-container">
-                <div className={`preview-container-layer-a ${selectedCollection ? "preview-container-layer-a--hidden" : ""}`}>
+                <div className={`preview-container-image ${!selectedCollection && !isLoading ? "visible" : ""}`}>
                     <div className="empty-state">
                         <img className="empty-state-image" src={splashImageSrc} alt="" />
                         <p className="empty-state-message">Export all your CMS content to CSV files.</p>
                     </div>
                 </div>
 
-                {selectedCollection && (
-                    <div className="preview-container-layer-b">
-                        <PreviewTable collection={selectedCollection} />
-                    </div>
-                )}
+                <div className={`preview-container-table ${selectedCollection ? "visible" : ""}`}>
+                    {selectedCollection && <PreviewTable collection={selectedCollection} />}
+                </div>
             </div>
 
             <div className="footer">
-                <select onChange={selectCollection} className={!selectedCollection ? "footer-select footer-select--unselected" : "footer-select"}>
+                <select
+                    onChange={selectCollection}
+                    className={!selectedCollection ? "footer-select footer-select--unselected" : "footer-select"}
+                >
                     <option selected disabled>
                         Select Collection…
                     </option>
 
-                    {collections.map(collection => {
-                        return <option selected={collection.id === selectedCollection?.id}>{collection.name}</option>
-                    })}
+                    {collections.map(collection => (
+                        <option key={collection.id} selected={collection.id === selectedCollection?.id}>
+                            {collection.name}
+                        </option>
+                    ))}
                 </select>
 
                 <div className="footer-actions">

--- a/plugins/color-extract/package.json
+++ b/plugins/color-extract/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "extract-colors": "^4.0.2",
         "framer-motion": "^11.0.18",
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "react": "^18",
         "react-dom": "^18",
         "vite-plugin-mkcert": "^1"

--- a/plugins/concentric/package.json
+++ b/plugins/concentric/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "@radix-ui/react-slider": "^1.1.2",
         "framer-motion": "^11.0.8",
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "react": "^18",
         "react-dom": "^18",
         "react-slider": "^2.0.6",

--- a/plugins/dither/package.json
+++ b/plugins/dither/package.json
@@ -16,7 +16,7 @@
         "@radix-ui/react-slider": "^1.2.0",
         "clsx": "^2.1.1",
         "colorjs.io": "^0.5.2",
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "ogl": "^1.0.8",
         "react": "^18",
         "react-dom": "^18",

--- a/plugins/doodles/package.json
+++ b/plugins/doodles/package.json
@@ -16,7 +16,7 @@
     "@uiw/react-color-shade-slider": "^2.1.1",
     "extract-colors": "^4.0.2",
     "framer-motion": "^11.0.18",
-    "framer-plugin": "^1.1.0",
+    "framer-plugin": "^2.0.2",
     "react": "^18",
     "react-color": "^2.19.3",
     "react-dom": "^18",

--- a/plugins/flip-image/package.json
+++ b/plugins/flip-image/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "comlink": "^4.4.1",
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "react": "^18",
         "react-dom": "^18",
         "vite-plugin-mkcert": "^1.17.5"

--- a/plugins/google-sheets/package.json
+++ b/plugins/google-sheets/package.json
@@ -12,7 +12,7 @@
     "dependencies": {
         "@tanstack/react-query": "^5.51.11",
         "classnames": "^2.5.1",
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "react": "^18",
         "react-dom": "^18",
         "react-error-boundary": "^4.0.13",

--- a/plugins/hubspot/package.json
+++ b/plugins/hubspot/package.json
@@ -13,7 +13,7 @@
         "@tanstack/react-query": "^5.49.2",
         "classnames": "^2.5.1",
         "framer-motion": "^11.2.9",
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "react": "^18",
         "react-dom": "^18",
         "react-error-boundary": "^4.0.13",

--- a/plugins/layout-insert/package.json
+++ b/plugins/layout-insert/package.json
@@ -10,7 +10,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "react": "^18",
         "react-dom": "^18",
         "vite-plugin-mkcert": "^1"

--- a/plugins/notion/package.json
+++ b/plugins/notion/package.json
@@ -14,7 +14,7 @@
         "@notionhq/client": "^2.2.15",
         "@tanstack/react-query": "^5.29.2",
         "classnames": "^2.5.1",
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "react": "^18",
         "react-dom": "^18",
         "react-error-boundary": "^4.0.13",

--- a/plugins/phosphor/package.json
+++ b/plugins/phosphor/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "@phosphor-icons/core": "^2.0.8",
         "@phosphor-icons/react": "^2.0.15",
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "fuse.js": "^7.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/plugins/photobooth/package.json
+++ b/plugins/photobooth/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "base64-arraybuffer": "^1.0.2",
         "framer-motion": "^11.0.8",
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "react": "^18",
         "react-dom": "^18",
         "react-webcam": "^7.2.0",

--- a/plugins/pong/package.json
+++ b/plugins/pong/package.json
@@ -12,7 +12,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "react": "^18",
         "react-dom": "^18",
         "vite-plugin-mkcert": "^1.17.5"

--- a/plugins/renamer/package.json
+++ b/plugins/renamer/package.json
@@ -24,6 +24,6 @@
     "vite-plugin-mkcert": "^1.17.5"
   },
   "dependencies": {
-    "framer-plugin": "^1.1.0"
+    "framer-plugin": "^2.0.2"
   }
 }

--- a/plugins/rss-feeds/package.json
+++ b/plugins/rss-feeds/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "classnames": "^2.5.1",
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "react": "^18",
         "react-dom": "^18",
         "vite-plugin-mkcert": "^1"

--- a/plugins/threshold/package.json
+++ b/plugins/threshold/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "comlink": "^4.4.1",
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "react": "^18",
         "react-dom": "^18",
         "roughjs": "^4.6.6",

--- a/plugins/tidyup/package.json
+++ b/plugins/tidyup/package.json
@@ -11,7 +11,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "react": "^18",
         "react-dom": "^18",
         "vite-plugin-mkcert": "^1.17.5"

--- a/plugins/unsplash/package.json
+++ b/plugins/unsplash/package.json
@@ -14,7 +14,7 @@
         "@tanstack/react-query": "^5.28.6",
         "blurhash": "^2.0.5",
         "classnames": "^2.5.1",
-        "framer-plugin": "^1.1.0",
+        "framer-plugin": "^2.0.2",
         "react": "^18",
         "react-blurhash": "^0.3.0",
         "react-dom": "^18",


### PR DESCRIPTION
### Description

When opening CMS Export we now automatically select the active collection.

Also updated all plugins to the latest version. And the lock file has lost a lot of "unnecessary" lines. Please check if that's okay.

### Testing

- [ ] CMS Export should automatically select the active collection
  - [ ] Add the sample collection
  - [ ] Open the CMS Export plugin
  - [ ] The active collection should be visible
  - [ ] Go to the canvas
  - [ ] The plugin should open without selecting any collections