### PR TITLE
Rename to Locale Sync

### DIFF
--- a/plugins/localization-import-export/framer.json
+++ b/plugins/localization-import-export/framer.json
@@ -1,6 +1,6 @@
 {
-    "id": "fc871f",
-    "name": "Locale Import & Export",
+    "id": "fc872a",
+    "name": "Locale Sync",
     "modes": ["localization"],
     "icon": "/icon.svg"
 }


### PR DESCRIPTION
Renames the locale plugin to "Locale Sync" and changes the manifest ID, so that we can reupload it.