### PR TITLE
Add exponential backoff for Airtable requests

### DIFF
--- a/plugins/airtable/src/App.tsx
+++ b/plugins/airtable/src/App.tsx
@@ -1,5 +1,5 @@
 import { framer } from "framer-plugin"
-import { useEffect, useLayoutEffect, useState } from "react"
+import { useEffect, useLayoutEffect, useRef, useState } from "react"
 import { getTableIdMapForBase, PluginContext, PluginContextNew, PluginContextUpdate, syncTable } from "./airtable"
 import { useBaseSchemaQuery, useSyncTableMutation } from "./api"
 import { assert } from "./utils"
@@ -131,12 +131,16 @@ export function App({ pluginContext }: AppProps) {
     const mode = framer.mode
     const shouldSyncOnly = mode === "syncManagedCollection" && shouldSyncImmediately(context)
 
+    const isSyncing = useRef(false)
+
     useLayoutEffect(() => {
+        if (isSyncing.current) return
         if (!shouldSyncOnly) return
 
         assert(context.type === "update")
         assert(context.slugFieldId !== null, "Expected slug field")
 
+        isSyncing.current = true
         framer.hideUI()
 
         const { baseId, tableId, collectionFields, ignoredFieldIds, slugFieldId, tableSchema, lastSyncedTime } = context


### PR DESCRIPTION
### Description

This pull request implements exponential back-off to avoid getting rate limited by the Airtable API. The main logic comes from the official [Airtable SDK](https://github.com/Airtable/airtable.js/blob/899adb414ebc789aa3b0dcfe6c19113377315564/src/base.ts#L81).

This PR is a follow up on https://github.com/framer/plugins/pull/146#pullrequestreview-2520432769.

### Testing

- [ ] Import a base with more than 100 items
  - [ ] Open https://airtable.com/appsSUBLDCC9PvjXt/shrhmouTrRQK4saLh/tblzuKOcc3gjwX7Gd/viws9tt34yvdmT8QE and copy base to your workspace (for Framer employees there is a shared account for Airbase, ping me on Slack)
  - [ ] Import the base
  - [ ] You should have 1000 items

<!-- Thank you for contributing! -->