### PR TITLE
[Side project] Configure Biome as default formatter for specific file types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,24 @@
     "eslint.workingDirectories": [{ "mode": "auto" }],
     "biome.enabled": true,
     "editor.defaultFormatter": "biomejs.biome",
+    "[typescript]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    },
+    "[javascript]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    },
+    "[javascriptreact]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    },
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    },
+    "[json]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    },
+    "[jsonc]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    },
     "search.exclude": {
         "**/.turbo": true,
         "**/.yarn": true,


### PR DESCRIPTION
### Description

This pull request configures VS Code to use Biome as the default formatter for specific file types. It adds explicit formatter settings for TypeScript, JavaScript, JSX, TSX, JSON, and JSONC files, ensuring consistent formatting across these file types.

### Testing

- [x] Verify Biome formatting works for TypeScript files
  - Open a TypeScript file in VS Code
  - Make some changes
  - Save and confirm Biome is used
- [x] Verify Biome formatting works for JavaScript files
  - Open a JavaScript file in VS Code
  - Make some changes
  - Save and confirm Biome is used
- [x] Verify Biome formatting works for JSON files
  - Open a JSON file in VS Code
  - Make some changes
  - Save and confirm Biome is used