### PR TITLE
Fix Google Sheets date

### DIFF
--- a/plugins/google-sheets/src/App.tsx
+++ b/plugins/google-sheets/src/App.tsx
@@ -167,8 +167,8 @@ export function App({ pluginContext }: AppProps) {
             sheetTitle,
             fields,
             // Determine if the field type is already configured, otherwise default to "string"
-            colFieldTypes: headerRow.map((_, colIndex) => {
-                const field = fields.find(field => Number(field.id) === colIndex)
+            colFieldTypes: headerRow.map(colName => {
+                const field = fields.find(field => field?.name === colName)
                 return field?.type ?? "string"
             }),
         }).then(() => framer.closePlugin())

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -56,7 +56,7 @@ const inferFieldType = (cellValue: CellValue): CollectionFieldType => {
 
         // If the cell value contains a newline, it's probably a formatted text field
         if (cellValueLowered.includes("\n")) return "formattedText"
-        if (/^\d{1,2}\/\d{1,2}\/\d{4}/.test(cellValueLowered)) return "date"
+        if (/^\d{1,2}-\d{1,2}-\d{4}/.test(cellValueLowered)) return "date"
         if (/^#[0-9a-f]{6}$/.test(cellValueLowered)) return "color"
         if (/<[a-z][\s\S]*>/.test(cellValueLowered)) return "formattedText"
 

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -294,7 +294,9 @@ function getFieldValue(fieldType: CollectionFieldType, cellValue: CellValue) {
         }
         case "date": {
             if (typeof cellValue !== "string") return null
-            return new Date(cellValue).toUTCString()
+            const [month, day, year] = cellValue.split(/[-/]/).map(Number)
+            const date = new Date(Date.UTC(year, month - 1, day, 12, 0, 0, 0))
+            return date.toISOString()
         }
         case "enum":
         case "image":


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request fixes a bug when syncing date field the day would be offsetted. It's because we need to use UTC when re-creating the date.

Fixes: #142 

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Importing a spreadsheet with date works
  - [x] Import the `With Date` sheet: https://docs.google.com/spreadsheets/d/1o1RaseNzmT1ug5kYQr-LWrHbCWCglOISJpv8jGdxC28/edit?gid=0#gid=0
  - [x] The date should be the same as the one in Google Sheets

<!-- Thank you for contributing! -->