### PR TITLE
Unsplash: allow resizing the plugin window

### DIFF
--- a/plugins/unsplash/src/App.tsx
+++ b/plugins/unsplash/src/App.tsx
@@ -28,8 +28,9 @@ void framer.showUI({
     position: "top right",
     width: minWindowWidth,
     minWidth: minWindowWidth,
+    maxWidth: 750,
     minHeight: 400,
-    resizable: false,
+    resizable: true,
 })
 
 export function App() {

--- a/plugins/unsplash/src/App.tsx
+++ b/plugins/unsplash/src/App.tsx
@@ -23,6 +23,7 @@ const minWindowWidth = mode === "canvas" ? 260 : 600
 const minColumnWidth = 100
 const columnGap = 5
 const sidePadding = 15 * 2
+const resizable = framer.mode === "canvas"
 
 void framer.showUI({
     position: "top right",
@@ -30,7 +31,7 @@ void framer.showUI({
     minWidth: minWindowWidth,
     maxWidth: 750,
     minHeight: 400,
-    resizable: true,
+    resizable,
 })
 
 export function App() {


### PR DESCRIPTION
### Description

This pull request adds support for resizing the Unsplash plugin window to see more images at a time and larger previews - useful for Framer users with large screens.

The default/min width and height are the same, and there's a max width of 750 which is 6 columns.

<img width="436" alt="image" src="https://github.com/user-attachments/assets/9aa99d2e-45f8-4c76-9648-fdad5072a5b3" />
<img width="292" alt="image" src="https://github.com/user-attachments/assets/5f28b380-c5e9-45d4-a386-bc4c3c43ca5b" />


### Testing

- [ ] Resize the Unsplash plugin in canvas mode.