### PR TITLE
Use framer-plugin@3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14193,7 +14193,7 @@
         "plugins/redirect-sync": {
             "version": "0.0.0",
             "dependencies": {
-                "framer-plugin": "^3.2.0-alpha.0",
+                "framer-plugin": "^3.2.0",
                 "papaparse": "^5.5.2",
                 "react": "^18",
                 "react-dom": "^18",
@@ -14434,9 +14434,9 @@
             }
         },
         "plugins/redirect-sync/node_modules/framer-plugin": {
-            "version": "3.2.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-3.2.0-alpha.0.tgz",
-            "integrity": "sha512-QbXB6bZ3eRyfUowh6ULhWm9R044gElZ7ITOD3zWtU+k/YjAKadXVimbQmGG+3BQKWyDdmazv7vLxY++BT3jLEw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-3.2.0.tgz",
+            "integrity": "sha512-KPFjygdYlI3fEqIIR1yElK8XSVe75XxIlWYXOSlYc0oHKI430yANqfmrLHlpdgEyjaf/nJqmjnget4YOvtgvfA==",
             "peerDependencies": {
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"

--- a/plugins/redirect-sync/package.json
+++ b/plugins/redirect-sync/package.json
@@ -11,7 +11,7 @@
         "pack": "npx framer-plugin-tools@latest pack"
     },
     "dependencies": {
-        "framer-plugin": "^3.2.0-alpha.0",
+        "framer-plugin": "^3.2.0",
         "papaparse": "^5.5.2",
         "react": "^18",
         "react-dom": "^18",

--- a/plugins/redirect-sync/src/App.tsx
+++ b/plugins/redirect-sync/src/App.tsx
@@ -24,7 +24,7 @@ async function importCsv() {
             const totalMissingRedirects = parsedRedirects.length - nonMissingRedirects.length
 
             const redirectInputs = await normalizeRedirectInputs(nonMissingRedirects)
-            await framer.alpha_addRedirects(redirectInputs)
+            await framer.addRedirects(redirectInputs)
 
             framer.notify(
                 `Successfully imported ${redirectInputs.length} redirect${redirectInputs.length !== 1 ? "s" : ""}${
@@ -47,7 +47,7 @@ async function exportCsv() {
     const filename = "redirects.csv"
 
     try {
-        const redirects = await framer.alpha_getRedirects()
+        const redirects = await framer.getRedirects()
         const csv = generateCsv(redirects)
         downloadBlob(csv, filename, "text/csv")
 

--- a/plugins/redirect-sync/src/csv.ts
+++ b/plugins/redirect-sync/src/csv.ts
@@ -35,7 +35,7 @@ export function countAndRemoveMissingRedirects(redirects: ParsedRedirects[]): Pa
 }
 
 export async function normalizeRedirectInputs(redirects: ParsedRedirects[]): Promise<RedirectInput[]> {
-    const existingRedirects = await framer.alpha_getRedirects()
+    const existingRedirects = await framer.getRedirects()
     const existingRedirectsByFrom = new Map<string, Redirect>()
 
     for (const redirect of existingRedirects) {


### PR DESCRIPTION
### Description

This pull request updates the redirect-sync plugin to use the stable version of the framer-plugin API instead of alpha versions. It upgrades the framer-plugin dependency from `^3.2.0-alpha.0` to `^3.2.0` in package.json and package-lock.json, and replaces alpha method calls with their stable counterparts:
- `framer.alpha_addRedirects` → `framer.addRedirects`
- `framer.alpha_getRedirects` → `framer.getRedirects`

### QA

- [x] Verify CSV import functionality
  - Open the redirect-sync plugin
  - Import a CSV file with redirects
  - Confirm redirects are successfully added to the project
  - Verify appropriate success notification appears
- [x] Verify CSV export functionality
  - Open the redirect-sync plugin
  - Export redirects to CSV
  - Confirm the downloaded file contains all expected redirects
  - Verify appropriate success notification appears