### PR TITLE
Simplify data source options

### DIFF
--- a/starters/cms/src/FieldMapping.tsx
+++ b/starters/cms/src/FieldMapping.tsx
@@ -1,6 +1,6 @@
 import { type EditableManagedCollectionField, framer, type ManagedCollection } from "framer-plugin"
 import { useEffect, useState } from "react"
-import { type DataSource, getDataSources, mergeFieldsWithExistingFields, syncCollection } from "./data"
+import { type DataSource, dataSourceOptions, mergeFieldsWithExistingFields, syncCollection } from "./data"
 
 interface FieldMappingRowProps {
     field: EditableManagedCollectionField
@@ -75,11 +75,7 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
     const [fields, setFields] = useState(initialManagedCollectionFields)
     const [ignoredFieldIds, setIgnoredFieldIds] = useState(initialFieldIds)
 
-    const [dataSourceName] = useState(
-        () =>
-            getDataSources().find(dataSourceIdentifier => dataSourceIdentifier.id === dataSource.id)?.name ||
-            dataSource.id
-    )
+    const dataSourceName = dataSourceOptions.find(option => option.id === dataSource.id)?.name ?? dataSource.id
 
     useEffect(() => {
         const abortController = new AbortController()

--- a/starters/cms/src/SelectDataSource.tsx
+++ b/starters/cms/src/SelectDataSource.tsx
@@ -1,14 +1,13 @@
 import { framer } from "framer-plugin"
 import { useState } from "react"
-import { type DataSource, getDataSource, getDataSources } from "./data"
+import { type DataSource, getDataSource, dataSourceOptions } from "./data"
 
 interface SelectDataSourceProps {
     onSelectDataSource: (dataSource: DataSource) => void
 }
 
 export function SelectDataSource({ onSelectDataSource }: SelectDataSourceProps) {
-    const [dataSources] = useState(() => getDataSources())
-    const [selectedDataSourceId, setSelectedDataSourceId] = useState<string>(dataSources[0]?.id ?? "")
+    const [selectedDataSourceId, setSelectedDataSourceId] = useState<string>(dataSourceOptions[0].id)
     const [isLoading, setIsLoading] = useState(false)
 
     const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -56,7 +55,7 @@ export function SelectDataSource({ onSelectDataSource }: SelectDataSourceProps) 
                         <option value="" disabled>
                             Choose Source…
                         </option>
-                        {dataSources.map(({ id, name }) => (
+                        {dataSourceOptions.map(({ id, name }) => (
                             <option key={id} value={id}>
                                 {name}
                             </option>

--- a/starters/cms/src/data.ts
+++ b/starters/cms/src/data.ts
@@ -17,12 +17,10 @@ export interface DataSource {
     items: FieldDataInput[]
 }
 
-export function getDataSources() {
-    return [
-        { id: "articles", name: "Articles" },
-        { id: "categories", name: "Categories" },
-    ]
-}
+export const dataSourceOptions = [
+    { id: "articles", name: "Articles" },
+    { id: "categories", name: "Categories" },
+] as const
 
 /**
  * Retrieve data and process it into a structured format.


### PR DESCRIPTION
### Description

No need in `useState`.

### Testing

- [ ] Data source selection still works.
- [ ] Field-mapping still works.