### PR TITLE
Transform value with line breaks to formatted text

### DIFF
--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -55,7 +55,7 @@ const inferFieldType = (cellValue: CellValue): CollectionFieldType => {
         const cellValueLowered = cellValue.trim().toLowerCase()
 
         // If the cell value contains a newline, it's probably a formatted text field
-        if (/\n/.test(cellValueLowered)) return "formattedText"
+        if (cellValueLowered.includes("\n")) return "formattedText"
         if (/^\d{1,2}\/\d{1,2}\/\d{4}/.test(cellValueLowered)) return "date"
         if (/^#[0-9a-f]{6}$/.test(cellValueLowered)) return "color"
         if (/<[a-z][\s\S]*>/.test(cellValueLowered)) return "formattedText"

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -52,13 +52,13 @@ const inferFieldType = (cellValue: CellValue): CollectionFieldType => {
     if (typeof cellValue === "number") return "number"
 
     if (typeof cellValue === "string") {
-        const cellValueLowered = cellValue.toLowerCase()
+        const cellValueLowered = cellValue.trim().toLowerCase()
 
+        // If the cell value contains a newline, it's probably a formatted text field
+        if (/\n/.test(cellValueLowered)) return "formattedText"
         if (/^\d{1,2}\/\d{1,2}\/\d{4}/.test(cellValueLowered)) return "date"
-
         if (/^#[0-9a-f]{6}$/.test(cellValueLowered)) return "color"
-
-        if (/<[a-z][\s\S]*>/i.test(cellValueLowered)) return "formattedText"
+        if (/<[a-z][\s\S]*>/.test(cellValueLowered)) return "formattedText"
 
         try {
             new URL(cellValueLowered)


### PR DESCRIPTION
### Description

If a cell contains a line break, then we should make the field type a Formatted Text.

### Testing

- [ ] Import a Google Sheets with a cell having a long text with paragraphs
- [ ] The type should be infered to `Formatted Text`