### PR TITLE
Airtable: add support for color fields

### DIFF
--- a/plugins/airtable/src/FieldMapping.tsx
+++ b/plugins/airtable/src/FieldMapping.tsx
@@ -219,6 +219,16 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
                         return { ...field, type: "string" } as PossibleField
                     case "formattedText":
                         return { ...field, type: "formattedText" } as PossibleField
+                    case "number":
+                        return { ...field, type: "number" } as PossibleField
+                    case "boolean":
+                        return { ...field, type: "boolean" } as PossibleField
+                    case "color":
+                        return { ...field, type: "color" } as PossibleField
+                    case "date":
+                        return { ...field, type: "date" } as PossibleField
+                    case "enum":
+                        return { ...field, type: "enum" } as PossibleField
                     default:
                         return field
                 }

--- a/plugins/airtable/src/FieldMapping.tsx
+++ b/plugins/airtable/src/FieldMapping.tsx
@@ -219,16 +219,8 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
                         return { ...field, type: "string" } as PossibleField
                     case "formattedText":
                         return { ...field, type: "formattedText" } as PossibleField
-                    case "number":
-                        return { ...field, type: "number" } as PossibleField
-                    case "boolean":
-                        return { ...field, type: "boolean" } as PossibleField
                     case "color":
                         return { ...field, type: "color" } as PossibleField
-                    case "date":
-                        return { ...field, type: "date" } as PossibleField
-                    case "enum":
-                        return { ...field, type: "enum" } as PossibleField
                     default:
                         return field
                 }

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -130,7 +130,7 @@ function getFieldDataEntryForFieldSchema(fieldSchema: PossibleField, value: unkn
             }
 
         case "color":
-            if (typeof value !== "string") return null
+            if (!value || typeof value !== "string") return null
             return {
                 value,
                 type: "color",
@@ -239,13 +239,18 @@ export async function getItems(dataSource: DataSource, slugFieldId: string) {
                     case "image":
                     case "file":
                     case "link":
-                    case "color":
                     case "date":
                     case "collectionReference":
                     case "multiCollectionReference":
                         fieldData[field.id] = {
                             value: null,
                             type: field.type,
+                        }
+                        break
+                    case "color":
+                        fieldData[field.id] = {
+                            value: "#000000",
+                            type: "color",
                         }
                         break
                     default:

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -240,17 +240,12 @@ export async function getItems(dataSource: DataSource, slugFieldId: string) {
                     case "file":
                     case "link":
                     case "date":
+                    case "color":
                     case "collectionReference":
                     case "multiCollectionReference":
                         fieldData[field.id] = {
                             value: null,
                             type: field.type,
-                        }
-                        break
-                    case "color":
-                        fieldData[field.id] = {
-                            value: "#000000",
-                            type: "color",
                         }
                         break
                     default:

--- a/plugins/airtable/src/fields.ts
+++ b/plugins/airtable/src/fields.ts
@@ -100,7 +100,7 @@ function inferStringField(fieldSchema: AirtableFieldSchema & { type: "singleLine
         userEditable: false,
         airtableType: fieldSchema.type,
         type: "string",
-        allowedTypes: ["string", "formattedText"],
+        allowedTypes: ["string", "formattedText", "color"],
     }
 }
 


### PR DESCRIPTION
### Description

This pull request adds support for importing single line text fields from Airtable as colors in Framer. Airtable does not have a color field type built-in, so this update lets you enter colors as text.

The default color if a color field has no value is #000000.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Add a single line text column to your Airtable base.
- [x] Fill in the column with color values in different formats such as hex, hsl, and rgba.
- [x] Select the "Color" type in the Airtable plugin when importing.

<!-- Thank you for contributing! -->