### PR TITLE
Use the collection slug field name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12018,7 +12018,7 @@
         "plugins/cms-export": {
             "version": "0.0.0",
             "dependencies": {
-                "framer-plugin": "^2.0.4",
+                "framer-plugin": "^3.0.0",
                 "react": "^18",
                 "react-dom": "^18",
                 "vite-plugin-mkcert": "^1"
@@ -12034,7 +12034,7 @@
                 "eslint-plugin-react-refresh": "^0",
                 "typescript": "^5.3.3",
                 "vite": "^6",
-                "vite-plugin-framer": "^1.0.1"
+                "vite-plugin-framer": "^1.0.6"
             }
         },
         "plugins/cms-export/node_modules/@typescript-eslint/eslint-plugin": {
@@ -12212,6 +12212,15 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "plugins/cms-export/node_modules/framer-plugin": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-3.0.0.tgz",
+            "integrity": "sha512-JRHSSa/uf+LTPRfk1CQfzpU2Al0/gW5OP5CTlpotHUqyak3gGyjmVw9tmr9xE1tLXqPpkHl4mN5QEHwHPNzp4g==",
+            "peerDependencies": {
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
             }
         },
         "plugins/color-extract": {

--- a/plugins/cms-export/package.json
+++ b/plugins/cms-export/package.json
@@ -11,7 +11,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "framer-plugin": "^2.0.4",
+        "framer-plugin": "^3.0.0",
         "react": "^18",
         "react-dom": "^18",
         "vite-plugin-mkcert": "^1"
@@ -27,6 +27,6 @@
         "eslint-plugin-react-refresh": "^0",
         "typescript": "^5.3.3",
         "vite": "^6",
-        "vite-plugin-framer": "^1.0.1"
+        "vite-plugin-framer": "^1.0.6"
     }
 }

--- a/plugins/cms-export/src/App.tsx
+++ b/plugins/cms-export/src/App.tsx
@@ -57,10 +57,7 @@ export function App() {
     }
 
     const selectCollection = (event: ChangeEvent<HTMLSelectElement>) => {
-        const index = event.currentTarget.selectedIndex
-        if (index === -1) return
-
-        const collection = collections[index - 1]
+        const collection = collections.find(collection => collection.id === event.currentTarget.value)
         if (!collection) return
 
         setSelectedCollection(collection)
@@ -85,13 +82,14 @@ export function App() {
                 <select
                     onChange={selectCollection}
                     className={!selectedCollection ? "footer-select footer-select--unselected" : "footer-select"}
+                    value={selectedCollection?.id ?? ""}
                 >
-                    <option selected disabled>
+                    <option value="" disabled>
                         Select Collection…
                     </option>
 
                     {collections.map(collection => (
-                        <option key={collection.id} selected={collection.id === selectedCollection?.id}>
+                        <option key={collection.id} value={collection.id}>
                             {collection.name}
                         </option>
                     ))}

--- a/plugins/cms-export/src/PreviewTable.css
+++ b/plugins/cms-export/src/PreviewTable.css
@@ -1,4 +1,3 @@
-
 .preview-table {
   background: color-mix(in srgb, transparent, var(--framer-color-bg-tertiary) 10%);
   border-radius: 8px;
@@ -11,7 +10,7 @@
   border-radius: 8px;
   width: 100%;
   height: 100%;
-  overflow: hidden;
+  overflow: auto;
   position: absolute;
 }
 

--- a/plugins/cms-export/src/PreviewTable.tsx
+++ b/plugins/cms-export/src/PreviewTable.tsx
@@ -35,7 +35,7 @@ export function PreviewTable({ collection }: Props) {
                 previewItems.push(items[index])
             }
 
-            setPreviewCSV(getDataForCSV(fields, previewItems))
+            setPreviewCSV(getDataForCSV(collection.slugFieldName, fields, previewItems))
         }
 
         const resize = () => {
@@ -77,7 +77,9 @@ export function PreviewTable({ collection }: Props) {
                             return (
                                 <tr key={`${rowIndex}`}>
                                     {row.map((cell, columnIndex) => (
-                                        <td key={`${rowIndex}-${columnIndex}`}>{cell}</td>
+                                        <td key={`${rowIndex}-${columnIndex}`} title={cell}>
+                                            {cell}
+                                        </td>
                                     ))}
                                 </tr>
                             )


### PR DESCRIPTION
Closes https://github.com/framer/company/issues/32023

### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request ensure we export the collection slug field name (when available) instead of `Slug`.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- Add a sample Blog CMS
- Change the name of the Slug field
- Export the Collection
- [x] Ensure that the first field has the correct name

<!-- Thank you for contributing! -->