### PR TITLE
Explicitly set undefined column value to null

### DIFF
--- a/plugins/google-sheets/src/App.tsx
+++ b/plugins/google-sheets/src/App.tsx
@@ -1,6 +1,7 @@
 import { framer } from "framer-plugin"
 import { useEffect, useLayoutEffect, useState } from "react"
 import {
+    CollectionFieldType,
     getPluginContext,
     PluginContext,
     PluginContextUpdate,
@@ -166,6 +167,14 @@ export function App({ pluginContext }: AppProps) {
         } = context
         const [headerRow] = sheet.values
 
+        const colFieldTypes: Record<string, CollectionFieldType> = {}
+
+        // Determine if the field type is already configured, otherwise default to "string"
+        for (const colName of headerRow) {
+            const field = fields.find(field => field?.name === colName)
+            colFieldTypes[colName] = field?.type ?? "string"
+        }
+
         syncSheet({
             ignoredColumns,
             slugColumn,
@@ -174,11 +183,7 @@ export function App({ pluginContext }: AppProps) {
             spreadsheetId,
             sheetTitle,
             fields,
-            // Determine if the field type is already configured, otherwise default to "string"
-            colFieldTypes: headerRow.map(colName => {
-                const field = fields.find(field => field?.name === colName)
-                return field?.type ?? "string"
-            }),
+            colFieldTypes,
         }).then(() => framer.closePlugin())
     }, [context, shouldSyncOnly])
 

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -222,11 +222,17 @@ export function MapSheetFieldsPage({
                 return field
             })
 
+        const colFieldTypes: Record<string, CollectionFieldType> = {}
+
+        for (const field of allFields) {
+            colFieldTypes[field.id] = field.type
+        }
+
         onSubmit({
             fields: allFields,
             spreadsheetId,
             sheetTitle,
-            colFieldTypes: fieldConfig.map(field => field.type ?? "string"),
+            colFieldTypes,
             ignoredColumns: Array.from(disabledColumns),
             slugColumn,
             lastSyncedTime: getLastSyncedTime(pluginContext, slugColumn),

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -392,6 +392,12 @@ function processSheetRow({
         return null
     }
 
+    for (const headerRowName of uniqueHeaderRowNames) {
+        if (!(headerRowName in fieldData)) {
+            fieldData[headerRowName] = null
+        }
+    }
+
     return {
         id: itemId,
         slug: slugValue,


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request ensures that when a field does not have a defined value it's set to null. Allowing to clear it.

### Context

https://framer-team.slack.com/archives/C06L5H5ADK2/p1739362411251979

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [ ] Set values to null when re-syncing a spreadsheet
  - [ ] Import a spreadsheet
  - [ ] Remove any value (not the slug)
  - [ ] Re-sync the spreadsheet
  - [ ] Check that the field value is either unset or set to the default value (in case of a number)

<!-- Thank you for contributing! -->
