### PR TITLE
Fix vite-plugin-mkcert to latest major

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2211,132 +2211,169 @@
             "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.3.tgz",
-            "integrity": "sha512-MmKSfaB9GX+zXl6E8z4koOr/xU63AMVleLEa64v7R0QF/ZloMs5vcD1sHgM64GXXS1csaJutG+ddtzcueI/BLg==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.27.4.tgz",
+            "integrity": "sha512-2Y3JT6f5MrQkICUyRVCw4oa0sutfAsgaSsb0Lmmy1Wi2y7X5vT9Euqw4gOsCyy0YfKURBg35nhUKZS4mDcfULw==",
             "cpu": [
                 "arm"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.3.tgz",
-            "integrity": "sha512-zrt8ecH07PE3sB4jPOggweBjJMzI1JG5xI2DIsUbkA+7K+Gkjys6eV7i9pOenNSDJH3eOr/jLb/PzqtmdwDq5g==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.27.4.tgz",
+            "integrity": "sha512-wzKRQXISyi9UdCVRqEd0H4cMpzvHYt1f/C3CoIjES6cG++RHKhrBj2+29nPF0IB5kpy9MS71vs07fvrNGAl/iA==",
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.3.tgz",
-            "integrity": "sha512-P0UxIOrKNBFTQaXTxOH4RxuEBVCgEA5UTNV6Yz7z9QHnUJ7eLX9reOd/NYMO3+XZO2cco19mXTxDMXxit4R/eQ==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.27.4.tgz",
+            "integrity": "sha512-PlNiRQapift4LNS8DPUHuDX/IdXiLjf8mc5vdEmUR0fF/pyy2qWwzdLjB+iZquGr8LuN4LnUoSEvKRwjSVYz3Q==",
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.3.tgz",
-            "integrity": "sha512-L1M0vKGO5ASKntqtsFEjTq/fD91vAqnzeaF6sfNAy55aD+Hi2pBI5DKwCO+UNDQHWsDViJLqshxOahXyLSh3EA==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.27.4.tgz",
+            "integrity": "sha512-o9bH2dbdgBDJaXWJCDTNDYa171ACUdzpxSZt+u/AAeQ20Nk5x+IhA+zsGmrQtpkLiumRJEYef68gcpn2ooXhSQ==",
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.27.4.tgz",
+            "integrity": "sha512-NBI2/i2hT9Q+HySSHTBh52da7isru4aAAo6qC3I7QFVsuhxi2gM8t/EI9EVcILiHLj1vfi+VGGPaLOUENn7pmw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.27.4.tgz",
+            "integrity": "sha512-wYcC5ycW2zvqtDYrE7deary2P2UFmSh85PUpAx+dwTCO9uw3sgzD6Gv9n5X4vLaQKsrfTSZZ7Z7uynQozPVvWA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.3.tgz",
-            "integrity": "sha512-btVgIsCjuYFKUjopPoWiDqmoUXQDiW2A4C3Mtmp5vACm7/GnyuprqIDPNczeyR5W8rTXEbkmrJux7cJmD99D2g==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.27.4.tgz",
+            "integrity": "sha512-9OwUnK/xKw6DyRlgx8UizeqRFOfi9mf5TYCw1uolDaJSbUmBxP85DE6T4ouCMoN6pXw8ZoTeZCSEfSaYo+/s1w==",
             "cpu": [
                 "arm"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.3.tgz",
-            "integrity": "sha512-zmjbSphplZlau6ZTkxd3+NMtE4UKVy7U4aVFMmHcgO5CUbw17ZP6QCgyxhzGaU/wFFdTfiojjbLG3/0p9HhAqA==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.27.4.tgz",
+            "integrity": "sha512-Vgdo4fpuphS9V24WOV+KwkCVJ72u7idTgQaBoLRD0UxBAWTF9GWurJO9YD9yh00BzbkhpeXtm6na+MvJU7Z73A==",
             "cpu": [
                 "arm"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.3.tgz",
-            "integrity": "sha512-nSZfcZtAnQPRZmUkUQwZq2OjQciR6tEoJaZVFvLHsj0MF6QhNMg0fQ6mUOsiCUpTqxTx0/O6gX0V/nYc7LrgPw==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.27.4.tgz",
+            "integrity": "sha512-pleyNgyd1kkBkw2kOqlBx+0atfIIkkExOTiifoODo6qKDSpnc6WzUY5RhHdmTdIJXBdSnh6JknnYTtmQyobrVg==",
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.3.tgz",
-            "integrity": "sha512-MnvSPGO8KJXIMGlQDYfvYS3IosFN2rKsvxRpPO2l2cum+Z3exiExLwVU+GExL96pn8IP+GdH8Tz70EpBhO0sIQ==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.27.4.tgz",
+            "integrity": "sha512-caluiUXvUuVyCHr5DxL8ohaaFFzPGmgmMvwmqAITMpV/Q+tPoaHZ/PWa3t8B2WyoRcIIuu1hkaW5KkeTDNSnMA==",
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.3.tgz",
-            "integrity": "sha512-+W+p/9QNDr2vE2AXU0qIy0qQE75E8RTwTwgqS2G5CRQ11vzq0tbnfBd6brWhS9bCRjAjepJe2fvvkvS3dno+iw==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.27.4.tgz",
+            "integrity": "sha512-FScrpHrO60hARyHh7s1zHE97u0KlT/RECzCKAdmI+LEoC1eDh/RDji9JgFqyO+wPDb86Oa/sXkily1+oi4FzJQ==",
             "cpu": [
                 "ppc64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.3.tgz",
-            "integrity": "sha512-yXH6K6KfqGXaxHrtr+Uoy+JpNlUlI46BKVyonGiaD74ravdnF9BUNC+vV+SIuB96hUMGShhKV693rF9QDfO6nQ==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.27.4.tgz",
+            "integrity": "sha512-qyyprhyGb7+RBfMPeww9FlHwKkCXdKHeGgSqmIXw9VSUtvyFZ6WZRtnxgbuz76FK7LyoN8t/eINRbPUcvXB5fw==",
             "cpu": [
                 "riscv64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.3.tgz",
-            "integrity": "sha512-R8cwY9wcnApN/KDYWTH4gV/ypvy9yZUHlbJvfaiXSB48JO3KpwSpjOGqO4jnGkLDSk1hgjYkTbTt6Q7uvPf8eg==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.27.4.tgz",
+            "integrity": "sha512-PFz+y2kb6tbh7m3A7nA9++eInGcDVZUACulf/KzDtovvdTizHpZaJty7Gp0lFwSQcrnebHOqxF1MaKZd7psVRg==",
             "cpu": [
                 "s390x"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2355,48 +2392,52 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.3.tgz",
-            "integrity": "sha512-S0Yq+xA1VEH66uiMNhijsWAafffydd2X5b77eLHfRmfLsRSpbiAWiRHV6DEpz6aOToPsgid7TI9rGd6zB1rhbg==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.27.4.tgz",
+            "integrity": "sha512-5AeeAF1PB9TUzD+3cROzFTnAJAcVUGLuR8ng0E0WXGkYhp6RD6L+6szYVX+64Rs0r72019KHZS1ka1q+zU/wUw==",
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.3.tgz",
-            "integrity": "sha512-9isNzeL34yquCPyerog+IMCNxKR8XYmGd0tHSV+OVx0TmE0aJOo9uw4fZfUuk2qxobP5sug6vNdZR6u7Mw7Q+Q==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.27.4.tgz",
+            "integrity": "sha512-yOpVsA4K5qVwu2CaS3hHxluWIK5HQTjNV4tWjQXluMiiiu4pJj4BN98CvxohNCpcjMeTXk/ZMJBRbgRg8HBB6A==",
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.3.tgz",
-            "integrity": "sha512-nMIdKnfZfzn1Vsk+RuOvl43ONTZXoAPUUxgcU0tXooqg4YrAqzfKzVenqqk2g5efWh46/D28cKFrOzDSW28gTA==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.27.4.tgz",
+            "integrity": "sha512-KtwEJOaHAVJlxV92rNYiG9JQwQAdhBlrjNRp7P9L8Cb4Rer3in+0A+IPhJC9y68WAi9H0sX4AiG2NTsVlmqJeQ==",
             "cpu": [
                 "ia32"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.3.tgz",
-            "integrity": "sha512-fOvu7PCQjAj4eWDEuD8Xz5gpzFqXzGlxHZozHP4b9Jxv9APtdxL6STqztDzMLuRXEc4UpXGGhx029Xgm91QBeA==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.27.4.tgz",
+            "integrity": "sha512-3j4jx1TppORdTAoBJRd+/wJRGCPC0ETWkXOecJ6PPZLj6SptXkrXcNqdj0oclbKML6FkQltdz7bBA3rUSirZug==",
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -2822,9 +2863,10 @@
             "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
         },
         "node_modules/@types/estree": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+            "license": "MIT"
         },
         "node_modules/@types/http-cache-semantics": {
             "version": "4.0.4",
@@ -3760,9 +3802,10 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.7.7",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-            "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+            "version": "1.7.8",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.8.tgz",
+            "integrity": "sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==",
+            "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
@@ -8011,11 +8054,12 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.3.tgz",
-            "integrity": "sha512-7sqRtBNnEbcBtMeRVc6VRsJMmpI+JU1z9VTvW8D4gXIYQFz0aLcsE6rRkyghZkLfEgUZgVvOG7A5CVz/VW5GIA==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.27.4.tgz",
+            "integrity": "sha512-RLKxqHEMjh/RGLsDxAEsaLO3mWgyoU6x9w6n1ikAzet4B3gI2/3yP6PWY2p9QzRTh6MfEIXB3MwsOY0Iv3vNrw==",
+            "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.5"
+                "@types/estree": "1.0.6"
             },
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -8025,32 +8069,35 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.21.3",
-                "@rollup/rollup-android-arm64": "4.21.3",
-                "@rollup/rollup-darwin-arm64": "4.21.3",
-                "@rollup/rollup-darwin-x64": "4.21.3",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.21.3",
-                "@rollup/rollup-linux-arm-musleabihf": "4.21.3",
-                "@rollup/rollup-linux-arm64-gnu": "4.21.3",
-                "@rollup/rollup-linux-arm64-musl": "4.21.3",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.21.3",
-                "@rollup/rollup-linux-riscv64-gnu": "4.21.3",
-                "@rollup/rollup-linux-s390x-gnu": "4.21.3",
-                "@rollup/rollup-linux-x64-gnu": "4.21.3",
-                "@rollup/rollup-linux-x64-musl": "4.21.3",
-                "@rollup/rollup-win32-arm64-msvc": "4.21.3",
-                "@rollup/rollup-win32-ia32-msvc": "4.21.3",
-                "@rollup/rollup-win32-x64-msvc": "4.21.3",
+                "@rollup/rollup-android-arm-eabi": "4.27.4",
+                "@rollup/rollup-android-arm64": "4.27.4",
+                "@rollup/rollup-darwin-arm64": "4.27.4",
+                "@rollup/rollup-darwin-x64": "4.27.4",
+                "@rollup/rollup-freebsd-arm64": "4.27.4",
+                "@rollup/rollup-freebsd-x64": "4.27.4",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.27.4",
+                "@rollup/rollup-linux-arm-musleabihf": "4.27.4",
+                "@rollup/rollup-linux-arm64-gnu": "4.27.4",
+                "@rollup/rollup-linux-arm64-musl": "4.27.4",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.27.4",
+                "@rollup/rollup-linux-riscv64-gnu": "4.27.4",
+                "@rollup/rollup-linux-s390x-gnu": "4.27.4",
+                "@rollup/rollup-linux-x64-gnu": "4.27.4",
+                "@rollup/rollup-linux-x64-musl": "4.27.4",
+                "@rollup/rollup-win32-arm64-msvc": "4.27.4",
+                "@rollup/rollup-win32-ia32-msvc": "4.27.4",
+                "@rollup/rollup-win32-x64-msvc": "4.27.4",
                 "fsevents": "~2.3.2"
             }
         },
         "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.3.tgz",
-            "integrity": "sha512-kZPbX/NOPh0vhS5sI+dR8L1bU2cSO9FgxwM8r7wHzGydzfSjLRCFAT87GR5U9scj2rhzN3JPYVC7NoBbl4FZ0g==",
+            "version": "4.27.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.27.4.tgz",
+            "integrity": "sha512-Ni8mMtfo+o/G7DVtweXXV/Ol2TFf63KYjTtoZ5f078AUgJTmaIJnj4JFU7TK/9SVWTaSJGxPi5zMDgK4w+Ez7Q==",
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -9888,7 +9935,7 @@
                 "react": "^18",
                 "react-dom": "^18",
                 "react-dropzone": "^14.2.3",
-                "vite-plugin-mkcert": "^1.17.5"
+                "vite-plugin-mkcert": "^1"
             },
             "devDependencies": {
                 "@swc/cli": "^0.4.0",
@@ -10170,7 +10217,7 @@
                 "ogl": "^1.0.8",
                 "react": "^18",
                 "react-dom": "^18",
-                "vite-plugin-mkcert": "^1.17.5"
+                "vite-plugin-mkcert": "^1"
             },
             "devDependencies": {
                 "@swc/cli": "^0.4.0",
@@ -10230,7 +10277,7 @@
                 "framer-plugin": "^2.0.4",
                 "react": "^18",
                 "react-dom": "^18",
-                "vite-plugin-mkcert": "^1.17.5"
+                "vite-plugin-mkcert": "^1"
             },
             "devDependencies": {
                 "@types/react": "^18",
@@ -11341,7 +11388,7 @@
                 "fuse.js": "^7.0.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
-                "vite-plugin-mkcert": "^1.17.5"
+                "vite-plugin-mkcert": "^1"
             },
             "devDependencies": {
                 "@types/react": "^18.0.26",
@@ -11366,7 +11413,7 @@
                 "react": "^18",
                 "react-dom": "^18",
                 "react-webcam": "^7.2.0",
-                "vite-plugin-mkcert": "^1.17.5"
+                "vite-plugin-mkcert": "^1"
             },
             "devDependencies": {
                 "@types/react": "^18",
@@ -11388,7 +11435,7 @@
                 "framer-plugin": "^2.0.4",
                 "react": "^18",
                 "react-dom": "^18",
-                "vite-plugin-mkcert": "^1.17.5"
+                "vite-plugin-mkcert": "^1"
             },
             "devDependencies": {
                 "@types/react": "^18",
@@ -11420,7 +11467,7 @@
                 "typescript": "^5.2.2",
                 "vite": "^5",
                 "vite-plugin-framer": "^1.0.1",
-                "vite-plugin-mkcert": "^1.17.5"
+                "vite-plugin-mkcert": "^1"
             }
         },
         "plugins/rss-feeds": {
@@ -11636,7 +11683,7 @@
                 "react": "^18",
                 "react-dom": "^18",
                 "roughjs": "^4.6.6",
-                "vite-plugin-mkcert": "^1.17.5"
+                "vite-plugin-mkcert": "^1"
             },
             "devDependencies": {
                 "@types/react": "^18",
@@ -11660,7 +11707,7 @@
                 "framer-plugin": "^2.0.4",
                 "react": "^18",
                 "react-dom": "^18",
-                "vite-plugin-mkcert": "^1.17.5"
+                "vite-plugin-mkcert": "^1"
             },
             "devDependencies": {
                 "@types/react": "^18",
@@ -11870,7 +11917,7 @@
                 "react-dom": "^18",
                 "react-error-boundary": "^4.0.13",
                 "valibot": "0.29.0",
-                "vite-plugin-mkcert": "^1.17.5"
+                "vite-plugin-mkcert": "^1"
             },
             "devDependencies": {
                 "@types/react": "^18",

--- a/plugins/ascii/package.json
+++ b/plugins/ascii/package.json
@@ -23,7 +23,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-dropzone": "^14.2.3",
-        "vite-plugin-mkcert": "^1.17.5"
+        "vite-plugin-mkcert": "^1"
     },
     "devDependencies": {
         "@swc/cli": "^0.4.0",

--- a/plugins/dither/package.json
+++ b/plugins/dither/package.json
@@ -21,7 +21,7 @@
         "ogl": "^1.0.8",
         "react": "^18",
         "react-dom": "^18",
-        "vite-plugin-mkcert": "^1.17.5"
+        "vite-plugin-mkcert": "^1"
     },
     "devDependencies": {
         "@swc/cli": "^0.4.0",

--- a/plugins/flip-image/package.json
+++ b/plugins/flip-image/package.json
@@ -17,7 +17,7 @@
         "framer-plugin": "^2.0.4",
         "react": "^18",
         "react-dom": "^18",
-        "vite-plugin-mkcert": "^1.17.5"
+        "vite-plugin-mkcert": "^1"
     },
     "devDependencies": {
         "@types/react": "^18",

--- a/plugins/phosphor/package.json
+++ b/plugins/phosphor/package.json
@@ -19,7 +19,7 @@
         "fuse.js": "^7.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "vite-plugin-mkcert": "^1.17.5"
+        "vite-plugin-mkcert": "^1"
     },
     "devDependencies": {
         "@types/react": "^18.0.26",

--- a/plugins/photobooth/package.json
+++ b/plugins/photobooth/package.json
@@ -19,7 +19,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-webcam": "^7.2.0",
-        "vite-plugin-mkcert": "^1.17.5"
+        "vite-plugin-mkcert": "^1"
     },
     "devDependencies": {
         "@types/react": "^18",

--- a/plugins/pong/package.json
+++ b/plugins/pong/package.json
@@ -16,7 +16,7 @@
         "framer-plugin": "^2.0.4",
         "react": "^18",
         "react-dom": "^18",
-        "vite-plugin-mkcert": "^1.17.5"
+        "vite-plugin-mkcert": "^1"
     },
     "devDependencies": {
         "@types/react": "^18",

--- a/plugins/renamer/package.json
+++ b/plugins/renamer/package.json
@@ -22,7 +22,7 @@
     "typescript": "^5.2.2",
     "vite": "^5",
     "vite-plugin-framer": "^1.0.1",
-    "vite-plugin-mkcert": "^1.17.5"
+    "vite-plugin-mkcert": "^1"
   },
   "dependencies": {
     "framer-plugin": "^2.0.4"

--- a/plugins/threshold/package.json
+++ b/plugins/threshold/package.json
@@ -19,7 +19,7 @@
         "react": "^18",
         "react-dom": "^18",
         "roughjs": "^4.6.6",
-        "vite-plugin-mkcert": "^1.17.5"
+        "vite-plugin-mkcert": "^1"
     },
     "devDependencies": {
         "@types/react": "^18",

--- a/plugins/tidyup/package.json
+++ b/plugins/tidyup/package.json
@@ -15,7 +15,7 @@
         "framer-plugin": "^2.0.4",
         "react": "^18",
         "react-dom": "^18",
-        "vite-plugin-mkcert": "^1.17.5"
+        "vite-plugin-mkcert": "^1"
     },
     "devDependencies": {
         "@types/react": "^18",

--- a/plugins/unsplash/package.json
+++ b/plugins/unsplash/package.json
@@ -21,7 +21,7 @@
         "react-dom": "^18",
         "react-error-boundary": "^4.0.13",
         "valibot": "0.29.0",
-        "vite-plugin-mkcert": "^1.17.5"
+        "vite-plugin-mkcert": "^1"
     },
     "devDependencies": {
         "@types/react": "^18",


### PR DESCRIPTION
Pin the `vite-plugin-mkcert` version to the latest major. It bumps rollup and axios versions.