### PR TITLE
Convert Notion plugin to use CMS Starter

### DIFF
--- a/plugins/notion/src/App.tsx
+++ b/plugins/notion/src/App.tsx
@@ -23,8 +23,8 @@ export function AuthenticatedApp({ context }: AuthenticatedAppProps) {
     )
 
     useEffect(() => {
-        const width = databaseConfig ? 360 : 325
-        const height = databaseConfig ? 425 : 370
+        const width = databaseConfig ? 600 : 325
+        const height = databaseConfig ? 500 : 370
         framer.showUI({
             width,
             height,


### PR DESCRIPTION
Changes:

* Convert the Notion plugin to use the [CMS Starter](https://www.framer.com/updates/cms-starter-plugin) for shared UI and logic code.
* Update `framer-plugin` to 3.1.0
* Increase default plugin size to 600 x 500 to prevent text getting cut off.

Another PR: https://github.com/framer/plugins/pull/220 includes over 20 improvements, new field types, and bug fixes to the Notion plugin. @triozer suggested that Notion be switched to use the CMS starter first before merging that PR.