### PR TITLE
Use SERIAL_NUMBER for Date parsing

### DIFF
--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -56,8 +56,6 @@ const inferFieldType = (cellValue: CellValue): CollectionFieldType => {
 
         // If the cell value contains a newline, it's probably a formatted text field
         if (cellValueLowered.includes("\n")) return "formattedText"
-        const maybeDate = new Date(cellValueLowered)
-        if (!Number.isNaN(maybeDate.getTime())) return "date"
         if (/^#[0-9a-f]{6}$/.test(cellValueLowered)) return "color"
         if (/<[a-z][\s\S]*>/.test(cellValueLowered)) return "formattedText"
 

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -167,7 +167,7 @@ function fetchSheet(spreadsheetId: string, sheetTitle: string, range?: string) {
         query: {
             range: range ?? sheetTitle,
             valueRenderOption: "UNFORMATTED_VALUE",
-            dateTimeRenderOption: "FORMATTED_STRING",
+            dateTimeRenderOption: "SERIAL_NUMBER",
         },
     })
 }
@@ -279,6 +279,30 @@ export interface SyncMutationOptions {
     lastSyncedTime: string | null
 }
 
+const BASE_DATE_1900 = new Date(Date.UTC(1899, 11, 30))
+const BASE_DATE_1904 = new Date(Date.UTC(1904, 0, 1))
+const MS_PER_DAY = 24 * 60 * 60 * 1000 // hours * minutes * seconds * milliseconds
+
+/**
+ * Extracts a date from a serial number in Lotus 1-2-3 date representation.
+ */
+function extractDateFromSerialNumber(serialNumber: number) {
+    // Use 1900 system by default, but if date is before 1904,
+    // switch to 1904 system
+    let baseDate = BASE_DATE_1900
+    const date1900 = new Date(BASE_DATE_1900.getTime() + serialNumber * MS_PER_DAY)
+
+    if (date1900 < BASE_DATE_1904) {
+        baseDate = BASE_DATE_1904
+    }
+
+    const wholeDays = Math.floor(serialNumber)
+    const fractionalDay = serialNumber - wholeDays
+    const milliseconds = Math.round(fractionalDay * MS_PER_DAY)
+
+    return new Date(baseDate.getTime() + wholeDays * MS_PER_DAY + milliseconds)
+}
+
 function getFieldValue(fieldType: CollectionFieldType, cellValue: CellValue) {
     switch (fieldType) {
         case "number": {
@@ -293,9 +317,9 @@ function getFieldValue(fieldType: CollectionFieldType, cellValue: CellValue) {
             return CELL_BOOLEAN_VALUES.includes(cellValue)
         }
         case "date": {
-            if (typeof cellValue !== "string") return null
+            if (typeof cellValue !== "number") return null
             try {
-                const date = new Date(Date.parse(cellValue))
+                const date = extractDateFromSerialNumber(cellValue)
                 return date.toISOString()
             } catch {
                 return null


### PR DESCRIPTION
Closes https://github.com/framer/company/issues/31732

### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request use the [`SERIAL_NUMBER` date time render option](https://developers.google.com/sheets/api/reference/rest/v4/DateTimeRenderOption) from Google Sheets to get the correct Date value. Before we were relying on the cell formatted value which could be set to a non-standardized (ISO 8601).

Doing so, we lose the ability to auto-detect dates field (we could add it back by doing another call to the API as we were doing before e.g. using `FORMATTED_STRING`)

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] It imports date into the CMS
  - [x] Start the OAuth Worker locally
  - [x] Start the Plugin locally
  - [x] Launch the Plugin in Framer
  - [x] Import the `With Date` sheet from → https://docs.google.com/spreadsheets/d/1o1RaseNzmT1ug5kYQr-LWrHbCWCglOISJpv8jGdxC28/edit?usp=sharing.
  - [x] Set the `Published Date` column type to Date
  - [x] It imports the correct date (the Published Date should match the expected one)


<!-- Thank you for contributing! -->