### PR TITLE
Fix file type handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7052,15 +7052,6 @@
                 }
             }
         },
-        "node_modules/framer-plugin": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/framer-plugin/-/framer-plugin-2.2.0.tgz",
-            "integrity": "sha512-GI1wFxh1mQxNH4fA87sRGGXctK/F3OEjPWdCfsKDkihvv3k6L9iwLV0652tAClAgwNxnB8pFyYaCNKsl/dRtHQ==",
-            "peerDependencies": {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
-            }
-        },
         "node_modules/framer-plugin-tools": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/framer-plugin-tools/-/framer-plugin-tools-1.0.0.tgz",

--- a/plugins/notion/src/MapFields.tsx
+++ b/plugins/notion/src/MapFields.tsx
@@ -289,7 +289,10 @@ export function MapDatabaseFields({
                                         }}
                                     ></input>
                                     <select
-                                        className={classNames("w-full", (!isSupported || !isAllowedToManage) && "opacity-50")}
+                                        className={classNames(
+                                            "w-full",
+                                            (!isSupported || !isAllowedToManage) && "opacity-50"
+                                        )}
                                         onChange={event =>
                                             handleFieldTypeChange(
                                                 property.id,

--- a/plugins/notion/src/notion.ts
+++ b/plugins/notion/src/notion.ts
@@ -21,7 +21,7 @@ import {
     type ManagedCollectionField,
     type ManagedCollectionFieldInput,
     type ManagedCollectionItemInput,
-    framer
+    framer,
 } from "framer-plugin"
 import pLimit from "p-limit"
 import { blocksToHtml, richTextToHTML } from "./blocksToHTML"
@@ -396,6 +396,7 @@ export function richTextToPlainText(richText: RichTextItemResponse[]) {
 
 export function getFieldDataEntryInput(
     property: PageObjectResponse["properties"][string],
+    fieldType: ManagedCollectionField["type"],
     { supportsHtml }: { supportsHtml: boolean }
 ): FieldDataEntryInput | undefined {
     switch (property.type) {
@@ -464,7 +465,8 @@ export function getFieldDataEntryInput(
             }
         }
         case "unique_id": {
-            if (Number.isNaN(property.unique_id.number) || typeof property.unique_id.number !== "number") return undefined
+            if (Number.isNaN(property.unique_id.number) || typeof property.unique_id.number !== "number")
+                return undefined
             return {
                 type: "number",
                 value: property.unique_id.number,
@@ -484,10 +486,11 @@ export function getFieldDataEntryInput(
         }
         case "files": {
             const firstFile = property.files[0]
-            if (!firstFile) return {
-                type: "file",
-                value: null,
-            }
+            if (!firstFile)
+                return {
+                    type: "file",
+                    value: null,
+                }
 
             if (firstFile.type === "external" && firstFile.external.url) {
                 return {
@@ -496,9 +499,10 @@ export function getFieldDataEntryInput(
                 }
             }
 
-            if (firstFile.type === "file") {
+            const isFileOrImage = fieldType === "file" || fieldType === "image"
+            if (firstFile.type === "file" && isFileOrImage) {
                 return {
-                    type: "file",
+                    type: fieldType,
                     value: firstFile.file.url,
                 }
             }
@@ -573,7 +577,7 @@ async function processItem(
         assert(property)
 
         if (property.id === slugFieldId) {
-            const resolvedSlug = getFieldDataEntryInput(property, { supportsHtml: false })
+            const resolvedSlug = getFieldDataEntryInput(property, "string", { supportsHtml: false })
             assert(typeof resolvedSlug?.value === "string", "Slug value is not a string")
             slugValue = slugify(resolvedSlug.value as string)
         }
@@ -585,7 +589,9 @@ async function processItem(
             continue
         }
 
-        const fieldDataEntry = getFieldDataEntryInput(property, { supportsHtml: field.type === "formattedText" })
+        const fieldDataEntry = getFieldDataEntryInput(property, field.type, {
+            supportsHtml: field.type === "formattedText",
+        })
         if (!fieldDataEntry) {
             status.warnings.push({
                 url: item.url,
@@ -762,7 +768,7 @@ export function useSynchronizeDatabaseMutation(
         onError,
         mutationFn: async (options: SynchronizeMutationOptions): Promise<SynchronizeResult> => {
             assert(database)
-            
+
             const collection = await framer.getActiveManagedCollection()
             await collection.setFields(options.fields)
             return synchronizeDatabase(database, options)


### PR DESCRIPTION
### Description

This PR improves file handling in the Notion plugin by checking the field type before processing file properties. Now, when a Notion file property is mapped, the system correctly handles it based on whether it's configured as a "file" or "image" field type in the collection.

### Testing

- [x] Test file handling functionality
  - [x] Create a Notion database with file attachments
  - [x] Map the file field as an image type
  - [x] Verify files appear correctly as images in the collection
  - [x] Map the file field as a file type
  - [x] Verify files appear correctly as files in the collection
