### PR TITLE
feat: add support for table block rendering in Notion HTML conversion

### DIFF
--- a/plugins/notion/src/blocksToHTML.ts
+++ b/plugins/notion/src/blocksToHTML.ts
@@ -98,6 +98,28 @@ export function blocksToHtml(blocks: BlockObjectResponse[]) {
             case "code":
                 htmlContent += `<pre><code class="language-${block.code.language.replace(" ", "-")}">${richTextToHTML(block.code.rich_text)}</code></pre>`
                 break
+            case "table":
+                htmlContent += `<table>`
+                break
+            case "table_row":
+                if (blocks[i - 1]?.type !== "table") {
+                    htmlContent += `<thead><tr>`
+                    block.table_row.cells.forEach((cell) => {
+                        htmlContent += `<th>${richTextToHTML(cell)}</th>`
+                    })
+                    htmlContent += `</tr></thead><tbody>`
+                } else {
+                    htmlContent += `<tr>`
+                    block.table_row.cells.forEach((cell) => {
+                        htmlContent += `<td>${richTextToHTML(cell)}</td>`
+                    })
+                    htmlContent += `</tr>`
+                }
+
+                if (blocks[i + 1]?.type !== "table_row") {
+                    htmlContent += `</tbody></table>`
+                }
+                break
             case "video": {
                 if (block.video.type !== "external") {
                     break

--- a/plugins/notion/src/notion.ts
+++ b/plugins/notion/src/notion.ts
@@ -480,6 +480,19 @@ export interface SynchronizeResult extends SyncStatus {
     status: "success" | "completed_with_errors"
 }
 
+async function getBlockChildrenIterator(blockId: string) {
+    assert(notion, "Notion client is not initialized")
+    const blocksIterator = iteratePaginatedAPI(notion.blocks.children.list, {
+        block_id: blockId,
+    })
+    const blocks: BlockObjectResponse[] = []
+    for await (const block of blocksIterator) {
+        if (!isFullBlock(block)) continue
+        blocks.push(block)
+    }
+    return blocks
+}
+
 async function getPageBlocksAsRichText(pageId: string) {
     assert(notion, "Notion client is not initialized")
 
@@ -491,6 +504,11 @@ async function getPageBlocksAsRichText(pageId: string) {
     for await (const block of blocksIterator) {
         if (!isFullBlock(block)) continue
         blocks.push(block)
+
+        if (block.type === "table") {
+            const tableRows = await getBlockChildrenIterator(block.id)
+            blocks.push(...tableRows)
+        }
     }
 
     assert(blocks.every(isFullBlock), "Response is not a full block")


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

Add support for table block rendering in Notion HTML conversion.

There is a confusing point: I can edit table in Framer CMS locked content 😂

<img width="623" alt="image" src="https://github.com/user-attachments/assets/9bdb49d9-94d1-4464-acb6-4caa2021a07d" />

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

Notion:

<img width="550" alt="image" src="https://github.com/user-attachments/assets/01650903-9f57-4658-a301-f6fa1b7bc7c6" />

blocksToHtml `htmlContent` result:
```
<table><tr><td>Name</td><td>Age</td></tr><thead><tr><th>Tom</th><th>21</th></tr></thead><tbody><thead><tr><th>Jerry</th><th>22</th></tr></thead><tbody><thead><tr><th>Marry</th><th>18</th></tr></thead><tbody></tbody></table><p></p><p></p><p></p>
```

Framer CMS:

<img width="634" alt="image" src="https://github.com/user-attachments/assets/fd026e26-4590-42ce-b7a0-4bc0754629a5" />


- [ ] Description of test case one
  - [ ] Create a simple table in Notion Page
  - [ ] Sync the CMS
  - [ ] Check CMS Content


<!-- Thank you for contributing! -->