### PR TITLE
increase modal size to 600x600

### DIFF
--- a/plugins/google-sheets/src/App.tsx
+++ b/plugins/google-sheets/src/App.tsx
@@ -88,8 +88,8 @@ export function AuthenticatedApp({ pluginContext, setContext }: AuthenticatedApp
 
     useLayoutEffect(() => {
         framer.showUI({
-            width: sheetTitle !== null ? 340 : 320,
-            height: sheetTitle !== null ? 425 : 345,
+            width: sheetTitle !== null ? 600 : 320,
+            height: sheetTitle !== null ? 600 : 345,
         })
     }, [sheetTitle])
 


### PR DESCRIPTION
### Description

The Google Sheets plugin UI is very small which makes it hard to read longer field names. Suggest increasing the modal size to 600x600 pixels. 
*Old:*
![CleanShot 2024-12-13 at 14 35 22@2x](https://github.com/user-attachments/assets/fb555762-2148-4ce5-8213-2c766ba754f3)

*New:*
![CleanShot 2024-12-13 at 14 38 31@2x](https://github.com/user-attachments/assets/9840f059-3fe2-4bc1-8ffd-feaf0b8bd0e4)
