### PR TITLE
Code Files: UI fixes and DRY styles

### DIFF
--- a/plugins/code-versions/src/App.tsx
+++ b/plugins/code-versions/src/App.tsx
@@ -3,8 +3,6 @@ import { useEffect } from "react"
 import CodeFileView from "./components/CodeFileView"
 import { MutationState, useCodeFileVersions } from "./hooks/useCodeFileVersions"
 import { StatusTypes, useSelectedCodeFile } from "./hooks/useSelectedCodeFile"
-import { cn } from "./utils"
-import { fadeInAnimationClassName } from "./utils/shared-styles"
 
 export default function App() {
     useEffect(() => {
@@ -128,12 +126,7 @@ export default function App() {
 
 function EmptyState() {
     return (
-        <div
-            className={cn(
-                "flex flex-col items-center justify-center space-y-3 h-screen w-screen",
-                fadeInAnimationClassName
-            )}
-        >
+        <div className="flex flex-col items-center justify-center space-y-3 h-screen w-screen animate-(--fade-in-animation)">
             <img src="/logo.svg" className="rounded-lg" />
 
             <div className="space-y-2 text-center max-w-36">

--- a/plugins/code-versions/src/components/CurrentCode.tsx
+++ b/plugins/code-versions/src/components/CurrentCode.tsx
@@ -5,8 +5,6 @@ import "prismjs/components/prism-jsx"
 import "prismjs/components/prism-tsx"
 import "prismjs/plugins/line-numbers/prism-line-numbers"
 import "./CurrentCode.css"
-import { cn } from "../utils"
-import { fadeInAnimationClassName } from "../utils/shared-styles"
 
 interface CurrentCodeProps {
     code: string
@@ -26,7 +24,7 @@ export default function CurrentCode({ code }: CurrentCodeProps) {
     }, [code])
 
     return (
-        <div className={cn("current-code line-numbers", fadeInAnimationClassName)}>
+        <div className="current-code line-numbers animate-(--fade-in-animation)">
             <pre className="font-mono text-code">
                 <code ref={codeRef} className="language-tsx">
                     {code}

--- a/plugins/code-versions/src/components/CurrentCode.tsx
+++ b/plugins/code-versions/src/components/CurrentCode.tsx
@@ -27,7 +27,7 @@ export default function CurrentCode({ code }: CurrentCodeProps) {
 
     return (
         <div className={cn("current-code line-numbers", fadeInAnimationClassName)}>
-            <pre className="font-mono text-code-size">
+            <pre className="font-mono text-code">
                 <code ref={codeRef} className="language-tsx">
                     {code}
                 </code>

--- a/plugins/code-versions/src/components/FileDiff.test.tsx
+++ b/plugins/code-versions/src/components/FileDiff.test.tsx
@@ -4,8 +4,8 @@ import FileDiff from "./FileDiff"
 
 const ADDED_CLASS_NAME = "bg-diff-add-bg/10"
 const REMOVED_CLASS_NAME = "bg-diff-remove-bg/10"
-const ADDED_ROW_CLASS_NAME = "bg-gradient-to-r from-transparent from-0% to-[60px] to-diff-add-bg/10"
-const REMOVED_ROW_CLASS_NAME = "bg-gradient-to-r from-transparent from-0% to-[35px] to-diff-remove/10"
+const ADDED_ROW_CLASS_NAME = "to-diff-add-bg/10"
+const REMOVED_ROW_CLASS_NAME = "to-diff-remove/10"
 
 describe("FileDiff", () => {
     describe("when content is identical", () => {

--- a/plugins/code-versions/src/components/FileDiff.tsx
+++ b/plugins/code-versions/src/components/FileDiff.tsx
@@ -24,9 +24,7 @@ export default function FileDiff({ original, revised }: FileDiffProps) {
     )
 
     return (
-        <table
-            className={cn("font-mono text-[11px] border-separate border-spacing-0 w-full ", fadeInAnimationClassName)}
-        >
+        <table className={cn("font-mono text-code border-separate border-spacing-0 w-full ", fadeInAnimationClassName)}>
             <tbody>{rows}</tbody>
         </table>
     )
@@ -45,7 +43,7 @@ function ChangeRow({ line }: { line: LineDiff & { type: "change" } }) {
                     <InlineDiffs parts={line.inlineDiffs} type="remove" />
                 </ContentCell>
             </tr>
-            <tr className="bg-gradient-to-r from-transparent from-0% to-[60px] to-diff-add-bg/10  h-(--code-row-height) leading-(--code-row-height)">
+            <tr className="bg-gradient-to-r from-transparent from-0% to-[35px] to-diff-add-bg/10  h-(--code-row-height) leading-(--code-row-height)">
                 <LineNumberCell variant="context" lineNumber={undefined} className={addBorderClass} />
                 <LineNumberCell variant="add" lineNumber={line.newLine} className={cn("ms-1", addBorderClass)} />
                 <ContentCell className={cn("text-diff-add dark:text-diff-add", addBorderClass)}>
@@ -70,7 +68,7 @@ function AddRow({ line }: { line: LineDiff & { type: "add" } }) {
     const borderClass = getEdgeBorderClass("add", line.isTopEdge, line.isBottomEdge)
 
     return (
-        <tr className="bg-gradient-to-r from-transparent from-0% to-[60px] to-diff-add-bg/10  h-(--code-row-height) leading-(--code-row-height)">
+        <tr className="bg-gradient-to-r from-transparent from-0% to-[35px] to-diff-add-bg/10  h-(--code-row-height) leading-(--code-row-height)">
             <td className={borderClass} />
             <LineNumberCell variant="add" lineNumber={line.newLine} className={borderClass} />
             <ContentCell className={cn("text-diff-add dark:text-diff-add", borderClass)}>{line.content}</ContentCell>
@@ -139,7 +137,7 @@ function LineNumberCell({
 }
 
 function ContentCell({ children, className }: { children: React.ReactNode; className?: string }) {
-    return <td className={cn("whitespace-pre text-[#666666] dark:text-[#EEEEEE] w-full", className)}>{children}</td>
+    return <td className={cn("whitespace-pre text-code-primary w-full", className)}>{children}</td>
 }
 
 function getEdgeBorderClass(type: "add" | "remove", isTopEdge = false, isBottomEdge = false): string {

--- a/plugins/code-versions/src/components/FileDiff.tsx
+++ b/plugins/code-versions/src/components/FileDiff.tsx
@@ -2,7 +2,6 @@ import { match, P } from "ts-pattern"
 import { cn } from "../utils"
 import { getLineDiffWithEdges } from "../utils/diff/line-diff"
 import type { InlineDiff, LineDiff } from "../utils/diff/types"
-import { fadeInAnimationClassName } from "../utils/shared-styles"
 
 interface FileDiffProps {
     original: string
@@ -24,7 +23,7 @@ export default function FileDiff({ original, revised }: FileDiffProps) {
     )
 
     return (
-        <table className={cn("font-mono text-code border-separate border-spacing-0 w-full ", fadeInAnimationClassName)}>
+        <table className="font-mono text-code border-separate border-spacing-0 w-full animate-(--fade-in-animation)">
             <tbody>{rows}</tbody>
         </table>
     )

--- a/plugins/code-versions/src/components/VersionsSidebar.tsx
+++ b/plugins/code-versions/src/components/VersionsSidebar.tsx
@@ -1,7 +1,6 @@
 import type { CodeFileVersion } from "framer-plugin"
 import { useMemo } from "react"
 import { cn } from "../utils"
-import { fadeInAnimationClassName } from "../utils/shared-styles"
 import { FormatFromNow } from "./FormatFromNow"
 
 interface VersionProps {
@@ -98,7 +97,7 @@ function VersionsList({ versions, selectedId, onSelect }: VersionsListProps) {
     const [currentVersion, ...historicalVersions] = versions
 
     return (
-        <div className={fadeInAnimationClassName}>
+        <div className="animate-(--fade-in-animation)">
             {currentVersion && (
                 <div className="px-3 pt-3 space-y-3">
                     <CurrentVersion

--- a/plugins/code-versions/src/styles.css
+++ b/plugins/code-versions/src/styles.css
@@ -56,6 +56,7 @@
     --color-selection-bg: light-dark(#0000000f, #ffffff14);
     --color-selection-text: light-dark(#ffffff, #222222);
     --code-row-height: 19px;
+    --text-code: 11px;
 }
 
 @layer base {

--- a/plugins/code-versions/src/styles.css
+++ b/plugins/code-versions/src/styles.css
@@ -40,6 +40,7 @@
 
     /* App specific tokens */
     --width-versions: calc(var(--spacing) * 48);
+    --fade-in-animation: fadeIn 150ms forwards;
 
     /* FileDiff and Code colors */
     --color-code-area-light: #fdfdfd;

--- a/plugins/code-versions/src/utils/shared-styles.ts
+++ b/plugins/code-versions/src/utils/shared-styles.ts
@@ -1,8 +1,0 @@
-import { cn } from "../utils"
-
-/**
- * One-time fade in animation that runs only once when the element is first rendered
- *
- * The animation starts with opacity 0 and animates to opacity 1 over 150ms
- */
-export const fadeInAnimationClassName = cn("animate-[fadeIn_150ms_forwards]")


### PR DESCRIPTION
### Description

- fix selection: no more overlap when selecting multiple lines in current code view
- fix inline diff gradient: The gradients now are the same width

![image](https://github.com/user-attachments/assets/4ccfc763-b20c-467f-b98a-a7964cd10a4d)
![image](https://github.com/user-attachments/assets/25a0308f-2f94-45e7-98e6-b160ed600159)


### Testing

- [ ] When selecting multiple lines in current versions, there is no more "overlap"
- [ ] Line Diff have the same gradient value to become solid
- [ ] Animation still work
  - [ ] Empty Screen
  - [ ] Versions
  - [ ] Current Code
  - [ ] File Diff