### PR TITLE
Update framer-plugin version of Locale Sync and CMS Starter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11559,9 +11559,9 @@
             }
         },
         "node_modules/vite-plugin-framer": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/vite-plugin-framer/-/vite-plugin-framer-1.0.6.tgz",
-            "integrity": "sha512-Y6lI/TPdvJ4fBBgq5O/9s3VpIHIO+9fAUl3K/GdGUm3og8Xgrm0xQfLSIeieI7PYSLuQM/fH5WJ2KDfHCI6Z4Q==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/vite-plugin-framer/-/vite-plugin-framer-1.0.7.tgz",
+            "integrity": "sha512-aUf7p6mbGOR1DlTfejSrT4yKmSmg0yr3IIAFi/V9SwWJSDI5GmVQUVStUQORFo+q9yxtfZh7kVKS4NdslxHnSQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13610,7 +13610,7 @@
         "plugins/locale-sync": {
             "version": "0.0.0",
             "dependencies": {
-                "framer-plugin": "^3.1.0-beta.1",
+                "framer-plugin": "^3.1.0",
                 "react": "^18",
                 "react-dom": "^18",
                 "vite-plugin-mkcert": "^1"
@@ -13628,7 +13628,7 @@
                 "typescript": "^5.3",
                 "typescript-eslint": "^8.0.1",
                 "vite": "^6",
-                "vite-plugin-framer": "^1"
+                "vite-plugin-framer": "^1.0.7"
             }
         },
         "plugins/locale-sync/node_modules/@eslint/eslintrc": {
@@ -13839,9 +13839,9 @@
             }
         },
         "plugins/locale-sync/node_modules/framer-plugin": {
-            "version": "3.1.0-beta.1",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-3.1.0-beta.1.tgz",
-            "integrity": "sha512-LWQPYb5PNkrzn79tTNXYTTWlocuGDVzpcJnMEyE328HeM0ukEGLkoZtoJYNwgEutDR5uSV9AeodrMfIAoM9ZXA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-3.1.0.tgz",
+            "integrity": "sha512-7nIsoj3pBGcT6kJuqeCTNq85Y2qM7qsINFRgXwcVepw68QKqEs8inIEOLO4utxUb2VjRV0zizPzFeYZus2bl/A==",
             "peerDependencies": {
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"
@@ -14899,7 +14899,7 @@
             "name": "cms-starter",
             "version": "0.0.0",
             "dependencies": {
-                "framer-plugin": "^3.0.0",
+                "framer-plugin": "^3.1.0",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1"
             },
@@ -14919,7 +14919,7 @@
                 "typescript": "^5.7.3",
                 "typescript-eslint": "^8.25.0",
                 "vite": "^6.2.6",
-                "vite-plugin-framer": "^1.0.6",
+                "vite-plugin-framer": "^1.0.7",
                 "vite-plugin-mkcert": "^1.17.7"
             }
         },
@@ -15114,9 +15114,9 @@
             }
         },
         "starters/cms/node_modules/framer-plugin": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-3.0.0.tgz",
-            "integrity": "sha512-JRHSSa/uf+LTPRfk1CQfzpU2Al0/gW5OP5CTlpotHUqyak3gGyjmVw9tmr9xE1tLXqPpkHl4mN5QEHwHPNzp4g==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-3.1.0.tgz",
+            "integrity": "sha512-7nIsoj3pBGcT6kJuqeCTNq85Y2qM7qsINFRgXwcVepw68QKqEs8inIEOLO4utxUb2VjRV0zizPzFeYZus2bl/A==",
             "peerDependencies": {
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"

--- a/plugins/locale-sync/package.json
+++ b/plugins/locale-sync/package.json
@@ -11,7 +11,7 @@
         "pack": "npx framer-plugin-tools@latest pack"
     },
     "dependencies": {
-        "framer-plugin": "^3.1.0-beta.1",
+        "framer-plugin": "^3.1.0",
         "react": "^18",
         "react-dom": "^18",
         "vite-plugin-mkcert": "^1"
@@ -29,6 +29,6 @@
         "typescript": "^5.3",
         "typescript-eslint": "^8.0.1",
         "vite": "^6",
-        "vite-plugin-framer": "^1"
+        "vite-plugin-framer": "^1.0.7"
     }
 }

--- a/starters/cms/package.json
+++ b/starters/cms/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc"
     },
     "dependencies": {
-        "framer-plugin": "^3.0.0",
+        "framer-plugin": "^3.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
     },
@@ -34,7 +34,7 @@
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.25.0",
         "vite": "^6.2.6",
-        "vite-plugin-framer": "^1.0.6",
+        "vite-plugin-framer": "^1.0.7",
         "vite-plugin-mkcert": "^1.17.7"
     }
 }


### PR DESCRIPTION
### Description

Updates Locale Sync and CMS Starter to use 3.1.0.

### Testing

- Just manually run the below from this branch
- [x] Locale Sync can export and import locale
- [x] CMS Starter still works as expected 