### PR TITLE
Fix files property types in Notion plugin

### DIFF
--- a/plugins/notion/src/notion.ts
+++ b/plugins/notion/src/notion.ts
@@ -487,22 +487,18 @@ export function getFieldDataEntryInput(
         }
         case "files": {
             const firstFile = property.files[0]
-            if (!firstFile) return { type: "file", value: null }
 
-            if (firstFile.type === "external" && firstFile.external.url) {
-                return {
-                    type: "link",
-                    value: firstFile.external.url,
+            if (firstFile) {
+                if (firstFile.type === "external") {
+                    return { type: fieldType, value: firstFile.external?.url ?? "" }
+                }
+
+                if (firstFile.type === "file") {
+                    return { type: fieldType, value: firstFile.file?.url ?? "" }
                 }
             }
 
-            const isFileOrImage = fieldType === "file" || fieldType === "image"
-            if (firstFile.type === "file" && isFileOrImage) {
-                return {
-                    type: fieldType,
-                    value: firstFile.file.url,
-                }
-            }
+            return { type: fieldType, value: "" }
         }
     }
 }


### PR DESCRIPTION
### Description

This pull request fixes the types of files properties in Notion. The files property type can be imported as a File or Image field, but it was hardcoded to use "link" or "file" for the type. This causes "external" type images to fail to import because of the type mismatch.

For the last week, any image added in Notion with "Embed link" fails to import because of this type mismatch error.
<img width="326" alt="image" src="https://github.com/user-attachments/assets/d8a5d2cf-0d13-4f5d-af76-b964350202e4" />

There's a TypeScript error on `type: fieldType`, but I can't figure out why because the types look correct.

### Testing

You can use this database to test:
https://www.notion.so/framer/Notion-Plugin-Test-Database-1efadf6e8c9680b38910d2d0575513a0?source=copy_link

The first item (Red) has an external image. On the production version of the Notion plugin, it doesn't import that image, and in this PR version it does. 

CMS plugins such as CMS Export also fail to load on the production version due to the type mismatch errors.