### PR TITLE
Improve Airtable plugin design

### DIFF
--- a/plugins/airtable/package.json
+++ b/plugins/airtable/package.json
@@ -12,6 +12,7 @@
         "typecheck": "tsc"
     },
     "dependencies": {
+        "classnames": "^2.5.1",
         "framer-plugin": "^3.3.2",
         "react": "^18",
         "react-dom": "^18",

--- a/plugins/airtable/src/App.css
+++ b/plugins/airtable/src/App.css
@@ -12,6 +12,14 @@ form {
     -webkit-user-select: none;
 }
 
+select {
+    padding: 0px 16px 1px 10px;
+}
+
+select:not([disabled]) {
+    cursor: pointer;
+}
+
 .sticky-top {
     position: sticky;
     top: 0;
@@ -45,6 +53,13 @@ form {
     border-radius: 10px;
 }
 
+.setup-container {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+}
+
 .setup label {
     display: flex;
     flex-direction: row;
@@ -66,7 +81,7 @@ form {
 
 .mapping .fields {
     display: grid;
-    grid-template-columns: 1fr 8px 1fr 8px 1fr;
+    grid-template-columns: 1fr 8px 1fr 1fr;
     gap: 10px;
     margin-bottom: auto;
     padding-bottom: 10px;
@@ -95,6 +110,10 @@ form {
     gap: 8px;
 }
 
+.mapping .source-field.unsupported {
+    pointer-events: none;
+}
+
 .mapping .source-field[aria-disabled="true"] {
     opacity: 0.5;
 }
@@ -110,6 +129,50 @@ form {
 
 .mapping .source-field input[type="checkbox"]:focus {
     box-shadow: none;
+}
+
+.mapping .unsupported-field {
+    grid-column: span 2;
+    background-color: var(--framer-color-bg-tertiary);
+    border-radius: 8px;
+    padding: 0px 10px;
+    height: 30px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    opacity: 0.5;
+    color: var(--framer-color-text-secondary);
+}
+
+.mapping .single-select-option {
+    background-color: var(--framer-color-bg-tertiary);
+    border-radius: 8px;
+    padding: 0px 10px;
+    height: 30px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    color: var(--framer-color-text);
+}
+
+.mapping .single-select-option.disabled {
+    opacity: 0.5;
+}
+
+.mapping .field-type-select {
+    width: 100%;
+}
+
+.mapping .heading-link {
+    width: fit-content;
+    max-width: 100%;
+    color: var(--framer-color-text-primary);
+    font-size: 1rem;
+    font-weight: 700;
+}
+
+.mapping .heading-link:hover {
+    text-decoration: underline;
 }
 
 .mapping footer {

--- a/plugins/airtable/src/App.tsx
+++ b/plugins/airtable/src/App.tsx
@@ -24,11 +24,11 @@ export function App({ collection, previousBaseId, previousTableId, previousSlugF
     const [noTableAccess, setNoTableAccess] = useState(false)
 
     useLayoutEffect(() => {
-        const hasDataSourceSelected = Boolean(dataSource)
+        const hasDataSourceSelected = Boolean(dataSource) || isLoadingDataSource
 
         framer.showUI({
-            width: hasDataSourceSelected ? 360 : 320,
-            height: hasDataSourceSelected ? 425 : 350,
+            width: hasDataSourceSelected ? 600 : 320,
+            height: hasDataSourceSelected ? 500 : 345,
             minWidth: hasDataSourceSelected ? 360 : undefined,
             minHeight: hasDataSourceSelected ? 425 : undefined,
             resizable: hasDataSourceSelected,

--- a/plugins/airtable/src/FieldMapping.tsx
+++ b/plugins/airtable/src/FieldMapping.tsx
@@ -6,6 +6,7 @@ import { framer, useIsAllowedTo } from "framer-plugin"
 import { useState, useEffect, memo } from "react"
 import { mergeFieldsWithExistingFields, syncCollection, syncMethods } from "./data"
 import { ALLOWED_FILE_TYPES, isCollectionReference } from "./utils"
+import cx from "classnames"
 
 function ChevronIcon() {
     return (
@@ -41,9 +42,16 @@ interface FieldMappingRowProps {
     originalFieldName: string | undefined
     isIgnored: boolean
     disabled: boolean
+    unsupported?: boolean
+    missingCollection?: boolean
     onToggleIgnored?: (fieldId: string) => void
     onNameChange?: (fieldId: string, name: string) => void
     onTypeChange?: (fieldId: string, type: string) => void
+}
+
+interface SelectOption {
+    id: string
+    label: string
 }
 
 const FieldMappingRow = memo(
@@ -52,15 +60,35 @@ const FieldMappingRow = memo(
         originalFieldName,
         isIgnored,
         disabled,
+        unsupported,
+        missingCollection,
         onToggleIgnored,
         onNameChange,
         onTypeChange,
     }: FieldMappingRowProps) => {
+        let selectOptions: SelectOption[] = []
+        if (!unsupported && !missingCollection) {
+            if (isCollectionReference(field)) {
+                selectOptions = field.supportedCollections.map(collection => ({
+                    id: collection.id,
+                    label: collection.name,
+                }))
+            } else if (Array.isArray(field.allowedTypes)) {
+                selectOptions = field.allowedTypes.map(type => {
+                    const capitalizedType = type.charAt(0).toUpperCase() + type.slice(1)
+                    return {
+                        id: type,
+                        label: fieldTypeOptions.find(option => option.type === type)?.label ?? capitalizedType,
+                    }
+                })
+            }
+        }
+
         return (
             <>
                 <button
                     type="button"
-                    className="source-field"
+                    className={cx("source-field", unsupported || missingCollection ? "unsupported" : "")}
                     aria-disabled={isIgnored}
                     onClick={disabled ? undefined : () => onToggleIgnored?.(field.id)}
                     tabIndex={0}
@@ -70,55 +98,46 @@ const FieldMappingRow = memo(
                     <span>{originalFieldName ?? field.id}</span>
                 </button>
                 <ChevronIcon />
-                <input
-                    type="text"
-                    style={{
-                        width: "100%",
-                        opacity: isIgnored || disabled ? 0.5 : 1,
-                    }}
-                    disabled={isIgnored || disabled}
-                    placeholder={field.id}
-                    value={field.name}
-                    onChange={event => onNameChange?.(field.id, event.target.value)}
-                    onKeyDown={event => {
-                        if (event.key === "Enter") {
-                            event.preventDefault()
-                        }
-                    }}
-                />
-                <ChevronIcon />
-                <select
-                    style={{
-                        width: "100%",
-                        opacity: isIgnored || disabled ? 0.5 : 1,
-                    }}
-                    disabled={isIgnored || disabled}
-                    value={isCollectionReference(field) ? field.collectionId : field.type}
-                    onChange={event => onTypeChange?.(field.id, event.target.value)}
-                >
-                    {isCollectionReference(field) && (
-                        <>
-                            {field.supportedCollections.length === 0 && (
-                                <option value="unsupported">Unsupported</option>
-                            )}
-                            {field.supportedCollections.map(collection => (
-                                <option key={collection.id} value={collection.id}>
-                                    {collection.name}
-                                </option>
-                            ))}
-                        </>
-                    )}
-                    {!isCollectionReference(field) &&
-                        field.allowedTypes?.map(type => {
-                            const capitalizedType = type.charAt(0).toUpperCase() + type.slice(1)
-
-                            return (
-                                <option key={type} value={type}>
-                                    {fieldTypeOptions.find(option => option.type === type)?.label ?? capitalizedType}
-                                </option>
-                            )
-                        })}
-                </select>
+                {unsupported || missingCollection ? (
+                    <div className="unsupported-field">{unsupported ? "Unsupported Field" : "Missing Collection"}</div>
+                ) : (
+                    <>
+                        <input
+                            type="text"
+                            style={{
+                                width: "100%",
+                                opacity: isIgnored || disabled ? 0.5 : 1,
+                            }}
+                            disabled={isIgnored || disabled}
+                            placeholder={originalFieldName ?? field.id}
+                            value={field.name}
+                            onChange={event => onNameChange?.(field.id, event.target.value)}
+                            onKeyDown={event => {
+                                if (event.key === "Enter") {
+                                    event.preventDefault()
+                                }
+                            }}
+                        />
+                        {selectOptions.length <= 1 ? (
+                            <div className={"single-select-option" + (isIgnored || disabled ? " disabled" : "")}>
+                                {selectOptions[0]?.label}
+                            </div>
+                        ) : (
+                            <select
+                                disabled={isIgnored || disabled}
+                                value={isCollectionReference(field) ? field.collectionId : field.type}
+                                onChange={event => onTypeChange?.(field.id, event.target.value)}
+                                className="field-type-select"
+                            >
+                                {selectOptions.map(option => (
+                                    <option key={option.id} value={option.id}>
+                                        {option.label}
+                                    </option>
+                                ))}
+                            </select>
+                        )}
+                    </>
+                )}
             </>
         )
     }
@@ -293,9 +312,23 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
         )
     }
 
+    const unsupportedFields = fields.filter(field => field.type === "unsupported")
+    const missingCollectionFields = fields.filter(
+        field => isCollectionReference(field) && field.supportedCollections.length === 0
+    )
+
     return (
         <form className="framer-hide-scrollbar mapping" onSubmit={handleSubmit}>
             <hr className="sticky-top" />
+
+            <a
+                href={`https://airtable.com/${dataSource.baseId}/${dataSource.tableId}`}
+                target="_blank"
+                className="heading-link"
+            >
+                {dataSource.tableName || "Untitled Table"}
+            </a>
+
             <label className="slug-field" htmlFor="slugField">
                 Slug Field
                 <select
@@ -323,15 +356,11 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
             </label>
 
             <div className="fields">
-                <span className="column-span-2">Column</span>
-                <span className="column-span-2">Field</span>
+                <span className="column-span-2">Airtable Column</span>
+                <span>Field Name</span>
                 <span>Type</span>
                 {fields
-                    .filter(
-                        field =>
-                            field.type !== "unsupported" &&
-                            (!isCollectionReference(field) || field.supportedCollections.length > 0)
-                    )
+                    .filter(field => !unsupportedFields.includes(field) && !missingCollectionFields.includes(field))
                     .map(field => (
                         <FieldMappingRow
                             key={`field-${field.id}`}
@@ -344,24 +373,26 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
                             onTypeChange={changeFieldType}
                         />
                     ))}
-                {fields
-                    .filter(
-                        field =>
-                            (isCollectionReference(field) && field.supportedCollections.length === 0) ||
-                            field.type === "unsupported"
-                    )
-                    .map(field => (
-                        <FieldMappingRow
-                            key={`field-${field.id}`}
-                            field={{
-                                ...field,
-                                name: isCollectionReference(field) ? "Missing Collection" : "Unsupported field",
-                            }}
-                            originalFieldName={dataSource.fields.find(sourceField => sourceField.id === field.id)?.name}
-                            isIgnored={true}
-                            disabled={!isAllowedToManage}
-                        />
-                    ))}
+                {missingCollectionFields.map(field => (
+                    <FieldMappingRow
+                        key={`field-${field.id}`}
+                        field={field}
+                        missingCollection
+                        originalFieldName={dataSource.fields.find(sourceField => sourceField.id === field.id)?.name}
+                        isIgnored={true}
+                        disabled={!isAllowedToManage}
+                    />
+                ))}
+                {unsupportedFields.map(field => (
+                    <FieldMappingRow
+                        key={`field-${field.id}`}
+                        field={field}
+                        unsupported
+                        originalFieldName={dataSource.fields.find(sourceField => sourceField.id === field.id)?.name}
+                        isIgnored={true}
+                        disabled={!isAllowedToManage}
+                    />
+                ))}
             </div>
 
             <footer>
@@ -371,6 +402,7 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
                     disabled={isSyncing || !isAllowedToManage}
                     tabIndex={0}
                     title={isAllowedToManage ? undefined : "Insufficient permissions"}
+                    className="framer-button-primary"
                 >
                     {isSyncing ? (
                         <div className="framer-spinner" />

--- a/plugins/airtable/src/SelectDataSource.tsx
+++ b/plugins/airtable/src/SelectDataSource.tsx
@@ -121,7 +121,11 @@ export function SelectDataSource({ collection, onSelectDataSource }: SelectDataS
                 </select>
             </label>
 
-            <button type="submit" disabled={!selectedBaseId || !selectedTableId || isLoading}>
+            <button
+                type="submit"
+                disabled={!selectedBaseId || !selectedTableId || isLoading}
+                className="framer-button-primary"
+            >
                 {isLoading ? <div className="framer-spinner" /> : "Next"}
             </button>
         </form>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,6 +3753,7 @@ __metadata:
     "@types/react-dom": "npm:^18"
     "@vitejs/plugin-react": "npm:^4.3.1"
     "@vitejs/plugin-react-swc": "npm:^3"
+    classnames: "npm:^2.5.1"
     eslint: "npm:^9.9.0"
     eslint-plugin-react-hooks: "npm:^5.1.0"
     eslint-plugin-react-refresh: "npm:^0.4.9"


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request improves the design and UX of the Airtable plugin.

- Increase default size of plugin window to prevent text getting cut off.
- Improve appearance and sorting of unsupported fields.
- Make field types with one option non-clickable.
- Add heading that links to the Airtable base.
- Use primary button style.

Before and after:
![image](https://github.com/user-attachments/assets/0a31b1c2-93e7-4bf7-9f8c-9e2bc4849915)
