### PR TITLE
Code Versions: Versions Sidebar scrolling fixes

### DIFF
--- a/plugins/code-versions/src/components/VersionsSidebar.tsx
+++ b/plugins/code-versions/src/components/VersionsSidebar.tsx
@@ -108,7 +108,7 @@ function VersionsList({ versions, selectedId, onSelect }: VersionsListProps) {
                     <hr className="h-px bg-framer-divider w-full" />
                 </div>
             )}
-            <div className="overflow-y-auto h-full flex-1 px-3 pt-3 scrollbar-hidden">
+            <div className="overflow-y-auto h-full flex-1 px-3 pt-3 scrollbar-hidden pb-6">
                 {historicalVersions.map(version => (
                     <HistoricalVersion
                         key={version.id}

--- a/plugins/code-versions/src/components/VersionsSidebar.tsx
+++ b/plugins/code-versions/src/components/VersionsSidebar.tsx
@@ -97,7 +97,7 @@ function VersionsList({ versions, selectedId, onSelect }: VersionsListProps) {
     const [currentVersion, ...historicalVersions] = versions
 
     return (
-        <div className="animate-(--fade-in-animation)">
+        <div className="animate-(--fade-in-animation) flex flex-col overflow-hidden">
             {currentVersion && (
                 <div className="px-3 pt-3 space-y-3">
                     <CurrentVersion


### PR DESCRIPTION
### Description

<img width="599" alt="image" src="https://github.com/user-attachments/assets/9165d9de-d485-4919-b902-0c0a65cfa090" />

- scrollable historic versions list
- add a little padding to the bottom, so it scrolls out of the "fade out"

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Historic Versions Sidebar scrolls
- [x] Goes out of the "shadow"/fade out
