### PR TITLE
Update framer-plugin to 3.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19297,7 +19297,7 @@
         "plugins/tidyup": {
             "version": "0.0.0",
             "dependencies": {
-                "framer-plugin": "^3.3.0-beta.1",
+                "framer-plugin": "^3.3.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "vite-plugin-mkcert": "^1"
@@ -19686,7 +19686,9 @@
             }
         },
         "plugins/tidyup/node_modules/framer-plugin": {
-            "version": "3.3.0-beta.1",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-3.3.2.tgz",
+            "integrity": "sha512-ZKFpbOUUdfne7aMP0wpRRvJzd4WQc6w5wZDM0sAZPnAE4a/MKnay9bsj14mJRUwlEoM6sk77KTfQyDNQ+770WQ==",
             "peerDependencies": {
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"

--- a/plugins/tidyup/package.json
+++ b/plugins/tidyup/package.json
@@ -12,7 +12,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "framer-plugin": "^3.3.0-beta.1",
+        "framer-plugin": "^3.3.2",
         "react": "^18",
         "react-dom": "^18",
         "vite-plugin-mkcert": "^1"


### PR DESCRIPTION
### Description

This pull request updates the framer-plugin dependency from version 3.3.0-beta.1 to 3.3.2 in the tidyup plugin. The update includes both package.json and package-lock.json changes to reflect the new stable version.

### Testing

- [x] Verify the tidyup plugin works correctly with the updated framer-plugin version
  - [x] Install dependencies with `npm install`
  - [x] Run the plugin locally
  - [x] Confirm all existing functionality works as expected