### PR TITLE
Merge existing and new fields so that it updates references when needed

### DIFF
--- a/plugins/airtable/src/App.tsx
+++ b/plugins/airtable/src/App.tsx
@@ -1,8 +1,15 @@
 import { framer } from "framer-plugin"
 import { useEffect, useLayoutEffect, useRef, useState } from "react"
-import { getTableIdMapForBase, PluginContext, PluginContextNew, PluginContextUpdate, syncTable } from "./airtable"
+import {
+    createFieldConfig,
+    getTableIdMapForBase,
+    PluginContext,
+    PluginContextNew,
+    PluginContextUpdate,
+    syncTable,
+} from "./airtable"
 import { useBaseSchemaQuery, useSyncTableMutation } from "./api"
-import { assert } from "./utils"
+import { assert, isDefined } from "./utils"
 import { PLUGIN_LOG_SYNC_KEY, logSyncResult } from "./debug"
 import { Authenticate } from "./pages/Authenticate"
 import { MapTableFieldsPage } from "./pages/MapTableFields"
@@ -143,10 +150,26 @@ export function App({ pluginContext }: AppProps) {
         isSyncing.current = true
         framer.hideUI()
 
-        const { baseId, tableId, collectionFields, ignoredFieldIds, slugFieldId, tableSchema, lastSyncedTime } = context
+        const {
+            baseId,
+            tableId,
+            ignoredFieldIds,
+            slugFieldId,
+            tableSchema,
+            tableMapId,
+            lastSyncedTime,
+        } = context
+
+        const fieldConfigs = createFieldConfig(
+            context,
+            tableSchema.primaryFieldId,
+            tableSchema.fields,
+            tableMapId
+        )
+        const fields = fieldConfigs.map(field => field.field).filter(isDefined)
 
         syncTable({
-            fields: collectionFields,
+            fields,
             ignoredFieldIds,
             lastSyncedTime,
             tableSchema,


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request ensures that when syncing (and re/importing) we merge the previous and new field.

Closes https://github.com/framer/company/issues/31462.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [ ] Adding a value in a Single select should update the Framer Option
  - [ ] Create an Airtable base with a Single Select field
  - [ ] Sync it to Framer
  - [ ] Add a new value in the Single select
  - [ ] Add a record that uses the new value
  - [ ] Re-sync it to Framer
  - [ ] It should work

<!-- Thank you for contributing! -->