### PR TITLE
Update framer-plugin dependency to version 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15209,7 +15209,7 @@
             "name": "cms-starter",
             "version": "0.0.0",
             "dependencies": {
-                "framer-plugin": "^3.1.0",
+                "framer-plugin": "^3.3.0-beta.1",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1"
             },
@@ -15424,9 +15424,9 @@
             }
         },
         "starters/cms/node_modules/framer-plugin": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-3.1.0.tgz",
-            "integrity": "sha512-7nIsoj3pBGcT6kJuqeCTNq85Y2qM7qsINFRgXwcVepw68QKqEs8inIEOLO4utxUb2VjRV0zizPzFeYZus2bl/A==",
+            "version": "3.3.0-beta.1",
+            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-3.3.0-beta.1.tgz",
+            "integrity": "sha512-4+LbLG2CnCWjuPUJG9dgUkd74QE+AWfCpUv5AHMFbc03pAduoi4tZ8kt7l6QeHpeqLvtOypBr0LsrSNVBZdmyw==",
             "peerDependencies": {
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"

--- a/starters/cms/package.json
+++ b/starters/cms/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc"
     },
     "dependencies": {
-        "framer-plugin": "^3.1.0",
+        "framer-plugin": "^3.3.0-beta.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
     },

--- a/starters/cms/src/FieldMapping.tsx
+++ b/starters/cms/src/FieldMapping.tsx
@@ -1,9 +1,9 @@
-import { type EditableManagedCollectionField, framer, type ManagedCollection } from "framer-plugin"
+import { type ManagedCollectionFieldSetInput, framer, type ManagedCollection } from "framer-plugin"
 import { useEffect, useState } from "react"
 import { type DataSource, dataSourceOptions, mergeFieldsWithExistingFields, syncCollection } from "./data"
 
 interface FieldMappingRowProps {
-    field: EditableManagedCollectionField
+    field: ManagedCollectionFieldSetInput
     originalFieldName: string | undefined
     disabled: boolean
     onToggleDisabled: (fieldId: string) => void
@@ -50,7 +50,7 @@ function FieldMappingRow({ field, originalFieldName, disabled, onToggleDisabled,
     )
 }
 
-const initialManagedCollectionFields: EditableManagedCollectionField[] = []
+const initialManagedCollectionFields: ManagedCollectionFieldSetInput[] = []
 const initialFieldIds: ReadonlySet<string> = new Set()
 
 interface FieldMappingProps {
@@ -68,7 +68,7 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
 
     const [possibleSlugFields] = useState(() => dataSource.fields.filter(field => field.type === "string"))
 
-    const [selectedSlugField, setSelectedSlugField] = useState<EditableManagedCollectionField | null>(
+    const [selectedSlugField, setSelectedSlugField] = useState<ManagedCollectionFieldSetInput | null>(
         possibleSlugFields.find(field => field.id === initialSlugFieldId) ?? possibleSlugFields[0] ?? null
     )
 

--- a/starters/cms/src/data.ts
+++ b/starters/cms/src/data.ts
@@ -1,5 +1,5 @@
 import {
-    type EditableManagedCollectionField,
+    type ManagedCollectionFieldSetInput,
     type FieldDataInput,
     framer,
     type ManagedCollection,
@@ -13,7 +13,7 @@ export const PLUGIN_KEYS = {
 
 export interface DataSource {
     id: string
-    fields: readonly EditableManagedCollectionField[]
+    fields: readonly ManagedCollectionFieldSetInput[]
     items: FieldDataInput[]
 }
 
@@ -44,7 +44,7 @@ export async function getDataSource(dataSourceId: string, abortSignal?: AbortSig
     const dataSource = await dataSourceResponse.json()
 
     // Map your source fields to supported field types in Framer
-    const fields: EditableManagedCollectionField[] = []
+    const fields: ManagedCollectionFieldSetInput[] = []
     for (const field of dataSource.fields) {
         switch (field.type) {
             case "string":
@@ -83,9 +83,9 @@ export async function getDataSource(dataSourceId: string, abortSignal?: AbortSig
 }
 
 export function mergeFieldsWithExistingFields(
-    sourceFields: readonly EditableManagedCollectionField[],
-    existingFields: readonly EditableManagedCollectionField[]
-): EditableManagedCollectionField[] {
+    sourceFields: readonly ManagedCollectionFieldSetInput[],
+    existingFields: readonly ManagedCollectionFieldSetInput[]
+): ManagedCollectionFieldSetInput[] {
     return sourceFields.map(sourceField => {
         const existingField = existingFields.find(existingField => existingField.id === sourceField.id)
         if (existingField) {
@@ -98,8 +98,8 @@ export function mergeFieldsWithExistingFields(
 export async function syncCollection(
     collection: ManagedCollection,
     dataSource: DataSource,
-    fields: readonly EditableManagedCollectionField[],
-    slugField: EditableManagedCollectionField
+    fields: readonly ManagedCollectionFieldSetInput[],
+    slugField: ManagedCollectionFieldSetInput
 ) {
     const sanitizedFields = fields.map(field => ({
         ...field,


### PR DESCRIPTION
### Description

#### `cms-starter`

This pull request updates the `framer-plugin` dependency to its latest version and replace the deprecated `EditableManagedCollectionField` type with `ManagedCollectionFieldSetInput`.

This fixes the type error currently present when creating a new 

- [ ] Update to stable release `framer-plugin@3.3.0`
    ℹ️ Is currently using the published `beta.1` version, update once published

### Testing

#### `cms-starter`

- [ ] creating a new project doesn't have type errors out of the box