### PR TITLE
Notion: sync phone number property

### DIFF
--- a/plugins/notion/src/api.ts
+++ b/plugins/notion/src/api.ts
@@ -65,6 +65,7 @@ export const supportedCMSTypeByNotionPropertyType = {
     status: ["enum"],
     url: ["link"],
     email: ["formattedText", "string"],
+    phone_number: ["string", "link"],
     files: ["file", "image"],
     relation: ["multiCollectionReference"],
 } satisfies Partial<Record<NotionProperty["type"], ReadonlyArray<ManagedCollectionField["type"]>>>

--- a/plugins/notion/src/data.ts
+++ b/plugins/notion/src/data.ts
@@ -419,6 +419,17 @@ export function getFieldDataEntryForProperty(
 
             return { type: field.type, value: property.email ?? "" }
         }
+        case "phone_number": {
+            if (field.type !== "string" && field.type !== "link") return null
+
+            const phoneNumber = property.phone_number ?? ""
+
+            if (field.type === "link") {
+                return { type: "link", value: phoneNumber ? `tel:${phoneNumber}` : null }
+            }
+
+            return { type: "string", value: phoneNumber }
+        }
     }
 
     return null


### PR DESCRIPTION
### Description

This pull request adds support for syncing the phone number property type from Notion. Previously, phone number properties were marked as "unsupported".

Phone numbers can be imported as string or link ("tel:" link).

### Testing

The "Kitchen Sink" database has a phone number property:
https://www.notion.so/framer/Plugin-Testing-11badf6e8c96804cba51ca8641eb4571

- [ ] Sync a Notion database with a phone number property
- [ ] Test the Plain Text and Link types.
- [ ] Add and remove values in Notion and re-sync the collection
