### PR TITLE
Google Sheets: fix background color opacity

### DIFF
--- a/plugins/google-sheets/src/components/Hero.tsx
+++ b/plugins/google-sheets/src/components/Hero.tsx
@@ -1,7 +1,7 @@
 import hero from "../assets/hero.png"
 
 export const Hero = () => (
-    <div className="min-h-[200px] flex items-center justify-center bg-[#00BD42] bg-opacity-[0.08] rounded-[10px]">
+    <div className="min-h-[200px] flex items-center justify-center bg-[rgba(0,189,66,0.08)] rounded-[10px]">
         <img src={hero} alt="Floating sheet" className="object-contain w-[160px] h-[160px]" />
     </div>
 )


### PR DESCRIPTION
### Description

This pull request fixes the background color of the Google Sheets plugin graphic. A side effect of a recent code change is that the `bg-opacity-[0.08]` tag is no longer working, maybe due to a Tailwind CSS version or config, so this PR reverts it back to the original opacity.

**Before and after:**
<img width="357" alt="Google Sheets (Development)" src="https://github.com/user-attachments/assets/7236ecc6-ba4a-4c41-97d4-72a1196bd499" /><img width="352" alt="image" src="https://github.com/user-attachments/assets/1d93e20e-b7aa-45d4-a960-2524d9bc7b6e" />