### PR TITLE
Add zed config

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,44 @@
+{
+    "languages": {
+        "JSONC": {
+            "formatter": {
+                "language_server": {
+                    "name": "biome"
+                }
+            }
+        },
+        "JSON": {
+            "formatter": {
+                "language_server": {
+                    "name": "biome"
+                }
+            }
+        },
+        "TypeScript": {
+            "formatter": {
+                "language_server": {
+                    "name": "biome"
+                }
+            },
+            "code_actions_on_format": {
+                "source.fixAll.biome": true,
+                "source.organizeImports.biome": true
+            }
+        },
+        "TSX": {
+            "formatter": {
+                "language_server": {
+                    "name": "biome"
+                }
+            },
+            "code_actions_on_format": {
+                "source.fixAll.biome": true,
+                "source.organizeImports.biome": true
+            }
+        }
+    },
+    "auto_install_extensions": {
+        "biome": true
+    },
+    "tab_size": 4
+}


### PR DESCRIPTION
### Description

Adds repo-relevant settings for Zed. Zed would default to using 

### Testing

- [ ] Use Zed, open a typescript file, make an edit and confirm that biome formats correctly, ie not with prettier.