### PR TITLE
Airtable: add Lookup, Rollup, Barcode, AI Text, User, and Duration fields

### DIFF
--- a/plugins/airtable/src/FieldMapping.tsx
+++ b/plugins/airtable/src/FieldMapping.tsx
@@ -234,8 +234,16 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
                         return { ...field, type: "string" } as PossibleField
                     case "formattedText":
                         return { ...field, type: "formattedText" } as PossibleField
+                    case "number":
+                        return { ...field, type: "number" } as PossibleField
+                    case "boolean":
+                        return { ...field, type: "boolean" } as PossibleField
                     case "color":
                         return { ...field, type: "color" } as PossibleField
+                    case "date":
+                        return { ...field, type: "date" } as PossibleField
+                    case "enum":
+                        return { ...field, type: "enum" } as PossibleField
                     default:
                         return field
                 }
@@ -274,10 +282,13 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
 
             const fieldsToSync = fields
                 .filter(field => !ignoredFieldIds.has(field.id))
-                .map(field => ({
-                    ...field,
-                    name: field.name.trim() || field.id,
-                }))
+                .map(field => {
+                    const originalFieldName = dataSource.fields.find(sourceField => sourceField.id === field.id)?.name
+                    return {
+                        ...field,
+                        name: field.name.trim() || originalFieldName || field.id,
+                    }
+                })
                 .filter(field => field.type !== "unsupported")
                 .filter(
                     field =>
@@ -399,13 +410,7 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
                     tabIndex={0}
                     title={isAllowedToManage ? undefined : "Insufficient permissions"}
                 >
-                    {isSyncing ? (
-                        <div className="framer-spinner" />
-                    ) : (
-                        <span>
-                            Import <span style={{ textTransform: "capitalize" }}>{dataSource.tableName}</span>
-                        </span>
-                    )}
+                    {isSyncing ? <div className="framer-spinner" /> : <span>Import {dataSource.tableName}</span>}
                 </button>
             </footer>
         </form>

--- a/plugins/airtable/src/api.ts
+++ b/plugins/airtable/src/api.ts
@@ -511,3 +511,16 @@ export const fetchAllBases = async () => {
 
     return allBases
 }
+
+
+export function isBarcodeValue(value: unknown): value is BarcodeValue {
+    return !!(value && typeof value === "object" && "text" in value && typeof value.text === "string")
+}
+
+export function isAiTextValue(value: unknown): value is AiTextValue {
+    return !!(value && typeof value === "object" && "value" in value && typeof value.value === "string")
+}
+
+export function isCollaboratorValue(value: unknown): value is CollaboratorValue {
+    return !!(value && typeof value === "object" && "name" in value && typeof value.name === "string")
+}

--- a/plugins/airtable/src/api.ts
+++ b/plugins/airtable/src/api.ts
@@ -54,7 +54,6 @@ type CountValue = number
 type DateValue = string
 type DateTimeValue = string
 type PhoneNumberValue = string
-type LookupValue = Array<string | number | boolean>
 type SingleSelectValue = string | Choice
 type MultipleSelectsValue = string[] | Choice[]
 type SingleCollaboratorValue = CollaboratorValue
@@ -104,7 +103,6 @@ export type AirtableFieldValues = {
     createdTime: CreatedTimeValue
     rollup: RollupValue
     count: CountValue
-    lookup: LookupValue
     multipleLookupValues: MultipleLookupValuesValue
     autoNumber: AutoNumberValue
     barcode: BarcodeValue
@@ -197,7 +195,10 @@ interface FormulaOption {
 interface RollupOption {
     fieldIdInLinkedTable?: string
     recordLinkFieldId?: string
-    result?: AirtableFieldType | null
+    result?: {
+        type: AirtableFieldType
+        options?: AirtableFieldOptions[AirtableFieldType]
+    } | null
     referencedFieldIds?: string[]
 }
 
@@ -206,10 +207,13 @@ interface CountOption {
     recordLinkFieldId?: string | null
 }
 
-interface LookupOption {
+interface MultipleLookupValuesOption {
     fieldIdInLinkedTable: string | null
     recordLinkFieldId: string | null
-    result: AirtableFieldType | null
+    result: {
+        type: AirtableFieldType
+        options?: AirtableFieldOptions[AirtableFieldType]
+    } | null
 }
 
 interface RatingOption {
@@ -265,8 +269,7 @@ type AirtableFieldOptions = {
     createdTime: Record<string, never>
     rollup: RollupOption
     count: CountOption
-    lookup: LookupOption
-    multipleLookupValues: LookupOption
+    multipleLookupValues: MultipleLookupValuesOption
     autoNumber: Record<string, never>
     barcode: Record<string, never>
     rating: RatingOption
@@ -309,7 +312,6 @@ export type AirtableFieldSchema = AirtableBaseEntity & { description?: string } 
         | { type: "createdTime"; options: AirtableFieldOptions["createdTime"] }
         | { type: "rollup"; options: AirtableFieldOptions["rollup"] }
         | { type: "count"; options: AirtableFieldOptions["count"] }
-        | { type: "lookup"; options: AirtableFieldOptions["lookup"] }
         | { type: "multipleLookupValues"; options: AirtableFieldOptions["multipleLookupValues"] }
         | { type: "autoNumber"; options: AirtableFieldOptions["autoNumber"] }
         | { type: "barcode"; options: AirtableFieldOptions["barcode"] }

--- a/plugins/airtable/src/api.ts
+++ b/plugins/airtable/src/api.ts
@@ -118,8 +118,11 @@ export type AirtableFieldValues = {
 }
 
 export type AirtableFieldType = keyof AirtableFieldValues
-
 export type AirtableFieldValue = AirtableFieldValues[AirtableFieldType]
+export type AirtableField<T extends AirtableFieldType> = Extract<AirtableFieldSchema, { type: T }>
+export type AirtableFieldResult = {
+    [K in AirtableFieldType]: Pick<AirtableField<K>, "type" | "options">
+}[AirtableFieldType]
 
 interface NumberOption {
     precision: number
@@ -195,10 +198,7 @@ interface FormulaOption {
 interface RollupOption {
     fieldIdInLinkedTable?: string
     recordLinkFieldId?: string
-    result?: {
-        type: AirtableFieldType
-        options?: AirtableFieldOptions[AirtableFieldType]
-    } | null
+    result: AirtableFieldResult | null
     referencedFieldIds?: string[]
 }
 
@@ -210,10 +210,7 @@ interface CountOption {
 interface MultipleLookupValuesOption {
     fieldIdInLinkedTable: string | null
     recordLinkFieldId: string | null
-    result: {
-        type: AirtableFieldType
-        options?: AirtableFieldOptions[AirtableFieldType]
-    } | null
+    result: AirtableFieldResult | null
 }
 
 interface RatingOption {
@@ -511,7 +508,6 @@ export const fetchAllBases = async () => {
 
     return allBases
 }
-
 
 export function isBarcodeValue(value: unknown): value is BarcodeValue {
     return !!(value && typeof value === "object" && "text" in value && typeof value.text === "string")

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -7,7 +7,16 @@ import type {
     ProtectedMethod,
 } from "framer-plugin"
 import { framer } from "framer-plugin"
-import { type AirtableFieldSchema, fetchAllBases, fetchRecords, fetchTable, fetchTables } from "./api"
+import {
+    type AirtableFieldSchema,
+    fetchAllBases,
+    fetchRecords,
+    fetchTable,
+    fetchTables,
+    isAiTextValue,
+    isBarcodeValue,
+    isCollaboratorValue,
+} from "./api"
 import type { PossibleField } from "./fields"
 import { inferFields } from "./fields"
 import { richTextToHTML } from "./utils"
@@ -139,12 +148,12 @@ function getFieldDataEntryForFieldSchema(fieldSchema: PossibleField, value: unkn
                 case "aiText": {
                     if (!isAiTextValue(value)) return null
                     return {
-                        value: value.value,
+                        value: value.value ?? "",
                         type: "string",
                     }
                 }
                 case "duration": {
-                    if (!isDurationValue(value)) return null
+                    if (typeof value !== "number" || Number.isNaN(value)) return null
 
                     const hours = Math.floor(value / 3600)
                     const minutes = Math.floor((value % 3600) / 60)
@@ -468,20 +477,4 @@ export async function syncExistingCollection(
         })
         return { didSync: false }
     }
-}
-
-function isBarcodeValue(value: unknown): value is { text: string } {
-    return !!(value && typeof value === "object" && "text" in value && typeof value.text === "string")
-}
-
-function isAiTextValue(value: unknown): value is { value: string } {
-    return !!(value && typeof value === "object" && "value" in value && typeof value.value === "string")
-}
-
-function isDurationValue(value: unknown): value is number {
-    return typeof value === "number" && !Number.isNaN(value)
-}
-
-function isCollaboratorValue(value: unknown): value is { name: string } {
-    return !!(value && typeof value === "object" && "name" in value && typeof value.name === "string")
 }

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -10,6 +10,7 @@ import type {
 import { framer } from "framer-plugin"
 import { type AirtableFieldSchema, fetchAllBases, fetchRecords, fetchTable, fetchTables } from "./api"
 import type { PossibleField } from "./fields"
+import { inferFields } from "./fields"
 import { richTextToHTML } from "./utils"
 
 export const PLUGIN_KEYS = {
@@ -53,6 +54,12 @@ const EMAIL_REGEX = /\S[^\s@]*@\S+\.\S+/
 const PHONE_REGEX = /^(\+?[0-9])[0-9]{7,14}$/
 
 function getFieldDataEntryForFieldSchema(fieldSchema: PossibleField, value: unknown): FieldDataEntryInput | null {
+    if (fieldSchema.originalAirtableType === "multipleLookupValues") {
+        if (!Array.isArray(value)) return null
+        if (value.length === 0) return null
+        value = value[0]
+    }
+
     switch (fieldSchema.type) {
         case "boolean":
             return {
@@ -122,6 +129,89 @@ function getFieldDataEntryForFieldSchema(fieldSchema: PossibleField, value: unkn
             return null
 
         case "string":
+            switch (fieldSchema.airtableType) {
+                case "barcode": {
+                    if (!value || typeof value !== "object" || !("text" in value) || typeof value.text !== "string")
+                        return null
+                    return {
+                        value: value.text,
+                        type: "string",
+                    }
+                }
+                case "aiText": {
+                    if (!value || typeof value !== "object" || !("value" in value) || typeof value.value !== "string")
+                        return null
+                    return {
+                        value: value.value,
+                        type: "string",
+                    }
+                }
+                case "duration": {
+                    if (typeof value !== "number" || Number.isNaN(value)) return null
+
+                    const hours = Math.floor(value / 3600)
+                    const minutes = Math.floor((value % 3600) / 60)
+                    const remainingSeconds = value % 60
+                    const seconds = Math.floor(remainingSeconds).toString().padStart(2, "0")
+
+                    let result = ""
+                    result += hours.toString()
+                    result += ":" + minutes.toString().padStart(2, "0")
+
+                    // Handle seconds and milliseconds based on format
+                    const durationOptions = fieldSchema.airtableOptions as { durationFormat?: string } | undefined
+                    switch (durationOptions?.durationFormat) {
+                        case "h:mm":
+                            break
+                        case "h:mm:ss":
+                            result += ":" + seconds
+                            break
+                        case "h:mm:ss.S":
+                            result += ":" + seconds
+                            result += "." + (remainingSeconds % 1).toFixed(1).substring(2)
+                            break
+                        case "h:mm:ss.SS":
+                            result += ":" + seconds
+                            result += "." + (remainingSeconds % 1).toFixed(2).substring(2)
+                            break
+                        case "h:mm:ss.SSS":
+                            result += ":" + seconds
+                            result += "." + (remainingSeconds % 1).toFixed(3).substring(2)
+                            break
+                    }
+
+                    return {
+                        value: result,
+                        type: "string",
+                    }
+                }
+                case "singleCollaborator":
+                case "createdBy":
+                case "lastModifiedBy": {
+                    if (!value || typeof value !== "object" || !("name" in value) || typeof value.name !== "string")
+                        return null
+                    return {
+                        value: value.name,
+                        type: "string",
+                    }
+                }
+                case "multipleCollaborators": {
+                    if (!Array.isArray(value) || value.length === 0) return null
+                    const firstCollaborator = value[0]
+                    if (
+                        !firstCollaborator ||
+                        typeof firstCollaborator !== "object" ||
+                        !("name" in firstCollaborator) ||
+                        typeof firstCollaborator.name !== "string"
+                    )
+                        return null
+                    return {
+                        value: firstCollaborator.name,
+                        type: "string",
+                    }
+                }
+            }
+
             if (typeof value !== "string") return null
             return {
                 value,
@@ -233,6 +323,12 @@ export async function getItems(dataSource: DataSource, slugFieldId: string) {
                         fieldData[field.id] = {
                             value: false,
                             type: "boolean",
+                        }
+                        break
+                    case "number":
+                        fieldData[field.id] = {
+                            value: 0,
+                            type: "number",
                         }
                         break
                     case "image":
@@ -356,13 +452,26 @@ export async function syncExistingCollection(
         if (!table) {
             throw new Error(`Table “${previousTableName}” not found`)
         }
+
+        // Use properly inferred fields instead of existing collection fields
+        const inferredFields = await inferFields(collection, table)
+
+        // Filter fields to match the format expected by syncCollection
+        const fieldsToSync = inferredFields
+            .filter(field => field.type !== "unsupported")
+            .filter(
+                field =>
+                    (field.type !== "collectionReference" && field.type !== "multiCollectionReference") ||
+                    field.collectionId !== ""
+            )
+
         const dataSource: DataSource = {
             baseId: previousBaseId,
             tableId: previousTableId,
             tableName: table.name,
-            fields: existingFields,
+            fields: inferredFields,
         }
-        await syncCollection(collection, dataSource, existingFields, previousSlugFieldId)
+        await syncCollection(collection, dataSource, fieldsToSync, previousSlugFieldId)
         return { didSync: true }
     } catch (error) {
         console.error(error)

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -194,21 +194,6 @@ function getFieldDataEntryForFieldSchema(fieldSchema: PossibleField, value: unkn
                         type: "string",
                     }
                 }
-                case "multipleCollaborators": {
-                    if (!Array.isArray(value) || value.length === 0) return null
-                    const firstCollaborator = value[0]
-                    if (
-                        !firstCollaborator ||
-                        typeof firstCollaborator !== "object" ||
-                        !("name" in firstCollaborator) ||
-                        typeof firstCollaborator.name !== "string"
-                    )
-                        return null
-                    return {
-                        value: firstCollaborator.name,
-                        type: "string",
-                    }
-                }
             }
 
             if (typeof value !== "string") return null

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -62,6 +62,7 @@ const EMAIL_REGEX = /\S[^\s@]*@\S+\.\S+/
 const PHONE_REGEX = /^(\+?[0-9])[0-9]{7,14}$/
 
 function getFieldDataEntryForFieldSchema(fieldSchema: PossibleField, value: unknown): FieldDataEntryInput | null {
+    // If the field is a lookup field, only use the first value from the array.
     if (fieldSchema.originalAirtableType === "multipleLookupValues") {
         if (!Array.isArray(value)) return null
         if (value.length === 0) return null

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -3,7 +3,6 @@ import type {
     FieldDataInput,
     ManagedCollection,
     ManagedCollectionField,
-    ManagedCollectionFieldInput,
     ManagedCollectionItemInput,
     ProtectedMethod,
 } from "framer-plugin"
@@ -390,7 +389,7 @@ export function mergeFieldsWithExistingFields(
 export async function syncCollection(
     collection: ManagedCollection,
     dataSource: DataSource,
-    fields: readonly ManagedCollectionFieldInput[],
+    fields: readonly PossibleField[],
     slugFieldId: string
 ) {
     const dataSourceItems = await getItems({ ...dataSource, fields }, slugFieldId)
@@ -457,13 +456,13 @@ export async function syncExistingCollection(
         const inferredFields = await inferFields(collection, table)
 
         // Filter fields to match the format expected by syncCollection
-        const fieldsToSync = inferredFields
-            .filter(field => field.type !== "unsupported")
-            .filter(
-                field =>
-                    (field.type !== "collectionReference" && field.type !== "multiCollectionReference") ||
-                    field.collectionId !== ""
-            )
+        const fieldsToSync = inferredFields.filter(
+            field =>
+                existingFields.find(existingField => existingField.id === field.id) &&
+                field.type !== "unsupported" &&
+                ((field.type !== "collectionReference" && field.type !== "multiCollectionReference") ||
+                    field.collectionId !== "")
+        )
 
         const dataSource: DataSource = {
             baseId: previousBaseId,

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -438,13 +438,20 @@ export async function syncExistingCollection(
         const inferredFields = await inferFields(collection, table)
 
         // Filter fields to match the format expected by syncCollection
-        const fieldsToSync = inferredFields.filter(
-            field =>
-                existingFields.find(existingField => existingField.id === field.id) &&
-                field.type !== "unsupported" &&
-                ((field.type !== "collectionReference" && field.type !== "multiCollectionReference") ||
-                    field.collectionId !== "")
-        )
+        const fieldsToSync = inferredFields.filter(field => {
+            // Only include fields that exist in the current collection
+            const existsInCollection = existingFields.some(existingField => existingField.id === field.id)
+
+            // Exclude unsupported fields
+            const isSupportedType = field.type !== "unsupported"
+
+            // For collection references, ensure collectionId is not empty
+            const isValidCollectionReference =
+                (field.type !== "collectionReference" && field.type !== "multiCollectionReference") ||
+                field.collectionId !== ""
+
+            return existsInCollection && isSupportedType && isValidCollectionReference
+        })
 
         const dataSource: DataSource = {
             baseId: previousBaseId,

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -130,23 +130,21 @@ function getFieldDataEntryForFieldSchema(fieldSchema: PossibleField, value: unkn
         case "string":
             switch (fieldSchema.airtableType) {
                 case "barcode": {
-                    if (!value || typeof value !== "object" || !("text" in value) || typeof value.text !== "string")
-                        return null
+                    if (!isBarcodeValue(value)) return null
                     return {
                         value: value.text,
                         type: "string",
                     }
                 }
                 case "aiText": {
-                    if (!value || typeof value !== "object" || !("value" in value) || typeof value.value !== "string")
-                        return null
+                    if (!isAiTextValue(value)) return null
                     return {
                         value: value.value,
                         type: "string",
                     }
                 }
                 case "duration": {
-                    if (typeof value !== "number" || Number.isNaN(value)) return null
+                    if (!isDurationValue(value)) return null
 
                     const hours = Math.floor(value / 3600)
                     const minutes = Math.floor((value % 3600) / 60)
@@ -187,8 +185,7 @@ function getFieldDataEntryForFieldSchema(fieldSchema: PossibleField, value: unkn
                 case "singleCollaborator":
                 case "createdBy":
                 case "lastModifiedBy": {
-                    if (!value || typeof value !== "object" || !("name" in value) || typeof value.name !== "string")
-                        return null
+                    if (!isCollaboratorValue(value)) return null
                     return {
                         value: value.name,
                         type: "string",
@@ -464,4 +461,20 @@ export async function syncExistingCollection(
         })
         return { didSync: false }
     }
+}
+
+function isBarcodeValue(value: unknown): value is { text: string } {
+    return !!(value && typeof value === "object" && "text" in value && typeof value.text === "string")
+}
+
+function isAiTextValue(value: unknown): value is { value: string } {
+    return !!(value && typeof value === "object" && "value" in value && typeof value.value === "string")
+}
+
+function isDurationValue(value: unknown): value is number {
+    return typeof value === "number" && !Number.isNaN(value)
+}
+
+function isCollaboratorValue(value: unknown): value is { name: string } {
+    return !!(value && typeof value === "object" && "name" in value && typeof value.name === "string")
 }

--- a/plugins/airtable/src/fields.ts
+++ b/plugins/airtable/src/fields.ts
@@ -205,33 +205,9 @@ function inferDateField(
     }
 }
 
-function inferBarcodeField(fieldSchema: AirtableFieldSchema & { type: "barcode" }): PossibleField {
-    return {
-        id: fieldSchema.id,
-        name: fieldSchema.name,
-        userEditable: false,
-        airtableType: fieldSchema.type,
-        type: "string",
-        allowedTypes: ["string"],
-        ...createFieldMetadata(fieldSchema),
-    }
-}
-
-function inferAiTextField(fieldSchema: AirtableFieldSchema & { type: "aiText" }): PossibleField {
-    return {
-        id: fieldSchema.id,
-        name: fieldSchema.name,
-        userEditable: false,
-        airtableType: fieldSchema.type,
-        type: "string",
-        allowedTypes: ["string"],
-        ...createFieldMetadata(fieldSchema),
-    }
-}
-
-function inferCollaboratorField(
+function inferStringBasedField(
     fieldSchema: AirtableFieldSchema & {
-        type: "singleCollaborator" | "createdBy" | "lastModifiedBy"
+        type: "barcode" | "aiText" | "singleCollaborator" | "createdBy" | "lastModifiedBy"
     }
 ): PossibleField {
     return {
@@ -421,15 +397,11 @@ async function inferFieldByType(
             return await inferFormulaField(fieldSchema, collection, tableIdBeingLinkedTo, depth)
 
         case "barcode":
-            return inferBarcodeField(fieldSchema)
-
         case "aiText":
-            return inferAiTextField(fieldSchema)
-
         case "singleCollaborator":
         case "createdBy":
         case "lastModifiedBy":
-            return inferCollaboratorField(fieldSchema)
+            return inferStringBasedField(fieldSchema)
 
         case "duration":
             return inferDurationField(fieldSchema)

--- a/plugins/airtable/src/fields.ts
+++ b/plugins/airtable/src/fields.ts
@@ -14,18 +14,12 @@ interface InferredField {
      * Only set when fields are inferred.
      */
     readonly airtableType?: Exclude<AirtableFieldSchema["type"], "multipleRecordLinks" | "singleSelect">
-    /**
-     * The original Airtable field schema options.
-     * Only set when fields are inferred.
-     */
-    readonly airtableOptions?: AirtableFieldSchema["options"]
     readonly allowedTypes?: [AllowedType, ...AllowedType[]]
 }
 
 interface InferredMultipleRecordLinksField {
     type: "collectionReference" | "multiCollectionReference"
     readonly airtableType: "multipleRecordLinks"
-    readonly airtableOptions?: AirtableFieldSchema["options"]
     readonly supportedCollections: { id: string; name: string }[]
     readonly allowedTypes?: []
 }
@@ -34,14 +28,12 @@ interface InferredEnumField {
     type: "enum"
     readonly airtableType: "singleSelect"
     readonly airtableCases: { id: string; name: string }[]
-    readonly airtableOptions?: AirtableFieldSchema["options"]
     readonly allowedTypes: ["enum"]
 }
 
 interface InferredUnsupportedField {
     type: "unsupported"
     readonly airtableType?: AirtableFieldSchema["type"]
-    readonly airtableOptions?: AirtableFieldSchema["options"]
     readonly allowedTypes: [AirtableFieldSchema["type"], ...AirtableFieldSchema["type"][]]
 }
 
@@ -60,6 +52,11 @@ export type PossibleField = (
          * For lookup fields, this will be "multipleLookupValues".
          */
         readonly originalAirtableType?: string
+        /**
+         * The Airtable field schema options.
+         * Only set when fields are inferred.
+         */
+        readonly airtableOptions?: AirtableFieldSchema["options"]
     }
 
 /**

--- a/plugins/airtable/src/fields.ts
+++ b/plugins/airtable/src/fields.ts
@@ -1,7 +1,7 @@
 import type { ManagedCollection, ManagedCollectionFieldInput } from "framer-plugin"
 
 import { framer } from "framer-plugin"
-import type { AirtableFieldSchema } from "./api"
+import type { AirtableFieldResult, AirtableFieldSchema } from "./api"
 import { PLUGIN_KEYS } from "./data"
 import { ALLOWED_FILE_TYPES } from "./utils"
 
@@ -224,16 +224,15 @@ async function inferLookupField(
     const { options } = fieldSchema
 
     // If the lookup field doesn't have a result type, treat as unsupported
-    if (!options.result || typeof options.result !== "object" || !options.result.type) {
+    if (!hasOptions(options.result)) {
         return createUnsupportedField(fieldSchema)
     }
 
-    const resultSchema = {
-        type: options.result.type,
+    const resultSchema: AirtableFieldSchema = {
+        ...options.result,
         id: fieldSchema.id,
         name: fieldSchema.name,
-        options: options.result.options,
-    } as AirtableFieldSchema
+    }
 
     const inferredField = await inferFieldByType(resultSchema, collection, tableIdBeingLinkedTo, 1)
 
@@ -248,16 +247,15 @@ async function inferRollupField(
     const { options } = fieldSchema
 
     // If the rollup field doesn't have a result type, treat as unsupported
-    if (!options.result || typeof options.result !== "object" || !options.result.type) {
+    if (!hasOptions(options.result)) {
         return createUnsupportedField(fieldSchema)
     }
 
-    const resultSchema = {
+    const resultSchema: AirtableFieldSchema = {
+        ...options.result,
         id: fieldSchema.id,
         name: fieldSchema.name,
-        type: options.result.type,
-        options: options.result.options,
-    } as AirtableFieldSchema
+    }
 
     const inferredField = await inferFieldByType(resultSchema, collection, tableIdBeingLinkedTo, 1)
 
@@ -478,6 +476,12 @@ export async function inferFields(collection: ManagedCollection, table: Airtable
     }
 
     return fields
+}
+
+function hasOptions(
+    result: AirtableFieldResult | null
+): result is AirtableFieldResult & { options: NonNullable<AirtableFieldResult["options"]> } {
+    return result !== null && result !== undefined && result.options !== undefined && result.options !== null
 }
 
 export interface AirtableTable {

--- a/plugins/airtable/src/fields.ts
+++ b/plugins/airtable/src/fields.ts
@@ -6,6 +6,7 @@ import { PLUGIN_KEYS } from "./data"
 import { ALLOWED_FILE_TYPES } from "./utils"
 
 type AllowedType = ManagedCollectionFieldInput["type"] | "unsupported"
+type FieldSchema<T extends AirtableFieldSchema["type"]> = Extract<AirtableFieldSchema, { type: T }>
 
 interface InferredField {
     /**
@@ -69,7 +70,7 @@ function createFieldMetadata(fieldSchema: AirtableFieldSchema) {
     }
 }
 
-function inferBooleanField(fieldSchema: AirtableFieldSchema & { type: "checkbox" }): PossibleField {
+function inferBooleanField(fieldSchema: FieldSchema<"checkbox">): PossibleField {
     return {
         id: fieldSchema.id,
         name: fieldSchema.name,
@@ -81,7 +82,7 @@ function inferBooleanField(fieldSchema: AirtableFieldSchema & { type: "checkbox"
     }
 }
 
-function inferEnumField(fieldSchema: AirtableFieldSchema & { type: "singleSelect" }): PossibleField {
+function inferEnumField(fieldSchema: FieldSchema<"singleSelect">): PossibleField {
     return {
         id: fieldSchema.id,
         name: fieldSchema.name,
@@ -102,9 +103,7 @@ function inferEnumField(fieldSchema: AirtableFieldSchema & { type: "singleSelect
 }
 
 function inferNumberField(
-    fieldSchema: AirtableFieldSchema & {
-        type: "number" | "percent" | "currency" | "autoNumber" | "rating" | "count"
-    }
+    fieldSchema: FieldSchema<"number" | "percent" | "currency" | "autoNumber" | "rating" | "count">
 ): PossibleField {
     return {
         id: fieldSchema.id,
@@ -117,7 +116,7 @@ function inferNumberField(
     }
 }
 
-function inferDurationField(fieldSchema: AirtableFieldSchema & { type: "duration" }): PossibleField {
+function inferDurationField(fieldSchema: FieldSchema<"duration">): PossibleField {
     return {
         id: fieldSchema.id,
         name: fieldSchema.name,
@@ -129,7 +128,7 @@ function inferDurationField(fieldSchema: AirtableFieldSchema & { type: "duration
     }
 }
 
-function inferStringField(fieldSchema: AirtableFieldSchema & { type: "singleLineText" }): PossibleField {
+function inferStringField(fieldSchema: FieldSchema<"singleLineText">): PossibleField {
     return {
         id: fieldSchema.id,
         name: fieldSchema.name,
@@ -141,7 +140,7 @@ function inferStringField(fieldSchema: AirtableFieldSchema & { type: "singleLine
     }
 }
 
-function inferEmailOrPhoneField(fieldSchema: AirtableFieldSchema & { type: "email" | "phoneNumber" }): PossibleField {
+function inferEmailOrPhoneField(fieldSchema: FieldSchema<"email" | "phoneNumber">): PossibleField {
     return {
         id: fieldSchema.id,
         name: fieldSchema.name,
@@ -153,7 +152,7 @@ function inferEmailOrPhoneField(fieldSchema: AirtableFieldSchema & { type: "emai
     }
 }
 
-function inferTextField(fieldSchema: AirtableFieldSchema & { type: "multilineText" | "richText" }): PossibleField {
+function inferTextField(fieldSchema: FieldSchema<"multilineText" | "richText">): PossibleField {
     return {
         id: fieldSchema.id,
         name: fieldSchema.name,
@@ -165,7 +164,7 @@ function inferTextField(fieldSchema: AirtableFieldSchema & { type: "multilineTex
     }
 }
 
-function inferUrlField(fieldSchema: AirtableFieldSchema & { type: "url" }): PossibleField {
+function inferUrlField(fieldSchema: FieldSchema<"url">): PossibleField {
     return {
         id: fieldSchema.id,
         name: fieldSchema.name,
@@ -177,7 +176,7 @@ function inferUrlField(fieldSchema: AirtableFieldSchema & { type: "url" }): Poss
     }
 }
 
-function inferAttachmentsField(fieldSchema: AirtableFieldSchema & { type: "multipleAttachments" }): PossibleField {
+function inferAttachmentsField(fieldSchema: FieldSchema<"multipleAttachments">): PossibleField {
     return {
         id: fieldSchema.id,
         name: fieldSchema.name,
@@ -190,9 +189,7 @@ function inferAttachmentsField(fieldSchema: AirtableFieldSchema & { type: "multi
 }
 
 function inferDateField(
-    fieldSchema: AirtableFieldSchema & {
-        type: "date" | "dateTime" | "createdTime" | "lastModifiedTime"
-    }
+    fieldSchema: FieldSchema<"date" | "dateTime" | "createdTime" | "lastModifiedTime">
 ): PossibleField {
     return {
         id: fieldSchema.id,
@@ -206,9 +203,7 @@ function inferDateField(
 }
 
 function inferStringBasedField(
-    fieldSchema: AirtableFieldSchema & {
-        type: "barcode" | "aiText" | "singleCollaborator" | "createdBy" | "lastModifiedBy"
-    }
+    fieldSchema: FieldSchema<"barcode" | "aiText" | "singleCollaborator" | "createdBy" | "lastModifiedBy">
 ): PossibleField {
     return {
         id: fieldSchema.id,
@@ -222,7 +217,7 @@ function inferStringBasedField(
 }
 
 async function inferLookupField(
-    fieldSchema: AirtableFieldSchema & { type: "multipleLookupValues" },
+    fieldSchema: FieldSchema<"multipleLookupValues">,
     collection: ManagedCollection,
     tableIdBeingLinkedTo: string
 ): Promise<PossibleField> {
@@ -246,7 +241,7 @@ async function inferLookupField(
 }
 
 async function inferRollupField(
-    fieldSchema: AirtableFieldSchema & { type: "rollup" },
+    fieldSchema: FieldSchema<"rollup">,
     collection: ManagedCollection,
     tableIdBeingLinkedTo: string
 ): Promise<PossibleField> {
@@ -270,7 +265,7 @@ async function inferRollupField(
 }
 
 async function inferRecordLinksField(
-    fieldSchema: AirtableFieldSchema & { type: "multipleRecordLinks" },
+    fieldSchema: FieldSchema<"multipleRecordLinks">,
     collection: ManagedCollection,
     tableIdBeingLinkedTo: string
 ): Promise<PossibleField> {
@@ -412,7 +407,7 @@ async function inferFieldByType(
 }
 
 async function inferFormulaField(
-    fieldSchema: AirtableFieldSchema & { type: "formula" },
+    fieldSchema: FieldSchema<"formula">,
     collection: ManagedCollection,
     tableIdBeingLinkedTo: string,
     depth = 0
@@ -451,7 +446,7 @@ async function inferFormulaField(
         return depth > 1
             ? createUnsupportedField(fieldSchema)
             : await inferFormulaField(
-                  resultSchema as AirtableFieldSchema & { type: "formula" },
+                  resultSchema as FieldSchema<"formula">,
                   collection,
                   tableIdBeingLinkedTo,
                   depth + 1

--- a/plugins/airtable/src/fields.ts
+++ b/plugins/airtable/src/fields.ts
@@ -231,7 +231,7 @@ function inferAiTextField(fieldSchema: AirtableFieldSchema & { type: "aiText" })
 
 function inferCollaboratorField(
     fieldSchema: AirtableFieldSchema & {
-        type: "singleCollaborator" | "createdBy" | "lastModifiedBy" | "multipleCollaborators"
+        type: "singleCollaborator" | "createdBy" | "lastModifiedBy"
     }
 ): PossibleField {
     return {
@@ -429,7 +429,6 @@ async function inferFieldByType(
         case "singleCollaborator":
         case "createdBy":
         case "lastModifiedBy":
-        case "multipleCollaborators":
             return inferCollaboratorField(fieldSchema)
 
         case "duration":

--- a/plugins/airtable/src/fields.ts
+++ b/plugins/airtable/src/fields.ts
@@ -233,19 +233,16 @@ async function inferLookupField(
         return createUnsupportedField(fieldSchema)
     }
 
-    // Use the result object as the field schema for recursive inference
     const resultSchema = {
-        type: options.result.type as AirtableFieldSchema["type"],
+        type: options.result.type,
         id: fieldSchema.id,
         name: fieldSchema.name,
-        options: options.result.options as AirtableFieldSchema["options"],
+        options: options.result.options,
     } as AirtableFieldSchema
 
-    // Use the helper functions to infer the appropriate type based on the result
     const inferredField = await inferFieldByType(resultSchema, collection, tableIdBeingLinkedTo, 1)
 
-    // Return the inferred field with the lookup field metadata
-    return { ...inferredField, originalAirtableType: "multipleLookupValues" } as PossibleField
+    return { ...inferredField, originalAirtableType: "multipleLookupValues" }
 }
 
 async function inferRollupField(
@@ -260,19 +257,16 @@ async function inferRollupField(
         return createUnsupportedField(fieldSchema)
     }
 
-    // Create a temporary schema with the result type for recursive inference
     const resultSchema = {
         id: fieldSchema.id,
         name: fieldSchema.name,
-        type: options.result.type as AirtableFieldSchema["type"],
-        options: options.result.options as AirtableFieldSchema["options"],
+        type: options.result.type,
+        options: options.result.options,
     } as AirtableFieldSchema
 
-    // Use the helper functions to infer the appropriate type based on the result
     const inferredField = await inferFieldByType(resultSchema, collection, tableIdBeingLinkedTo, 1)
 
-    // Return the inferred field with the rollup field metadata
-    return { ...inferredField, originalAirtableType: "rollup" } as PossibleField
+    return { ...inferredField, originalAirtableType: "rollup" }
 }
 
 async function inferRecordLinksField(


### PR DESCRIPTION
### Description

This PR adds support for more Airtable field types and improves other field types. v2 of https://github.com/framer/plugins/pull/248

* Added support for these Airtable field types:
  * Lookup
  * Rollup
  * Barcode
  * AI Text
  * Collaborator
  * Created By
  * Last Edited By
  * Count
* Allow importing URL as Plain Text field.
* Fixed warning spam for empty number fields.
* Fixed importing duration field. Previously it would only import as a number of seconds, now it imports as a string by default and uses the same hour:minute:second formatting as shown in the Airtable app.

**Notes:**
* User/collaborator fields are imported as the user's name (same as the Notion plugin).
* Lookup array fields only import the first value. When we have support for gallery fields and later arrays for all field types, we can update this to import as an array instead of only the first value.

Currently marked as draft. Will open for review after I have tested all changes.

### Testing

None yet.