### PR TITLE
Airtable fixes

### DIFF
--- a/plugins/airtable/src/FieldMapping.tsx
+++ b/plugins/airtable/src/FieldMapping.tsx
@@ -1,4 +1,4 @@
-import type { ManagedCollection, EditableManagedCollectionField, Field,  } from "framer-plugin"
+import type { ManagedCollection, EditableManagedCollectionField, Field } from "framer-plugin"
 import type { DataSource, PossibleField } from "./data"
 
 import { framer } from "framer-plugin"
@@ -199,6 +199,8 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
                         } as PossibleField
                     case "image":
                         return { ...field, type: "image" } as PossibleField
+                    case "string":
+                        return { ...field, type: "string" } as PossibleField
                     default:
                         return field
                 }

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -137,13 +137,21 @@ export async function inferFields(collection: ManagedCollection, table: Airtable
                 break
 
             case "singleLineText":
+                fields.push({
+                    ...fieldMetadata,
+                    airtableType: fieldSchema.type,
+                    type: "string",
+                    allowedTypes: ["string"],
+                })
+                break
+
             case "email":
             case "phoneNumber":
                 fields.push({
                     ...fieldMetadata,
                     airtableType: fieldSchema.type,
                     type: "string",
-                    allowedTypes: ["string"],
+                    allowedTypes: ["string", "link"],
                 })
                 break
 
@@ -301,6 +309,19 @@ function getFieldDataEntryForFieldSchema(fieldSchema: PossibleField, value: unkn
         case "image":
         case "file":
             if (typeof value === "string") {
+                if (fieldSchema.airtableType === "email") {
+                    return {
+                        value: `mailto:${value}`,
+                        type: "link",
+                    }
+                }
+                if (fieldSchema.airtableType === "phoneNumber") {
+                    return {
+                        value: `tel:${value}`,
+                        type: "link",
+                    }
+                }
+
                 return {
                     value,
                     type: "string",

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -324,7 +324,7 @@ function getFieldDataEntryForFieldSchema(fieldSchema: PossibleField, value: unkn
 
                 return {
                     value,
-                    type: "string",
+                    type: fieldSchema.type,
                 }
             }
 

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -459,10 +459,18 @@ export async function getItems(dataSource: DataSource, slugFieldId: string) {
                 switch (field.type) {
                     case "string":
                     case "formattedText":
-                    case "enum":
                         fieldData[field.id] = {
                             value: "",
                             type: field.type,
+                        }
+                        break
+                    case "enum":
+                        console.warn(
+                            `Missing value for field “${field.name}” on item “${item.id}”, it will be set to the first case.`
+                        )
+                        fieldData[field.id] = {
+                            value: field.cases[0].id,
+                            type: "enum",
                         }
                         break
                     case "boolean":


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request brings the following fixes:
- Allowing to import `email` and `tel` as Link (before we could only import them as String)
- Framer do not support empty value for enums, so instead of crashing, we set them to the first value
- When changing the type of an URL it sets the correct field type instead of always String

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

Start the Plugin locally or use the pending version from the Marketplace

- Select `FRAMER TEST TABLE`
- Set the Email and Phone fields to Link
- Set the URL field to Image
- [x] Importing should work

<!-- Thank you for contributing! -->