### PR TITLE
Add current database / collection ID mapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5503,9 +5503,9 @@
             }
         },
         "node_modules/framer-plugin": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-2.0.2.tgz",
-            "integrity": "sha512-Sm/7D1SisMp5JfDFb4Tb9omgbsqxNFNrOAMgJj6beIFAEPW7saSgc2sAWM00g1J/jdolOPVtD61S6z3EgqJFDg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-2.0.4.tgz",
+            "integrity": "sha512-gsIyg4npci2jTcC0j931PchdUII7rT69RMqvCe2Vdhhd2Bzm2RNIQBnLmRhm1wuEWIzOJo85xsaQFr27WWhjSA==",
             "peerDependencies": {
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"
@@ -11126,7 +11126,7 @@
                 "@notionhq/client": "^2.2.15",
                 "@tanstack/react-query": "^5.29.2",
                 "classnames": "^2.5.1",
-                "framer-plugin": "^2.0.2",
+                "framer-plugin": "^2.0.4",
                 "react": "^18",
                 "react-dom": "^18",
                 "react-error-boundary": "^4.0.13",

--- a/plugins/notion/package.json
+++ b/plugins/notion/package.json
@@ -14,7 +14,7 @@
         "@notionhq/client": "^2.2.15",
         "@tanstack/react-query": "^5.29.2",
         "classnames": "^2.5.1",
-        "framer-plugin": "^2.0.2",
+        "framer-plugin": "^2.0.4",
         "react": "^18",
         "react-dom": "^18",
         "react-error-boundary": "^4.0.13",

--- a/plugins/notion/src/App.tsx
+++ b/plugins/notion/src/App.tsx
@@ -1,7 +1,7 @@
 import { framer } from "framer-plugin"
 import { useEffect, useState } from "react"
 import "./App.css"
-import { PluginContext, useSynchronizeDatabaseMutation } from "./notion"
+import { PluginContext, PluginContextNew, PluginContextUpdate, useSynchronizeDatabaseMutation } from "./notion"
 
 import { GetDatabaseResponse } from "@notionhq/client/build/src/api-endpoints"
 import { SelectDatabase } from "./SelectDatabase"
@@ -13,7 +13,11 @@ interface AppProps {
     context: PluginContext
 }
 
-export function AuthenticatedApp({ context }: AppProps) {
+interface AuthenticatedAppProps {
+    context: PluginContextNew | PluginContextUpdate
+}
+
+export function AuthenticatedApp({ context }: AuthenticatedAppProps) {
     const [databaseConfig, setDatabaseConfig] = useState<GetDatabaseResponse | null>(
         context.type === "update" ? context.database : null
     )
@@ -46,8 +50,13 @@ export function AuthenticatedApp({ context }: AppProps) {
         },
     })
 
+    const handleDatabaseSelected = (database: GetDatabaseResponse) => {
+        context.databaseIdMap.set(database.id, context.collection.id)
+        setDatabaseConfig(database)
+    }
+
     if (!databaseConfig) {
-        return <SelectDatabase onDatabaseSelected={setDatabaseConfig} />
+        return <SelectDatabase onDatabaseSelected={handleDatabaseSelected} />
     }
 
     return (


### PR DESCRIPTION
### Description

Previously, when importing a Notion database with self-referencing relationships (records that reference other records within the same database), we had to follow a two-step process:
1.	First import the database
2.	Then perform a sync to populate the reference fields

With this PR, we're adding the current collection to the table mapping system during the import process itself, which allows us to handle circular references directly during the import. This eliminates the need for the additional sync step and ensures that self-referencing relationships are preserved correctly in a single operation.

This depends on https://github.com/framer/FramerStudio/pull/19792, which adds support for circular references when inserting items in a managed collection.

### Testing

- [ ] Importing a table with self-referencing values
  - [ ] Create a Notion database that contains records with relations to other records within the same database
  - [ ] Import this database into Framer
  - [ ] Verify that all self-referencing relationships are preserved correctly in the Framer collection