### PR TITLE
Notion: add Unique ID property support

### DIFF
--- a/plugins/notion/src/api.ts
+++ b/plugins/notion/src/api.ts
@@ -62,7 +62,7 @@ export const pageCoverProperty: FieldInfo = {
 }
 
 // The valid field types that can be used as a slug, in order of preference
-const slugFieldTypes: NotionProperty["type"][] = ["title", "rich_text"]
+const slugFieldTypes: NotionProperty["type"][] = ["title", "rich_text", "unique_id"]
 
 export const supportedCMSTypeByNotionPropertyType = {
     checkbox: ["boolean"],
@@ -79,6 +79,7 @@ export const supportedCMSTypeByNotionPropertyType = {
     phone_number: ["string", "link"],
     files: ["file", "image"],
     relation: ["multiCollectionReference"],
+    unique_id: ["string", "number"],
 } satisfies Partial<Record<NotionProperty["type"], ReadonlyArray<ManagedCollectionField["type"]>>>
 
 // Naive implementation to be authenticated, a token could be expired.
@@ -256,6 +257,10 @@ export function getSlugValue(property: PageObjectResponse["properties"][string])
             return richTextToPlainText(property.title)
         case "rich_text":
             return richTextToPlainText(property.rich_text)
+        case "unique_id":
+            return property.unique_id.prefix
+                ? `${property.unique_id.prefix}-${property.unique_id.number}`
+                : String(property.unique_id.number)
         default:
             return null
     }

--- a/plugins/notion/src/data.ts
+++ b/plugins/notion/src/data.ts
@@ -423,7 +423,18 @@ export function getFieldDataEntryForProperty(
             return { type: "link", value: property.url ?? "" }
         }
         case "unique_id": {
-            return { type: "string", value: property.unique_id.number?.toString() ?? "" }
+            if (field.type !== "string" && field.type !== "number") return null
+
+            if (field.type === "string") {
+                return {
+                    type: "string",
+                    value: property.unique_id.prefix
+                        ? `${property.unique_id.prefix}-${property.unique_id.number}`
+                        : String(property.unique_id.number),
+                }
+            }
+
+            return { type: "number", value: property.unique_id.number ?? 0 }
         }
         case "date": {
             return { type: "date", value: property.date?.start ?? null }


### PR DESCRIPTION
### Description

This pull request adds support for syncing the Unique ID property type from Notion databases.

### Testing

This database has a Unique ID property:
https://www.notion.so/framer/224adf6e8c9680eca17fda0e00267005?v=224adf6e8c9680899fb5000c4fa462a1

- [x] Test changing the prefix of the ID property in Notion.
- [x] Test switching between string and number types.
- [x] Test using the ID property as the slug field.