### PR TITLE
Preserve draft status in CMS import/export

### DIFF
--- a/plugins/cms-export/src/PreviewTable.tsx
+++ b/plugins/cms-export/src/PreviewTable.tsx
@@ -6,6 +6,10 @@ import { getDataForCSV } from "./csv"
 
 import "./PreviewTable.css"
 
+const cellTitleOverrides: Record<string, string> = {
+    ":draft": "Is Draft?",
+}
+
 interface Props {
     collection: Collection
 }
@@ -62,7 +66,7 @@ export function PreviewTable({ collection }: Props) {
                         <tr>
                             {previewCSV[0]?.map((cell, columnIndex) => (
                                 <td key={`0-${columnIndex}`} title={cell}>
-                                    {cell === ":draft" ? "Is Draft?" : cell}
+                                    {cellTitleOverrides[cell] ?? cell}
                                 </td>
                             ))}
                         </tr>

--- a/plugins/cms-export/src/PreviewTable.tsx
+++ b/plugins/cms-export/src/PreviewTable.tsx
@@ -62,7 +62,7 @@ export function PreviewTable({ collection }: Props) {
                         <tr>
                             {previewCSV[0]?.map((cell, columnIndex) => (
                                 <td key={`0-${columnIndex}`} title={cell}>
-                                    {cell}
+                                    {cell === ":draft" ? "Is Draft?" : cell}
                                 </td>
                             ))}
                         </tr>

--- a/plugins/cms-export/src/csv.ts
+++ b/plugins/cms-export/src/csv.ts
@@ -58,9 +58,16 @@ function isFieldSupported(field: Field): field is SupportedField {
 export function getDataForCSV(slugFieldName: string | null, fields: Field[], items: CollectionItem[]): Rows {
     const rows: Rows = []
     const supportedFields = fields.filter(isFieldSupported)
+    const hasDraftItems = items.some(item => item.draft)
 
     // Add header row with slug field at the start.
     const header: Columns = [slugFieldName ?? "Slug"]
+
+    // Add draft column if there are any draft items.
+    if (hasDraftItems) {
+        header.push(":draft")
+    }
+
     for (const field of supportedFields) {
         if (field.type === "image") {
             header.push(field.name, `${field.name}:alt`)
@@ -77,6 +84,11 @@ export function getDataForCSV(slugFieldName: string | null, fields: Field[], ite
 
         // Add the slug cell.
         columns.push(item.slug)
+
+        // Add draft column if there are any draft items.
+        if (hasDraftItems) {
+            columns.push(item.draft ? "true" : "false")
+        }
 
         for (const field of supportedFields) {
             const fieldData = item.fieldData[field.id]


### PR DESCRIPTION
### Description

This pull request adds draft support to CSV Import and CMS Export plugins. A new column named `:draft` has been added, which controls the draft status of each CMS item.

It's named ":draft" instead of "Draft" to avoid naming conflicts with a CMS field named "Draft". A similar syntax "Image:alt" is used for image alt text columns.

In the export plugin, the `:draft` column is only included if there are any draft items.

In the import plugin, if the `:draft` column is missing all items are imported as non-drafts.

With this update, you can export a CMS collection with draft items, and when you import them into a new collection the same items will be drafts.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Create a new blog collection.
- [x] Mark some items as draft.
- [x] Run the CMS Export plugin with this PR and save a copy of the collection.
- [x] Add a new collection.
- [x] Run the CSV Import plugin with this PR and import the saved copy of the other collection.
- [x] The same items are marked as draft.
- [x] You can also copy and paste from this sheet to test: https://docs.google.com/spreadsheets/d/1Z0fnCfTMj7NOTBL8Dh2fv73Xa6k1LTH1l8CQDqY3fGc/edit?usp=sharing

<!-- Thank you for contributing! -->