### PR TITLE
Support permissions in CMS Starter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15209,7 +15209,7 @@
             "name": "cms-starter",
             "version": "0.0.0",
             "dependencies": {
-                "framer-plugin": "^3.3.0",
+                "framer-plugin": "^3.3.1",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1"
             },
@@ -15424,9 +15424,9 @@
             }
         },
         "starters/cms/node_modules/framer-plugin": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-3.3.0.tgz",
-            "integrity": "sha512-8zrW63Oml0tUFNHoKjA55OJg2YyXCyeL9D5Y8lSZ334A45kOJOwdRJK731iGdtW/7PjctLRYa5IP/XQ3iGHEYw==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-3.3.1.tgz",
+            "integrity": "sha512-uIPLoGS/0wQqhl2dnnsNLs/b4h/vLI1Tvu8FeUt3VBhNwUSu1FO8SsSsQyncq9L2EsbiBP3Mnz7lK9jB/b2DYg==",
             "peerDependencies": {
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"

--- a/starters/cms/package.json
+++ b/starters/cms/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc"
     },
     "dependencies": {
-        "framer-plugin": "^3.3.0",
+        "framer-plugin": "^3.3.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
     },


### PR DESCRIPTION
### Description

**Warning:** To be merged when permissions are out of beta!

- In sync mode: Exits on success. Shows UI on failure or if missing permissions.
- In management mode: Shows UI regardless.
- Disables the UI if missing permissions, puts an explanation `title` on the import button.

Fixes: https://github.com/framer/company/issues/32805

### Testing

- [x] Steps:

1. Follow the account setup steps from this PR: https://github.com/framer/FramerStudio/pull/21714
2. Try relevant permutations of permissions in both plugin modes (including while open).