### PR TITLE
Unsplash: add alt text + fix drag and drop

### DIFF
--- a/plugins/unsplash/src/App.tsx
+++ b/plugins/unsplash/src/App.tsx
@@ -354,8 +354,8 @@ const Placeholders = ({ index }: { index: number }) => {
     const heights = placeholderHeights[index % placeholderHeights.length]
     if (!heights) return null
 
-    return heights.map(height => (
-        <div key={height} className="animate-pulse">
+    return heights.map((height, heightIndex) => (
+        <div key={heightIndex} className="animate-pulse">
             <div className="bg-secondary rounded-md" style={{ height }} />
             <div className="mt-1 bg-secondary rounded-md h-[8px]" />
         </div>

--- a/plugins/unsplash/src/App.tsx
+++ b/plugins/unsplash/src/App.tsx
@@ -275,6 +275,7 @@ const GridItem = memo(function GridItem({
                     type: "image",
                     image: photo.urls.full,
                     previewImage: photo.urls.thumb,
+                    name: photo.alt_description ?? photo.description ?? "Unsplash Image",
                     altText: photo.alt_description ?? photo.description ?? undefined,
                 }}
             >

--- a/plugins/unsplash/src/App.tsx
+++ b/plugins/unsplash/src/App.tsx
@@ -48,6 +48,7 @@ export function App() {
                 await framer.addImage({
                     image: randomPhoto.urls.full,
                     name: randomPhoto.alt_description ?? randomPhoto.description ?? "Unsplash Image",
+                    altText: randomPhoto.alt_description ?? randomPhoto.description ?? undefined,
                 })
                 return
             }
@@ -55,6 +56,7 @@ export function App() {
             await framer.setImage({
                 image: randomPhoto.urls.full,
                 name: randomPhoto.alt_description ?? randomPhoto.description ?? "Unsplash Image",
+                altText: randomPhoto.alt_description ?? randomPhoto.description ?? undefined,
             })
 
             await framer.closePlugin()

--- a/plugins/unsplash/src/App.tsx
+++ b/plugins/unsplash/src/App.tsx
@@ -125,6 +125,7 @@ const PhotosList = memo(function PhotosList({ query }: { query: string }) {
                 await framer.addImage({
                     image: photo.urls.full,
                     name: photo.alt_description ?? photo.description ?? "Unsplash Image",
+                    altText: photo.alt_description ?? photo.description ?? undefined,
                 })
 
                 return
@@ -133,6 +134,7 @@ const PhotosList = memo(function PhotosList({ query }: { query: string }) {
             await framer.setImage({
                 image: photo.urls.full,
                 name: photo.alt_description ?? photo.description ?? "Unsplash Image",
+                altText: photo.alt_description ?? photo.description ?? undefined,
             })
 
             await framer.closePlugin()
@@ -268,26 +270,27 @@ const GridItem = memo(function GridItem({
 
     return (
         <div key={photo.id} className="flex flex-col gap-[5px]">
-            <button
-                onClick={() => {
-                    if (!isAllowedToUpsertImage) return
-                    handleClick()
+            <Draggable
+                data={{
+                    type: "image",
+                    image: photo.urls.full,
+                    previewImage: photo.urls.thumb,
+                    altText: photo.alt_description ?? photo.description ?? undefined,
                 }}
-                className="cursor-pointer bg-cover relative rounded-lg"
-                style={{
-                    height,
-                    backgroundImage: `url(${photo.urls.thumb})`,
-                    backgroundColor: photo.color,
-                }}
-                disabled={!isAllowedToUpsertImage}
-                title={isAllowedToUpsertImage ? undefined : "Insufficient permissions"}
             >
-                <Draggable
-                    data={{
-                        type: "image",
-                        image: photo.urls.full,
-                        previewImage: photo.urls.thumb,
+                <button
+                    onClick={() => {
+                        if (!isAllowedToUpsertImage) return
+                        handleClick()
                     }}
+                    className="cursor-pointer bg-cover relative rounded-lg"
+                    style={{
+                        height,
+                        backgroundImage: `url(${photo.urls.thumb})`,
+                        backgroundColor: photo.color,
+                    }}
+                    disabled={!isAllowedToUpsertImage}
+                    title={isAllowedToUpsertImage ? undefined : "Insufficient permissions"}
                 >
                     <>
                         <div
@@ -304,8 +307,8 @@ const GridItem = memo(function GridItem({
                             </div>
                         )}
                     </>
-                </Draggable>
-            </button>
+                </button>
+            </Draggable>
             <a
                 target="_blank"
                 href={photo.user.links.html}


### PR DESCRIPTION
### Description

This pull request adds two improvements to the Unsplash plugin:
* Fixes drag-and-drop. It already uses the `<Draggable>` component, but it doesn't work because it's nested inside a `<button>`. This PR moves the `<Draggable>` outside the button, making drag-and-drop work again.
* Adds alt text to the inserted images.
* Fixes a React duplicate key error in Placeholders.

### Testing

- [x] Try dragging an image in the production version of Unsplash and in this version.
- [x] Check the alt text of images after inserting.

### Notes
Alt text on drag and drop images does not work because of this bug: https://github.com/framer/plugins/issues/284
However the correct `altText` attribute has been added to Draggable in this PR, so it will work once that's fixed.