### PR TITLE
Google Sheets: improve color and date detection

### DIFF
--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -51,12 +51,26 @@ const inferFieldType = (cellValue: CellValue): CollectionFieldType => {
     if (typeof cellValue === "number") return "number"
 
     if (typeof cellValue === "string") {
-        const cellValueLowered = cellValue.trim().toLowerCase()
+        const cellValueTrimmed = cellValue.trim()
+        const cellValueLowered = cellValueTrimmed.toLowerCase()
 
         // If the cell value contains a newline, it's probably a formatted text field
         if (cellValueLowered.includes("\n")) return "formattedText"
-        if (/^#[0-9a-f]{6}$/.test(cellValueLowered)) return "color"
         if (/<[a-z][\s\S]*>/.test(cellValueLowered)) return "formattedText"
+
+        // Check if the string is an ISO date
+        // Accepts formats like 2023-01-01, 2023-01-01T12:34:56Z, 2023-01-01T12:34:56.789+02:00, etc.
+        if (/^\d{4}-\d{2}-\d{2}(?:[Tt ][\d:.+-Zz]*)?$/.test(cellValueTrimmed) && !isNaN(Date.parse(cellValueTrimmed))) {
+            return "date"
+        }
+
+        // Detect hex, rgb(), and rgba() CSS color formats
+        if (
+            /^#[0-9a-f]{6}$/.test(cellValueLowered) ||
+            /^rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+(?:\s*,\s*(?:\d*\.?\d+|\d+%))?\s*\)$/i.test(cellValueTrimmed)
+        ) {
+            return "color"
+        }
 
         try {
             new URL(cellValueLowered)


### PR DESCRIPTION
### Description

This pull request improves type inference in Google Sheets.

- Detects rgb() and rgba() colors
- Detects dates in ISO format

### Testing

Try importing this sheet. Previously the last two columns would have been detected as string, now they are color and date types.
https://docs.google.com/spreadsheets/d/1Z0fnCfTMj7NOTBL8Dh2fv73Xa6k1LTH1l8CQDqY3fGc/edit?usp=sharing