### PR TITLE
Code Versions: Empty State fade in delay

### DIFF
--- a/plugins/code-versions/src/components/App.tsx
+++ b/plugins/code-versions/src/components/App.tsx
@@ -1,8 +1,9 @@
 import { framer } from "framer-plugin"
 import { useEffect } from "react"
-import CodeFileView from "./components/CodeFileView"
-import { MutationState, useCodeFileVersions } from "./hooks/useCodeFileVersions"
-import { StatusTypes, useSelectedCodeFile } from "./hooks/useSelectedCodeFile"
+import { MutationState, useCodeFileVersions } from "../hooks/useCodeFileVersions"
+import { StatusTypes, useSelectedCodeFile } from "../hooks/useSelectedCodeFile"
+import CodeFileView from "./CodeFileView"
+import { EmptyState } from "./EmptyState"
 
 export default function App() {
     useEffect(() => {
@@ -121,21 +122,6 @@ export default function App() {
                 <CodeFileView state={state} selectVersion={selectVersion} restoreVersion={restoreVersion} />
             </div>
         </Layout>
-    )
-}
-
-function EmptyState() {
-    return (
-        <div className="flex flex-col items-center justify-center space-y-3 h-screen w-screen animate-(--fade-in-animation)">
-            <img src="/logo.svg" className="rounded-lg" />
-
-            <div className="space-y-2 text-center max-w-36">
-                <h2 className="font-semibold text-framer-text-primary text-xs leading-[1.2]">Code Versions</h2>
-                <p className="text-framer-text-tertiary text-xs leading-[1.5]">
-                    Select a Code Component to restore previous versions.
-                </p>
-            </div>
-        </div>
     )
 }
 

--- a/plugins/code-versions/src/components/EmptyState.tsx
+++ b/plugins/code-versions/src/components/EmptyState.tsx
@@ -1,0 +1,14 @@
+export function EmptyState() {
+    return (
+        <div className="flex flex-col items-center justify-center space-y-3 h-screen w-screen animate-(--fade-in-animation)">
+            <img src="/logo.svg" className="rounded-lg" />
+
+            <div className="space-y-2 text-center max-w-36">
+                <h2 className="font-semibold text-framer-text-primary text-xs leading-[1.2]">Code Versions</h2>
+                <p className="text-framer-text-tertiary text-xs leading-[1.5]">
+                    Select a Code Component to restore previous versions.
+                </p>
+            </div>
+        </div>
+    )
+}

--- a/plugins/code-versions/src/components/EmptyState.tsx
+++ b/plugins/code-versions/src/components/EmptyState.tsx
@@ -1,6 +1,6 @@
 export function EmptyState() {
     return (
-        <div className="flex flex-col items-center justify-center space-y-3 h-screen w-screen animate-(--fade-in-animation)">
+        <div className="flex flex-col items-center justify-center space-y-3 h-screen w-screen animate-(--fade-in-animation) animation-delay-200 opacity-0">
             <img src="/logo.svg" className="rounded-lg" />
 
             <div className="space-y-2 text-center max-w-36">

--- a/plugins/code-versions/src/main.tsx
+++ b/plugins/code-versions/src/main.tsx
@@ -3,7 +3,7 @@ import "./styles.css"
 import React from "react"
 import ReactDOM from "react-dom/client"
 
-import App from "./App.tsx"
+import App from "./components/App.tsx"
 
 const root = document.getElementById("root")
 if (!root) throw new Error("Root element not found")

--- a/plugins/code-versions/src/styles.css
+++ b/plugins/code-versions/src/styles.css
@@ -40,7 +40,7 @@
 
     /* App specific tokens */
     --width-versions: calc(var(--spacing) * 48);
-    --fade-in-animation: fadeIn 150ms forwards;
+    --fade-in-animation: 150ms fadeIn forwards;
 
     /* FileDiff and Code colors */
     --color-code-area-light: #fdfdfd;
@@ -58,6 +58,9 @@
     --color-selection-text: light-dark(#ffffff, #222222);
     --code-row-height: 19px;
     --text-code: 11px;
+    --animation-delay-0: 0ms;
+    --animation-delay-100: 100ms;
+    --animation-delay-200: 200ms;
 }
 
 @layer base {
@@ -92,4 +95,8 @@
         opacity: 1;
         animation-timing-function: bezier(0.5, 0, 0.5, 1);
     }
+}
+
+@utility animation-delay-* {
+    animation-delay: --value(--animation-delay-*);
 }

--- a/plugins/code-versions/src/styles.css
+++ b/plugins/code-versions/src/styles.css
@@ -98,5 +98,10 @@
 }
 
 @utility animation-delay-* {
-    animation-delay: --value(--animation-delay-*);
+    /*
+        biome fails currently in `*`
+        as a workaround, escape the * with \* works for now and tailwind handles it correctly as well
+        https://github.com/biomejs/biome/discussions/3195
+     */
+    animation-delay: --value(--animation-delay-\*);
 }


### PR DESCRIPTION
### Description

Adding a little delay before the EmptyState becomes visible, to be sure the iframe has resized to the plugin size already.

- 🧹 refactor the EmptyState into into it's own component, move App into components as well
- 🧰 adding a animation-delay tailwind util
- ⏲️ use the delay in the EmptyState