### PR TITLE
Replace framer.isAllowedTo with useIsAllowedTo

### DIFF
--- a/plugins/csv-import/src/App.tsx
+++ b/plugins/csv-import/src/App.tsx
@@ -2,7 +2,7 @@ import type { Collection } from "framer-plugin"
 import type { ImportResult, ImportResultItem } from "./csv"
 
 import "./App.css"
-import { framer } from "framer-plugin"
+import { framer, useIsAllowedTo } from "framer-plugin"
 import { ChangeEvent, useEffect, useMemo, useRef, useState, useCallback } from "react"
 import { processRecords, parseCSV, importCSV, ImportError } from "./csv"
 
@@ -119,7 +119,7 @@ function ManageConflicts({ records, onAllConflictsResolved }: ManageConflictsPro
 }
 
 export function App({ collection }: { collection: Collection }) {
-    const isAllowedToAddItems = framer.isAllowedTo("Collection.addItems")
+    const isAllowedToAddItems = useIsAllowedTo("Collection.addItems")
 
     const form = useRef<HTMLFormElement>(null)
     const inputOpenedFromImportButton = useRef(false)


### PR DESCRIPTION
### Description

This pull request replaces the direct usage of `framer.isAllowedTo` with the React hook `useIsAllowedTo` in the CSV Import plugin. This change follows best practices for permission checking in React components.

### Testing

- [x] Test permission handling
  - [x] Test with a user who has permission to add items
  - [x] Test with a user who doesn't have permission to add items
  - [x] Verify appropriate UI is shown in both cases