### PR TITLE
Fix Google Sheet date

### DIFF
--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -56,7 +56,8 @@ const inferFieldType = (cellValue: CellValue): CollectionFieldType => {
 
         // If the cell value contains a newline, it's probably a formatted text field
         if (cellValueLowered.includes("\n")) return "formattedText"
-        if (/^\d{1,2}-\d{1,2}-\d{4}/.test(cellValueLowered)) return "date"
+        const maybeDate = new Date(cellValueLowered)
+        if (!Number.isNaN(maybeDate.getTime())) return "date"
         if (/^#[0-9a-f]{6}$/.test(cellValueLowered)) return "color"
         if (/<[a-z][\s\S]*>/.test(cellValueLowered)) return "formattedText"
 

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -283,7 +283,7 @@ function getFieldValue(fieldType: CollectionFieldType, cellValue: CellValue) {
     switch (fieldType) {
         case "number": {
             const num = Number(cellValue)
-            if (isNaN(num)) {
+            if (Number.isNaN(num)) {
                 return null
             }
 
@@ -294,9 +294,12 @@ function getFieldValue(fieldType: CollectionFieldType, cellValue: CellValue) {
         }
         case "date": {
             if (typeof cellValue !== "string") return null
-            const [month, day, year] = cellValue.split(/[-/]/).map(Number)
-            const date = new Date(Date.UTC(year, month - 1, day, 12, 0, 0, 0))
-            return date.toISOString()
+            try {
+                const date = new Date(Date.parse(cellValue))
+                return date.toISOString()
+            } catch {
+                return null
+            }
         }
         case "enum":
         case "image":

--- a/plugins/google-sheets/src/utils.ts
+++ b/plugins/google-sheets/src/utils.ts
@@ -33,14 +33,6 @@ export function slugify(value: string): string {
     return value.toLowerCase().replace(nonSlugCharactersRegExp, "-").replace(trimSlugRegExp, "")
 }
 
-export function parseToUTCDate(date: string): string | null {
-    const parsedDate = new Date(date)
-    if (!isNaN(parsedDate.getTime())) {
-        return parsedDate.toISOString()
-    }
-    return null
-}
-
 export function isDefined<T>(value: T): value is NonNullable<T> {
     return value !== undefined && value !== null
 }


### PR DESCRIPTION
### Description

This pull request fixes how we import Google Sheets dates. This 

### Testing

On the sheet `With Date` there are some dates (inserted using Google Sheets date tool): https://docs.google.com/spreadsheets/d/1o1RaseNzmT1ug5kYQr-LWrHbCWCglOISJpv8jGdxC28/edit?usp=sharing.

- [ ] It imports date into the CMS
  - [ ] Start the OAuth Worker locally
  - [ ] Start the Plugin locally
  - [ ] Launch the Plugin in Framer
  - [ ] Import the `With Date` sheet from → https://docs.google.com/spreadsheets/d/1o1RaseNzmT1ug5kYQr-LWrHbCWCglOISJpv8jGdxC28/edit?usp=sharing.
  - [ ] All columns with date values should be recognized as Date field
  - [ ] It imports the correct date
