### PR TITLE
Fix Google Sheets existing fields type

### DIFF
--- a/plugins/google-sheets/src/App.tsx
+++ b/plugins/google-sheets/src/App.tsx
@@ -167,8 +167,8 @@ export function App({ pluginContext }: AppProps) {
             sheetTitle,
             fields,
             // Determine if the field type is already configured, otherwise default to "string"
-            colFieldTypes: headerRow.map((_, colIndex) => {
-                const field = fields.find(field => Number(field.id) === colIndex)
+            colFieldTypes: headerRow.map(colName => {
+                const field = fields.find(field => field?.name === colName)
                 return field?.type ?? "string"
             }),
         }).then(() => framer.closePlugin())


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request fixes a bug when re-syncing a collection the existing fields where not fetched correctly and therefore their type where set to `string`

Fixes: #143 

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Sync a spreadsheet works
  - [x] Import the following spreadsheet: https://docs.google.com/spreadsheets/d/1o1RaseNzmT1ug5kYQr-LWrHbCWCglOISJpv8jGdxC28/edit?gid=0#gid=0
  - [x] Update a value in Google Sheets
  - [x] Synchronize the collection
