### PR TITLE
Fix logic for selecting initial airtable slug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4523,6 +4523,38 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
+        "node_modules/browserslist-to-esbuild": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/browserslist-to-esbuild/-/browserslist-to-esbuild-2.1.1.tgz",
+            "integrity": "sha512-KN+mty6C3e9AN8Z5dI1xeN15ExcRNeISoC3g7V0Kax/MMF9MSoYA2G7lkTTcVUFntiEjkpI0HNgqJC1NjdyNUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "browserslist-to-esbuild": "cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "browserslist": "*"
+            }
+        },
+        "node_modules/browserslist-to-esbuild/node_modules/meow": {
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/buffer-crc32": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
@@ -7723,9 +7755,10 @@
             "link": true
         },
         "node_modules/picocolors": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-            "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -10221,16 +10254,17 @@
             }
         },
         "node_modules/vite-plugin-framer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/vite-plugin-framer/-/vite-plugin-framer-1.0.1.tgz",
-            "integrity": "sha512-hYiinyQwBL8y+xaetNDYpLOjSalL/M/CW99HNmXBepuPSHY0GSJksv2FgAOT+8D6ElGTk0rgVCmq8TnhaOHHfA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/vite-plugin-framer/-/vite-plugin-framer-1.0.4.tgz",
+            "integrity": "sha512-zw6o6xLi1a51tb51KaOfa1WF1kjDhlQvPu/4h76iQUoMC5tswISAQwsGVUlnSORr8xfhGMoTEmU5GM9DayMaPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "picocolors": "^1.0.0"
+                "browserslist-to-esbuild": "^2.1.1",
+                "picocolors": "^1.1.1"
             },
             "peerDependencies": {
-                "vite": "^5.0.0"
+                "vite": ">=5.0.0"
             }
         },
         "node_modules/vite-plugin-mkcert": {
@@ -10538,7 +10572,7 @@
                 "tailwindcss": "^3.4.4",
                 "typescript": "^5.3.3",
                 "vite": "^5",
-                "vite-plugin-framer": "^0"
+                "vite-plugin-framer": "^1"
             }
         },
         "plugins/airtable/node_modules/@typescript-eslint/eslint-plugin": {
@@ -10732,18 +10766,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "plugins/airtable/node_modules/vite-plugin-framer": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/vite-plugin-framer/-/vite-plugin-framer-0.0.10.tgz",
-            "integrity": "sha512-BKWzLPfJZNSZGVfcQyB7oppvsXkipwRX8MwHc0nbHmUUK9sOW/tyYm0O8voJYfKnbqy6ccGp2Qd5c/iv+qgoZw==",
-            "dev": true,
-            "dependencies": {
-                "picocolors": "^1.0.0"
-            },
-            "peerDependencies": {
-                "vite": "^5.0.0"
             }
         },
         "plugins/ascii": {

--- a/plugins/airtable/package.json
+++ b/plugins/airtable/package.json
@@ -34,6 +34,6 @@
         "tailwindcss": "^3.4.4",
         "typescript": "^5.3.3",
         "vite": "^5",
-        "vite-plugin-framer": "^0"
+        "vite-plugin-framer": "^1"
     }
 }


### PR DESCRIPTION
### Description

Fixes the selection of the initial slug field for airtable. Previously it was just using the primary field, which may or may not be a valid slug field, and didn't then match the select.

### Testing

- [x] Copy https://airtable.com/appD9FwLtlJmCHmlh/shrROIklEvIzesb0O to your account
- [x] Run this plugin locally and import it
- [x] Confirm that without changing any field mappings that it will actually use the selected slug field