### PR TITLE
Check permissions in Airtable plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11660,7 +11660,7 @@
         "plugins/airtable": {
             "version": "0.0.0",
             "dependencies": {
-                "framer-plugin": "^3.0.0",
+                "framer-plugin": "^3.3.2",
                 "react": "^18",
                 "react-dom": "^18",
                 "vite-plugin-mkcert": "^1"
@@ -11693,7 +11693,9 @@
             }
         },
         "plugins/airtable/node_modules/framer-plugin": {
-            "version": "3.0.0",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-3.3.2.tgz",
+            "integrity": "sha512-ZKFpbOUUdfne7aMP0wpRRvJzd4WQc6w5wZDM0sAZPnAE4a/MKnay9bsj14mJRUwlEoM6sk77KTfQyDNQ+770WQ==",
             "peerDependencies": {
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"

--- a/plugins/airtable/package.json
+++ b/plugins/airtable/package.json
@@ -12,7 +12,7 @@
         "typecheck": "tsc"
     },
     "dependencies": {
-        "framer-plugin": "^3.0.0",
+        "framer-plugin": "^3.3.2",
         "react": "^18",
         "react-dom": "^18",
         "vite-plugin-mkcert": "^1"

--- a/plugins/airtable/src/FieldMapping.tsx
+++ b/plugins/airtable/src/FieldMapping.tsx
@@ -1,4 +1,4 @@
-import type { ManagedCollection, EditableManagedCollectionField, Field } from "framer-plugin"
+import type { ManagedCollection, ManagedCollectionFieldInput, Field } from "framer-plugin"
 import type { DataSource } from "./data"
 import type { PossibleField } from "./fields"
 
@@ -10,6 +10,7 @@ import { ALLOWED_FILE_TYPES, isCollectionReference } from "./utils"
 function ChevronIcon() {
     return (
         <svg xmlns="http://www.w3.org/2000/svg" width="8" height="16">
+            <title>Chevron</title>
             <path
                 d="M 3 11 L 6 8 L 3 5"
                 fill="transparent"
@@ -131,7 +132,7 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
 
     const [possibleSlugFields] = useState(() => dataSource.fields.filter(field => field.type === "string"))
 
-    const [selectedSlugField, setSelectedSlugField] = useState<EditableManagedCollectionField | null>(
+    const [selectedSlugField, setSelectedSlugField] = useState<ManagedCollectionFieldInput | null>(
         possibleSlugFields.find(field => field.id === initialSlugFieldId) ?? possibleSlugFields[0] ?? null
     )
 
@@ -337,7 +338,7 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
 
             <footer>
                 <hr className="sticky-top" />
-                <button disabled={isSyncing} tabIndex={0}>
+                <button type="submit" disabled={isSyncing} tabIndex={0}>
                     {isSyncing ? (
                         <div className="framer-spinner" />
                     ) : (

--- a/plugins/airtable/src/Login.tsx
+++ b/plugins/airtable/src/Login.tsx
@@ -23,17 +23,14 @@ export function Authenticate({ onAuthenticated }: AuthenticationProps) {
             clearInterval(pollInterval.current)
         }
 
-        return new Promise(
-            resolve =>
-                (pollInterval.current = setInterval(
-                    () =>
-                        auth.fetchTokens(readKey).then(tokens => {
-                            clearInterval(pollInterval.current)
-                            resolve(tokens)
-                        }),
-                    2500
-                ))
-        )
+        return new Promise(resolve => {
+            pollInterval.current = setInterval(() => {
+                auth.fetchTokens(readKey).then(tokens => {
+                    clearInterval(pollInterval.current)
+                    resolve(tokens)
+                })
+            }, 2500)
+        })
     }
 
     const login = async (event: React.FormEvent<HTMLFormElement>) => {

--- a/plugins/airtable/src/NoAccess.tsx
+++ b/plugins/airtable/src/NoAccess.tsx
@@ -46,13 +46,16 @@ export function NoTableAccess({
         <form onSubmit={handleRetryClick}>
             <p>
                 Your Airtable account does not have access to the synced table. Retry or{" "}
+                {/* biome-ignore lint/a11y/useValidAnchor: Too much effort, as default <button> is too button-like */}
                 <a href="#" style={{ color: "#27B5F8" }} onClick={handleLogout}>
                     log out
                 </a>{" "}
                 of the Airtable Plugin.
             </p>
             <div className="actions">
-                <button className="action-button">{isRetrying ? <div className="framer-spinner" /> : "Retry"}</button>
+                <button type="submit" className="action-button">
+                    {isRetrying ? <div className="framer-spinner" /> : "Retry"}
+                </button>
                 <button
                     type="button"
                     className="action-button"

--- a/plugins/airtable/src/SelectDataSource.tsx
+++ b/plugins/airtable/src/SelectDataSource.tsx
@@ -1,6 +1,6 @@
 import type { AirtableBase, AirtableTable, DataSource } from "./data"
 
-import { framer, ManagedCollection } from "framer-plugin"
+import { framer, type ManagedCollection } from "framer-plugin"
 import { useEffect, useState } from "react"
 import { getTables, getUserBases } from "./data"
 import { inferFields } from "./fields"
@@ -71,9 +71,7 @@ export function SelectDataSource({ collection, onSelectDataSource }: SelectDataS
             })
         } catch (error) {
             console.error(error)
-            framer.notify(`Failed to load data source. Check the logs for more details.`, {
-                variant: "error",
-            })
+            framer.notify("Failed to load data source. Check the logs for more details.", { variant: "error" })
         } finally {
             setIsLoading(false)
         }
@@ -123,7 +121,7 @@ export function SelectDataSource({ collection, onSelectDataSource }: SelectDataS
                 </select>
             </label>
 
-            <button disabled={!selectedBaseId || !selectedTableId || isLoading}>
+            <button type="submit" disabled={!selectedBaseId || !selectedTableId || isLoading}>
                 {isLoading ? <div className="framer-spinner" /> : "Next"}
             </button>
         </form>

--- a/plugins/airtable/src/api.ts
+++ b/plugins/airtable/src/api.ts
@@ -369,7 +369,7 @@ const MAX_RETRY_ATTEMPTS = 10
 
 // Exponential backoff with "Full Jitter" algorithm
 const calculateBackoffDelay = (numAttempts: number): number => {
-    const rawBackoffTime = INITIAL_RETRY_DELAY * Math.pow(2, numAttempts)
+    const rawBackoffTime = INITIAL_RETRY_DELAY * 2 ** numAttempts
     const clippedBackoffTime = Math.min(MAX_RETRY_DELAY, rawBackoffTime)
     return Math.random() * clippedBackoffTime
 }
@@ -387,7 +387,9 @@ const request = async ({ path, method, query, body, signal }: RequestOptions, nu
         for (const [key, value] of Object.entries(query)) {
             if (value !== undefined) {
                 if (Array.isArray(value)) {
-                    value.forEach(val => url.searchParams.append(key, decodeURIComponent(val)))
+                    for (const val of value) {
+                        url.searchParams.append(key, decodeURIComponent(val))
+                    }
                 } else {
                     url.searchParams.append(key, String(value))
                 }

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -112,7 +112,7 @@ function getFieldDataEntryForFieldSchema(fieldSchema: PossibleField, value: unkn
         case "date":
             if (typeof value === "string") {
                 const date = new Date(value)
-                if (isNaN(date.getTime())) return null
+                if (Number.isNaN(date.getTime())) return null
                 return {
                     value: date.toISOString(),
                     type: "date",
@@ -318,10 +318,7 @@ export async function syncCollection(
     const items: ManagedCollectionItemInput[] = []
     const unsyncedItems = new Set(await collection.getItemIds())
 
-    for (let i = 0; i < dataSourceItems.length; i++) {
-        const item = dataSourceItems[i]
-        if (!item) continue
-
+    for (const item of dataSourceItems) {
         items.push({
             id: item.id,
             slug: item.slugValue,

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -3,7 +3,9 @@ import type {
     FieldDataInput,
     ManagedCollection,
     ManagedCollectionField,
+    ManagedCollectionFieldInput,
     ManagedCollectionItemInput,
+    ProtectedMethod,
 } from "framer-plugin"
 import type { PossibleField } from "./fields"
 
@@ -265,7 +267,7 @@ export interface DataSource {
     baseId: string
     tableId: string
     tableName: string
-    fields: PossibleField[]
+    fields: readonly PossibleField[]
 }
 
 export function mergeFieldsWithExistingFields(
@@ -293,28 +295,10 @@ export function mergeFieldsWithExistingFields(
 export async function syncCollection(
     collection: ManagedCollection,
     dataSource: DataSource,
-    fields: readonly PossibleField[],
+    fields: readonly ManagedCollectionFieldInput[],
     slugFieldId: string
 ) {
-    const sanitizedFields = fields
-        .map(field => ({
-            ...field,
-            name: field.name.trim() || field.id,
-        }))
-        .filter(field => field.type !== "unsupported")
-        .filter(
-            field =>
-                (field.type !== "collectionReference" && field.type !== "multiCollectionReference") ||
-                field.collectionId !== ""
-        )
-
-    const dataSourceItems = await getItems(
-        {
-            ...dataSource,
-            fields: sanitizedFields,
-        },
-        slugFieldId
-    )
+    const dataSourceItems = await getItems({ ...dataSource, fields }, slugFieldId)
     const items: ManagedCollectionItemInput[] = []
     const unsyncedItems = new Set(await collection.getItemIds())
 
@@ -329,7 +313,6 @@ export async function syncCollection(
         unsyncedItems.delete(item.id)
     }
 
-    await collection.setFields(sanitizedFields)
     await collection.removeItems(Array.from(unsyncedItems))
     await collection.addItems(items)
 
@@ -340,6 +323,12 @@ export async function syncCollection(
         collection.setPluginData(PLUGIN_KEYS.SLUG_FIELD_ID, slugFieldId),
     ])
 }
+
+export const syncMethods = [
+    "ManagedCollection.removeItems",
+    "ManagedCollection.addItems",
+    "ManagedCollection.setPluginData",
+] as const satisfies ProtectedMethod[]
 
 export async function syncExistingCollection(
     collection: ManagedCollection,
@@ -353,6 +342,10 @@ export async function syncExistingCollection(
     }
 
     if (framer.mode !== "syncManagedCollection" || !previousSlugFieldId) {
+        return { didSync: false }
+    }
+
+    if (!framer.isAllowedTo(...syncMethods)) {
         return { didSync: false }
     }
 

--- a/plugins/airtable/src/fields.ts
+++ b/plugins/airtable/src/fields.ts
@@ -1,11 +1,11 @@
-import type { ManagedCollection, ManagedCollectionField } from "framer-plugin"
+import type { ManagedCollection, ManagedCollectionFieldInput } from "framer-plugin"
 
 import { framer } from "framer-plugin"
-import { type AirtableFieldSchema } from "./api"
+import type { AirtableFieldSchema } from "./api"
 import { PLUGIN_KEYS } from "./data"
 import { ALLOWED_FILE_TYPES } from "./utils"
 
-type AllowedType = ManagedCollectionField["type"] | "unsupported"
+type AllowedType = ManagedCollectionFieldInput["type"] | "unsupported"
 
 interface InferredField {
     /**
@@ -38,7 +38,7 @@ interface InferredUnsupportedField {
 }
 
 export type PossibleField = (
-    | ManagedCollectionField
+    | ManagedCollectionFieldInput
     | {
           id: string
           name: string
@@ -149,7 +149,9 @@ function inferAttachmentsField(fieldSchema: AirtableFieldSchema & { type: "multi
 }
 
 function inferDateField(
-    fieldSchema: AirtableFieldSchema & { type: "date" | "dateTime" | "createdTime" | "lastModifiedTime" }
+    fieldSchema: AirtableFieldSchema & {
+        type: "date" | "dateTime" | "createdTime" | "lastModifiedTime"
+    }
 ): PossibleField {
     return {
         id: fieldSchema.id,
@@ -185,7 +187,10 @@ async function inferRecordLinksField(
         )) {
             const existingTableId = await existingCollection.getPluginData(PLUGIN_KEYS.TABLE_ID)
             if (existingTableId === fieldSchema.options.linkedTableId) {
-                foundCollections.push({ id: existingCollection.id, name: existingCollection.name })
+                foundCollections.push({
+                    id: existingCollection.id,
+                    name: existingCollection.name,
+                })
             }
         }
     }
@@ -314,12 +319,12 @@ async function inferFormulaField(
     }
 
     // Create a temporary schema with the result type for recursive inference
-    const resultSchema: AirtableFieldSchema = {
+    const resultSchema = {
         id: fieldSchema.id,
         name: fieldSchema.name,
-        type: result.type as any,
-        options: {} as any,
-    }
+        type: result.type,
+        options: {},
+    } as AirtableFieldSchema
 
     // Handle formula result being another formula (prevent recursion)
     if (result.type === "formula") {

--- a/plugins/airtable/src/vite-env.d.ts
+++ b/plugins/airtable/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />


### PR DESCRIPTION
### Description

Fixes: https://github.com/framer/company/issues/32801

### Testing

- [x] Steps:

1. Make sure both "Plugin Permissions" and "Plugin Delayed Toast Clearing" experiments are on.
1. Mess around, import a collection, sync, manage, confirm it's all good.
1. Confirm that no toasts appear, talking about unchecked permissions.
1. Take away "Design" and/or "Content" permissions.
1. Synchronization should still work with "Design" disabled.
1. Management should require both.
1. The UI should react to the changes in the permissions.