### PR TITLE
Code Versions: Fix bug of AbortController not being called

### DIFF
--- a/plugins/code-versions/src/hooks/useCodeFileVersions.ts
+++ b/plugins/code-versions/src/hooks/useCodeFileVersions.ts
@@ -46,8 +46,9 @@ export function useCodeFileVersions(): CodeFileVersionsState {
 
         // Cleanup function
         return () => {
+            abortController.abort()
+            // Only clear the ref if it still points to this controller
             if (versionsAbortControllerRef.current === abortController) {
-                abortController.abort()
                 versionsAbortControllerRef.current = null
             }
         }
@@ -71,8 +72,9 @@ export function useCodeFileVersions(): CodeFileVersionsState {
 
         // Cleanup function
         return () => {
+            abortController.abort()
+            // Only clear the ref if it still points to this controller
             if (contentAbortControllerRef.current === abortController) {
-                abortController.abort()
                 contentAbortControllerRef.current = null
             }
         }


### PR DESCRIPTION
### Description

This fixes a bug where the abort controllers weren't reliably called.
Fixed this by always call the controller (duh!).

### Testing

- [ ] Switching between versions really fast doesn't mix up requests
  - [ ] Click on different versions fast
  - [ ] when stoped, you see the right version in the code view

---

## 🤖 ✍️ :

This pull request includes small but important updates to the cleanup logic in the `useCodeFileVersions` hook. The changes ensure that the abort controller references are cleared only if they still point to the current controller.

Cleanup logic improvements:

* [`plugins/code-versions/src/hooks/useCodeFileVersions.ts`](diffhunk://#diff-e2190c4e93762e21ff0375b730e5b11f4ab8f5ac844ec19de235514319c3d154L49-R51): Updated the cleanup logic for `versionsAbortControllerRef` to clear the reference only if it still points to the current abort controller.
* [`plugins/code-versions/src/hooks/useCodeFileVersions.ts`](diffhunk://#diff-e2190c4e93762e21ff0375b730e5b11f4ab8f5ac844ec19de235514319c3d154L74-R77): Updated the cleanup logic for `contentAbortControllerRef` to clear the reference only if it still points to the current abort controller.