### PR TITLE
Allow Google Sheets modal to be resizable

### DIFF
--- a/plugins/google-sheets/src/App.tsx
+++ b/plugins/google-sheets/src/App.tsx
@@ -87,9 +87,17 @@ export function AuthenticatedApp({ pluginContext, setContext }: AuthenticatedApp
     }, [isUserInfoError, isSelectSheetError, setContext])
 
     useLayoutEffect(() => {
+        const width = sheetTitle !== null ? 360 : 320
+        const height = sheetTitle !== null ? 425 : 345
+
         framer.showUI({
-            width: sheetTitle !== null ? 340 : 320,
-            height: sheetTitle !== null ? 425 : 345,
+            width,
+            height,
+            minWidth: width,
+            minHeight: height,
+            // Only allow resizing when mapping fields as the default size could not be enough.
+            // This will keep the given dimensions in the Select Sheet Screen.
+            resizable: sheetTitle !== null,
         })
     }, [sheetTitle])
 


### PR DESCRIPTION
### Description

See https://github.com/framer/plugins/pull/140.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [ ] Open the plugin in a managed collection
  - [ ] You should be able to resize the window

<!-- Thank you for contributing! -->