### PR TITLE
Notion: sync page cover image

### DIFF
--- a/plugins/notion/src/api.ts
+++ b/plugins/notion/src/api.ts
@@ -50,6 +50,17 @@ export const pageContentProperty: FieldInfo = {
     notionProperty: null,
 }
 
+// Every page can have a cover image. We add it as a property so it displays
+// in the list where you can configure properties to be synced with the CMS
+export const pageCoverProperty: FieldInfo = {
+    id: "page-cover",
+    type: "image",
+    name: "Cover Image",
+    originalName: "Cover Image",
+    allowedTypes: ["image"],
+    notionProperty: null,
+}
+
 // The valid field types that can be used as a slug, in order of preference
 const slugFieldTypes: NotionProperty["type"][] = ["title", "rich_text"]
 
@@ -165,8 +176,8 @@ function isSupportedPropertyType(type: string): type is keyof typeof supportedCM
 export function getDatabaseFieldsInfo(database: GetDatabaseResponse, databaseIdMap: DatabaseIdMap) {
     const result: FieldInfo[] = []
 
-    // This property is always there but not included in `"database.properties"
-    result.push(pageContentProperty)
+    // These properties are always there but not included in `"database.properties"
+    result.push(pageCoverProperty, pageContentProperty)
 
     const supported: FieldInfo[] = []
     const unsupported: FieldInfo[] = []

--- a/plugins/notion/src/api.ts
+++ b/plugins/notion/src/api.ts
@@ -55,8 +55,8 @@ export const pageContentProperty: FieldInfo = {
 export const pageCoverProperty: FieldInfo = {
     id: "page-cover",
     type: "image",
-    name: "Cover Image",
-    originalName: "Cover Image",
+    name: "Cover",
+    originalName: "Cover",
     allowedTypes: ["image"],
     notionProperty: null,
 }

--- a/plugins/notion/src/data.ts
+++ b/plugins/notion/src/data.ts
@@ -149,10 +149,15 @@ export async function syncCollection(
                 let coverValue: string | null = null
 
                 if (item.cover) {
-                    if (item.cover.type === "external") {
-                        coverValue = item.cover.external.url
-                    } else if (item.cover.type === "file") {
-                        coverValue = item.cover.file.url
+                    switch (item.cover.type) {
+                        case "external":
+                            coverValue = item.cover.external.url
+                            break
+                        case "file":
+                            coverValue = item.cover.file.url
+                            break
+                        default:
+                            item.cover satisfies never
                     }
                 }
 

--- a/plugins/notion/src/data.ts
+++ b/plugins/notion/src/data.ts
@@ -19,6 +19,7 @@ import {
     isUnchangedSinceLastSync,
     PLUGIN_KEYS,
     pageContentProperty,
+    pageCoverProperty,
     richTextToPlainText,
 } from "./api"
 import { richTextToHtml } from "./blocksToHtml"
@@ -144,6 +145,20 @@ export async function syncCollection(
                 fieldData[pageContentProperty.id] = { type: "formattedText", value: contentHTML }
             }
 
+            if (fieldsById.has(pageCoverProperty.id)) {
+                let coverValue: string | null = null
+
+                if (item.cover) {
+                    if (item.cover.type === "external") {
+                        coverValue = item.cover.external.url
+                    } else if (item.cover.type === "file") {
+                        coverValue = item.cover.file.url
+                    }
+                }
+
+                fieldData[pageCoverProperty.id] = { type: "image", value: coverValue }
+            }
+
             return {
                 id: item.id,
                 slug: slugValue,
@@ -241,6 +256,14 @@ export async function fieldsInfoToCollectionFields(
         if (fieldInfo.id === pageContentProperty.id) {
             fields.push({
                 type: "formattedText",
+                id: fieldInfo.id,
+                name: fieldName,
+                userEditable: false,
+            })
+            continue
+        } else if (fieldInfo.id === pageCoverProperty.id) {
+            fields.push({
+                type: "image",
                 id: fieldInfo.id,
                 name: fieldName,
                 userEditable: false,


### PR DESCRIPTION
### Description

This pull request adds support for importing page cover images from Notion.

![Cover Image](https://github.com/user-attachments/assets/84936d44-2224-4ea2-872c-ccb7e4aa3047)

<img width="482" alt="image" src="https://github.com/user-attachments/assets/e8534bd0-af69-46e1-9276-9d490e698df4" />

### Testing

The teams database in this page has a "Gallery" view with cover images:
https://www.notion.so/framer/Plugin-Testing-11badf6e8c96804cba51ca8641eb4571

- [x] Add and remove cover images from pages and re-sync to check that the changes are synced properly.
- [x] Test syncing with the Cover field enabled and disabled.