### PR TITLE
Notion Plugin: Add youtube embed support

### DIFF
--- a/plugins/notion/src/blocksToHTML.ts
+++ b/plugins/notion/src/blocksToHTML.ts
@@ -38,9 +38,7 @@ export function richTextToHTML(texts: RichTextItemResponse[]) {
         .join("")
 }
 
-const YOUTUBE_ID_REGEX =
-    /(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)(?<videoId>[^"&?\/\s]{11})/i
-
+const YOUTUBE_ID_REGEX = /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/))(?<videoId>[^?&]+)/iu
 export function blocksToHtml(blocks: BlockObjectResponse[]) {
     let htmlContent = ""
 


### PR DESCRIPTION
### Description

Notion & Framer both support YouTube embeds. This syncs them to framer.

This pull request …

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Add youtube video as embed to notion
  - [x] Sync framer cms collection
  - [x] Check if youtube embed is rendered correctly


In Notion:
![image](https://github.com/user-attachments/assets/0d92f58d-9265-409c-9c81-ec4ecce47e01)

In Framer:
![image](https://github.com/user-attachments/assets/a2f6686c-cb6e-4ebb-823b-47528d05b039)
