### PR TITLE
Use new getActiveLocale API

### DIFF
--- a/plugins/localization-import-export/src/App.tsx
+++ b/plugins/localization-import-export/src/App.tsx
@@ -60,9 +60,10 @@ export function App() {
             setLocales(initialLocales)
             setDefaultLocale(initialDefaultLocale)
 
-            const firstLocale = initialLocales[0]
-            if (!firstLocale) return
-            setSelectedLocaleId(firstLocale.id)
+            const activeLocale = await framer.unstable_getActiveLocale()
+            if (activeLocale) {
+                setSelectedLocaleId(activeLocale.id)
+            }
         }
 
         loadLocales()


### PR DESCRIPTION
### Description

Updates localization import & export to use the new getActiveLocale API to default the export collection select input to the active locale.

### Testing

- [ ] Add multiple locales
- [ ] Select different locales and confirm that when you open the plugin, the select is defaulted to the active locale