### PR TITLE
Notion: add color fields

### DIFF
--- a/plugins/notion/src/api.ts
+++ b/plugins/notion/src/api.ts
@@ -58,7 +58,7 @@ export const supportedCMSTypeByNotionPropertyType = {
     date: ["date"],
     number: ["number"],
     title: ["string"],
-    rich_text: ["formattedText", "string"],
+    rich_text: ["formattedText", "string", "color"],
     created_time: ["date"],
     last_edited_time: ["date"],
     select: ["enum"],

--- a/plugins/notion/src/data.ts
+++ b/plugins/notion/src/data.ts
@@ -257,7 +257,8 @@ export async function fieldsInfoToCollectionFields(
             case "string":
             case "formattedText":
             case "link":
-            case "image": {
+            case "image":
+            case "color": {
                 assertFieldTypeMatchesPropertyType(property.type, fieldType)
                 fields.push({
                     type: fieldType,
@@ -354,6 +355,8 @@ export function getFieldDataEntryForProperty(
         case "rich_text": {
             if (field.type === "formattedText") {
                 return { type: "formattedText", value: richTextToHtml(property.rich_text) }
+            } else if (field.type === "color") {
+                return { type: "color", value: richTextToPlainText(property.rich_text) || null }
             }
 
             return { type: "string", value: richTextToPlainText(property.rich_text) }


### PR DESCRIPTION
### Description

This pull request adds support for importing colors from Notion databases. Notion does not have a color property type, so instead you can use a regular text property and write colors in hex, rgb, rgba, hsl etc. format and choose to import them as colors in Framer.

<img width="213" alt="image" src="https://github.com/user-attachments/assets/39cedc17-46f7-4620-9da7-b9f5870243ec" />
<img width="86" alt="image" src="https://github.com/user-attachments/assets/d3dfac10-1bd1-4367-8199-cd9bcf291f53" />
<br>
<img width="435" alt="image" src="https://github.com/user-attachments/assets/ea8ff6bd-0aca-42da-a8ea-ed1553cd7e7b" />



### Testing

This Notion database has a text property named "Color"
https://www.notion.so/framer/224adf6e8c9680eca17fda0e00267005?v=224adf6e8c9680899fb5000c4fa462a1

- [ ] Change the field type of a text field to "Color"
- [ ] Test adding colors in different formats such as hex, rgb and rgba.
- [ ] Test empty color values, which import into Framer as the default color #0099FF