### PR TITLE
Code Versions: Fade in after load

### DIFF
--- a/plugins/code-versions/src/App.tsx
+++ b/plugins/code-versions/src/App.tsx
@@ -12,7 +12,7 @@ export default function App() {
             minWidth: 600,
             minHeight: 360,
             resizable: true,
-            position: "bottom right",
+            position: "center",
         })
     }, [])
 

--- a/plugins/code-versions/src/App.tsx
+++ b/plugins/code-versions/src/App.tsx
@@ -3,6 +3,8 @@ import { useEffect } from "react"
 import CodeFileView from "./components/CodeFileView"
 import { MutationState, useCodeFileVersions } from "./hooks/useCodeFileVersions"
 import { StatusTypes, useSelectedCodeFile } from "./hooks/useSelectedCodeFile"
+import { cn } from "./utils"
+import { fadeInAnimationClassName } from "./utils/shared-styles"
 
 export default function App() {
     useEffect(() => {
@@ -126,7 +128,12 @@ export default function App() {
 
 function EmptyState() {
     return (
-        <div className="flex flex-col items-center justify-center h-full space-y-3">
+        <div
+            className={cn(
+                "flex flex-col items-center justify-center space-y-3 h-screen w-screen",
+                fadeInAnimationClassName
+            )}
+        >
             <img src="/logo.svg" className="rounded-lg" />
 
             <div className="space-y-2 text-center max-w-36">

--- a/plugins/code-versions/src/components/CodeFileView.tsx
+++ b/plugins/code-versions/src/components/CodeFileView.tsx
@@ -27,7 +27,6 @@ export default function CodeFileView({ state, selectVersion, restoreVersion }: C
                 versions={state.versions}
                 selectedId={state.selectedVersionId}
                 onSelect={selectVersion}
-                isLoading={state.versionsLoading === LoadingState.Initial}
             />
             <div className="bg-code-area-light dark:bg-code-area-dark overflow-y-auto relative scrollbar-hidden">
                 <div className="absolute inset-0 ms-3 me-4 mt-3">

--- a/plugins/code-versions/src/components/CurrentCode.tsx
+++ b/plugins/code-versions/src/components/CurrentCode.tsx
@@ -5,6 +5,8 @@ import "prismjs/components/prism-jsx"
 import "prismjs/components/prism-tsx"
 import "prismjs/plugins/line-numbers/prism-line-numbers"
 import "./CurrentCode.css"
+import { cn } from "../utils"
+import { fadeInAnimationClassName } from "../utils/shared-styles"
 
 interface CurrentCodeProps {
     code: string
@@ -24,7 +26,7 @@ export default function CurrentCode({ code }: CurrentCodeProps) {
     }, [code])
 
     return (
-        <div className="current-code line-numbers">
+        <div className={cn("current-code line-numbers", fadeInAnimationClassName)}>
             <pre className="font-mono text-code-size">
                 <code ref={codeRef} className="language-tsx">
                     {code}

--- a/plugins/code-versions/src/components/FileDiff.tsx
+++ b/plugins/code-versions/src/components/FileDiff.tsx
@@ -2,6 +2,7 @@ import { match, P } from "ts-pattern"
 import { cn } from "../utils"
 import { getLineDiffWithEdges } from "../utils/diff/line-diff"
 import type { InlineDiff, LineDiff } from "../utils/diff/types"
+import { fadeInAnimationClassName } from "../utils/shared-styles"
 
 interface FileDiffProps {
     original: string
@@ -23,7 +24,9 @@ export default function FileDiff({ original, revised }: FileDiffProps) {
     )
 
     return (
-        <table className="font-mono text-[11px] border-separate border-spacing-0 w-full">
+        <table
+            className={cn("font-mono text-[11px] border-separate border-spacing-0 w-full ", fadeInAnimationClassName)}
+        >
             <tbody>{rows}</tbody>
         </table>
     )

--- a/plugins/code-versions/src/components/VersionsSidebar.tsx
+++ b/plugins/code-versions/src/components/VersionsSidebar.tsx
@@ -69,7 +69,6 @@ export default function VersionsSidebar({
     versions,
     selectedId,
     onSelect,
-    isLoading,
 }: VersionsListProps & {
     className?: string
 }) {
@@ -82,7 +81,7 @@ export default function VersionsSidebar({
                 className
             )}
         >
-            <VersionsList versions={versions} selectedId={selectedId} onSelect={onSelect} isLoading={isLoading} />
+            <VersionsList versions={versions} selectedId={selectedId} onSelect={onSelect} />
         </aside>
     )
 }
@@ -91,11 +90,10 @@ interface VersionsListProps {
     versions: readonly CodeFileVersion[]
     selectedId: string | undefined
     onSelect: (id: string) => void
-    isLoading: boolean
 }
 
-function VersionsList({ versions, selectedId, onSelect, isLoading }: VersionsListProps) {
-    if (isLoading) return null
+function VersionsList({ versions, selectedId, onSelect }: VersionsListProps) {
+    if (versions.length === 0) return null
 
     const [currentVersion, ...historicalVersions] = versions
 

--- a/plugins/code-versions/src/components/VersionsSidebar.tsx
+++ b/plugins/code-versions/src/components/VersionsSidebar.tsx
@@ -1,7 +1,7 @@
 import type { CodeFileVersion } from "framer-plugin"
 import { useMemo } from "react"
-
 import { cn } from "../utils"
+import { fadeInAnimationClassName } from "../utils/shared-styles"
 import { FormatFromNow } from "./FormatFromNow"
 
 interface VersionProps {
@@ -70,47 +70,57 @@ export default function VersionsSidebar({
     selectedId,
     onSelect,
     isLoading,
-}: {
+}: VersionsListProps & {
     className?: string
-    versions: readonly CodeFileVersion[]
-    selectedId?: string
-    onSelect: (id: string) => void
-    isLoading?: boolean
 }) {
-    const [currentVersion, ...historicalVersions] = versions
-
     return (
         <aside
             className={cn(
                 "relative flex flex-col h-full border-r border-framer-divider",
                 "after:absolute after:inset-x-0 w-versions after:bottom-0 after:h-6 after:pointer-events-none after:bg-gradient-to-t after:from-framer-bg-base after:to-transparent",
+
                 className
             )}
         >
-            {isLoading ? null : (
-                <>
-                    {currentVersion && (
-                        <div className="px-3 pt-3 space-y-3">
-                            <CurrentVersion
-                                version={currentVersion}
-                                isSelected={currentVersion.id === selectedId}
-                                onSelect={onSelect}
-                            />
-                            <hr className="h-px bg-framer-divider w-full" />
-                        </div>
-                    )}
-                    <div className="overflow-y-auto h-full flex-1 px-3 pt-3 scrollbar-hidden">
-                        {historicalVersions.map(version => (
-                            <HistoricalVersion
-                                key={version.id}
-                                version={version}
-                                isSelected={version.id === selectedId}
-                                onSelect={onSelect}
-                            />
-                        ))}
-                    </div>
-                </>
-            )}
+            <VersionsList versions={versions} selectedId={selectedId} onSelect={onSelect} isLoading={isLoading} />
         </aside>
+    )
+}
+
+interface VersionsListProps {
+    versions: readonly CodeFileVersion[]
+    selectedId: string | undefined
+    onSelect: (id: string) => void
+    isLoading: boolean
+}
+
+function VersionsList({ versions, selectedId, onSelect, isLoading }: VersionsListProps) {
+    if (isLoading) return null
+
+    const [currentVersion, ...historicalVersions] = versions
+
+    return (
+        <div className={fadeInAnimationClassName}>
+            {currentVersion && (
+                <div className="px-3 pt-3 space-y-3">
+                    <CurrentVersion
+                        version={currentVersion}
+                        isSelected={currentVersion.id === selectedId}
+                        onSelect={onSelect}
+                    />
+                    <hr className="h-px bg-framer-divider w-full" />
+                </div>
+            )}
+            <div className="overflow-y-auto h-full flex-1 px-3 pt-3 scrollbar-hidden">
+                {historicalVersions.map(version => (
+                    <HistoricalVersion
+                        key={version.id}
+                        version={version}
+                        isSelected={version.id === selectedId}
+                        onSelect={onSelect}
+                    />
+                ))}
+            </div>
+        </div>
     )
 }

--- a/plugins/code-versions/src/hooks/useCodeFileVersions.ts
+++ b/plugins/code-versions/src/hooks/useCodeFileVersions.ts
@@ -46,8 +46,9 @@ export function useCodeFileVersions(): CodeFileVersionsState {
 
         // Cleanup function
         return () => {
+            abortController.abort()
+            // Only clear the ref if it still points to this controller
             if (versionsAbortControllerRef.current === abortController) {
-                abortController.abort()
                 versionsAbortControllerRef.current = null
             }
         }
@@ -71,8 +72,9 @@ export function useCodeFileVersions(): CodeFileVersionsState {
 
         // Cleanup function
         return () => {
+            abortController.abort()
+            // Only clear the ref if it still points to this controller
             if (contentAbortControllerRef.current === abortController) {
-                abortController.abort()
                 contentAbortControllerRef.current = null
             }
         }

--- a/plugins/code-versions/src/hooks/useCodeFileVersions.ts
+++ b/plugins/code-versions/src/hooks/useCodeFileVersions.ts
@@ -109,7 +109,6 @@ export function useCodeFileVersions(): CodeFileVersionsState {
             versions: state.versions,
             selectedVersionId: state.selectedVersionId,
             versionContent: state.versionContent,
-            versionsLoading: state.versionsLoading,
             contentLoading: state.contentLoading,
             restoreLoading: state.restoreLoading,
             restoreCompleted: state.restoreCompleted,
@@ -164,7 +163,6 @@ interface VersionsState {
     versions: readonly CodeFileVersion[]
     selectedVersionId: string | undefined
     versionContent: string | undefined
-    versionsLoading: LoadingState
     contentLoading: LoadingState
     restoreLoading: MutationState
     restoreCompleted: boolean
@@ -213,7 +211,6 @@ function versionsReducer(state: VersionsState, action: VersionsAction): Versions
                     versions: [],
                     selectedVersionId: undefined,
                     versionContent: undefined,
-                    versionsLoading: LoadingState.Initial,
                     contentLoading: LoadingState.Initial,
                     restoreLoading: MutationState.Idle,
                     errors: {},
@@ -228,13 +225,11 @@ function versionsReducer(state: VersionsState, action: VersionsAction): Versions
         })
         .with({ type: VersionsActionType.VersionsLoadStarted }, () => ({
             ...state,
-            versionsLoading: state.versions.length === 0 ? LoadingState.Initial : LoadingState.Refreshing,
             errors: { ...state.errors, versions: undefined },
         }))
         .with({ type: VersionsActionType.VersionsLoaded }, ({ payload }) => ({
             ...state,
             versions: payload.versions,
-            versionsLoading: LoadingState.Idle,
             selectedVersionId: !state.selectedVersionId
                 ? getDefaultSelectedVersionId(payload.versions)
                 : state.selectedVersionId,
@@ -259,7 +254,6 @@ function versionsReducer(state: VersionsState, action: VersionsAction): Versions
         }))
         .with({ type: VersionsActionType.VersionsError }, ({ payload }) => ({
             ...state,
-            versionsLoading: LoadingState.Idle,
             errors: { ...state.errors, versions: payload.error },
         }))
         .with({ type: VersionsActionType.ContentError }, ({ payload }) => ({
@@ -289,7 +283,6 @@ function versionsReducer(state: VersionsState, action: VersionsAction): Versions
         .with({ type: VersionsActionType.StateResetCompleted }, () => initialState)
         .with({ type: VersionsActionType.OperationCancelled }, ({ payload }) => ({
             ...state,
-            versionsLoading: payload.operation === "versions" ? LoadingState.Idle : state.versionsLoading,
             contentLoading: payload.operation === "content" ? LoadingState.Idle : state.contentLoading,
         }))
         .exhaustive()
@@ -367,7 +360,6 @@ const initialState: VersionsState = {
     versions: [],
     selectedVersionId: undefined,
     versionContent: undefined,
-    versionsLoading: LoadingState.Idle,
     contentLoading: LoadingState.Idle,
     restoreLoading: MutationState.Idle,
     restoreCompleted: false,

--- a/plugins/code-versions/src/styles.css
+++ b/plugins/code-versions/src/styles.css
@@ -80,3 +80,14 @@
         display: none;
     }
 }
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        animation-timing-function: bezier(0.5, 0, 0.5, 1);
+    }
+    to {
+        opacity: 1;
+        animation-timing-function: bezier(0.5, 0, 0.5, 1);
+    }
+}

--- a/plugins/code-versions/src/utils/shared-styles.ts
+++ b/plugins/code-versions/src/utils/shared-styles.ts
@@ -1,0 +1,8 @@
+import { cn } from "../utils"
+
+/**
+ * One-time fade in animation that runs only once when the element is first rendered
+ *
+ * The animation starts with opacity 0 and animates to opacity 1 over 150ms
+ */
+export const fadeInAnimationClassName = cn("animate-[fadeIn_150ms_forwards]")


### PR DESCRIPTION
### Description

This introduces loading animation and also includes #287

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Switching between versions really fast doesn't mix up requests
  - [x] Click on different versions fast
  - [x] when stoped, you see the right version in the code view
- [x] Versions fade in (after switching components)
- [x] Code fades in after selecting a version
- [x] Empty State fade in