### PR TITLE
Remove <meta name="plugin-modes"> from all plugins

### DIFF
--- a/plugins/ascii/index.html
+++ b/plugins/ascii/index.html
@@ -4,7 +4,6 @@
         <meta charset="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/framer.svg" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta name="plugin-modes" content="default, image, editImage" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link

--- a/plugins/dither/index.html
+++ b/plugins/dither/index.html
@@ -4,7 +4,6 @@
         <meta charset="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/framer.svg" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta name="plugin-modes" content="default, image, editImage" />
         <title>Dither</title>
     </head>
     <body>

--- a/plugins/flip-image/index.html
+++ b/plugins/flip-image/index.html
@@ -4,7 +4,6 @@
         <meta charset="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/framer.svg" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta name="plugin-modes" content="default, editImage" />
         <title>Flip Image</title>
     </head>
     <body>

--- a/plugins/photobooth/index.html
+++ b/plugins/photobooth/index.html
@@ -4,7 +4,6 @@
         <meta charset="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/framer.svg" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta name="plugin-modes" content="default, image" />
         <title>Photobooth</title>
     </head>
     <body>

--- a/plugins/threshold/index.html
+++ b/plugins/threshold/index.html
@@ -4,7 +4,6 @@
         <meta charset="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/framer.svg" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta name="plugin-modes" content="default, image, editImage" />
         <title>Threshold</title>
     </head>
     <body>

--- a/plugins/unsplash/index.html
+++ b/plugins/unsplash/index.html
@@ -4,7 +4,6 @@
         <meta charset="UTF-8" />
         <link rel="icon" type="image/png" href="/Unsplash.png" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta name="plugin-modes" content="default, image, editImage" />
         <title>Unsplash</title>
     </head>
     <body>


### PR DESCRIPTION
### Description

This pull request removes `<meta name="plugin-modes">` from all plugins. It's a leftover from before `framer.json` existed.

https://framer-team.slack.com/archives/C06L5H5ADK2/p1751675452821369