### PR TITLE
Improve Google Sheets header syncing

### DIFF
--- a/plugins/google-sheets/src/App.tsx
+++ b/plugins/google-sheets/src/App.tsx
@@ -127,7 +127,7 @@ export function AuthenticatedApp({ pluginContext, setContext }: AuthenticatedApp
 
 function shouldSyncImmediately(pluginContext: PluginContext): pluginContext is PluginContextUpdate {
     if (pluginContext.type !== "update") return false
-    if (pluginContext.slugFieldColumnIndex === null) return false
+    if (pluginContext.slugColumn === null) return false
     if (pluginContext.hasChangedFields) return false
 
     return true
@@ -143,7 +143,7 @@ export function App({ pluginContext }: AppProps) {
     useLayoutEffect(() => {
         if (!shouldSyncOnly) return
         assert(context.type === "update")
-        assert(context.slugFieldColumnIndex !== null, "Expected slug field column index")
+        assert(context.slugColumn !== null, "Expected slug column")
 
         framer.hideUI()
 
@@ -151,16 +151,16 @@ export function App({ pluginContext }: AppProps) {
             spreadsheetId,
             sheetTitle,
             collectionFields: fields,
-            ignoredFieldColumnIndexes,
-            slugFieldColumnIndex,
+            ignoredColumns,
+            slugColumn,
             lastSyncedTime,
             sheet,
         } = context
         const [headerRow] = sheet.values
 
         syncSheet({
-            ignoredFieldColumnIndexes,
-            slugFieldColumnIndex,
+            ignoredColumns,
+            slugColumn,
             fetchedSheet: sheet,
             lastSyncedTime,
             spreadsheetId,

--- a/plugins/google-sheets/src/pages/SelectSheet.tsx
+++ b/plugins/google-sheets/src/pages/SelectSheet.tsx
@@ -27,6 +27,14 @@ export function SelectSheetPage({ onError, onSheetSelected }: Props) {
         }
     }, [isSpreadSheetInfoError, onError])
 
+    useEffect(() => {
+        if (!spreadsheetInfo?.sheets.length) {
+            return
+        }
+
+        setSelectedSheetTitle(spreadsheetInfo.sheets[0].properties.title)
+    }, [spreadsheetInfo])
+
     const handleSheetSelect = (e: SelectChangeEvent) => {
         setSelectedSheetTitle(e.target.value)
     }

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -587,6 +587,11 @@ export async function getPluginContext(): Promise<PluginContext> {
         collectionFields = reorderedCollectionFields
     }
 
+    // If the stored slug column is not in the spreadsheet header row, we need to update it
+    if (slugColumn && !sheetHeaderRow.includes(slugColumn)) {
+        slugColumn = null
+    }
+
     return {
         type: "update",
         isAuthenticated,

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -24,6 +24,7 @@ const PLUGIN_IGNORED_COLUMNS_KEY = "sheetsPluginIgnoredColumns"
 const PLUGIN_SHEET_HEADER_ROW_HASH_KEY = "sheetsPluginSheetHeaderRowHash"
 const PLUGIN_SLUG_COLUMN_KEY = "sheetsPluginSlugColumn"
 
+/** @deprecated - use PLUGIN_SHEET_ID_KEY instead */
 const DO_NOT_USE_ME_PLUGIN_SHEET_TITLE_KEY = "sheetsPluginSheetTitle"
 /** @deprecated - use PLUGIN_SHEET_HEADER_ROW_HASH_KEY instead  */
 const DO_NOT_USE_ME_PLUGIN_SHEET_HEADER_ROW_KEY = "sheetsPluginSheetHeaderRow"
@@ -556,13 +557,7 @@ export async function getPluginContext(): Promise<PluginContext> {
             id: uniqueHeaderRowNames.find(name => name === field.name) ?? uniqueHeaderRowNames[index],
         }))
 
-        await collection.setFields(collectionFields)
-
         await Promise.all([
-            collection.setPluginData(PLUGIN_IGNORED_COLUMNS_KEY, JSON.stringify(ignoredColumns)),
-            collection.setPluginData(PLUGIN_SLUG_COLUMN_KEY, slugColumn),
-            collection.setPluginData(PLUGIN_SHEET_HEADER_ROW_HASH_KEY, currentSheetHeaderRowHash),
-
             collection.setPluginData(DO_NOT_USE_ME_PLUGIN_IGNORED_FIELD_COLUMN_INDEXES_KEY, null),
             collection.setPluginData(DO_NOT_USE_ME_PLUGIN_SLUG_INDEX_COLUMN_KEY, null),
             collection.setPluginData(DO_NOT_USE_ME_PLUGIN_SHEET_HEADER_ROW_KEY, null),

--- a/plugins/google-sheets/src/utils.ts
+++ b/plugins/google-sheets/src/utils.ts
@@ -88,3 +88,17 @@ export function generateHashId(text: string): string {
     const unsignedHash = hash >>> 0
     return unsignedHash.toString(16).padStart(8, "0")
 }
+
+/**
+ * Generates unique names by appending a suffix if the name is already used.
+ */
+export function generateUniqueNames(names: string[]): string[] {
+    const nameCount = new Map<string, number>()
+
+    return names.map(name => {
+        const count = nameCount.get(name) || 0
+        nameCount.set(name, count + 1)
+
+        return count > 0 ? `${name} ${count + 1}` : name
+    })
+}


### PR DESCRIPTION
### Description

Update how we map Google Sheets header to the plugin. Previously we were using number-based Indexes and that would lead to shift when adding / moving / removing columns in the spreadsheet and then syncing it in Framer. 

### Testing

- [ ] Should support column operations
  - [ ] Import a spreadsheet
  - [ ] Edit/add/remove/move a column anywhere in the spreadsheet
  - [ ] Sync
  - [ ] You should be prompted to re-configure the collection
- [ ] Should be backward compatible
  - [ ] Checkout main
  - [ ] Import a spreadsheet and change the slug, the field name and ignore some fields
  - [ ] Checkout `fix/sheets-stable-header`
  - [ ] Click on either sync or manage
  - [ ] You should be prompted to re-configure the collection with pre-filled slug, field name and ignored field