### PR TITLE
Close stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Mark and close stale PRs
+
+on:
+  schedule:
+    - cron: "33 3 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 7
+          days-before-close: 7
+          stale-pr-label: "stale"
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not had
+            any activity in the last 7 days. It will be closed if no further activity
+            occurs in the next 7 days.
+            


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request adds a workflow to mark inactive PRs as stale after 7 days of inactivity and close them after 7 days if no follow up actions are taken.

### Testing

N/A