### PR TITLE
Remove lazy loading of `CurrentCode`

### DIFF
--- a/plugins/code-versions/src/components/CodeFileView.tsx
+++ b/plugins/code-versions/src/components/CodeFileView.tsx
@@ -1,14 +1,12 @@
-import { lazy, Suspense } from "react"
 import {
     type CodeFileVersionsState,
     LoadingState,
     MutationState,
     useCanRestoreVersion,
 } from "../hooks/useCodeFileVersions"
+import CurrentCode from "./CurrentCode"
 import FileDiff from "./FileDiff"
 import VersionsSidebar from "./VersionsSidebar"
-
-const CurrentCode = lazy(() => import("./CurrentCode").then(module => ({ default: module.default })))
 
 interface CodeFileViewProps {
     state: CodeFileVersionsState["state"]
@@ -72,12 +70,7 @@ function Code({
     isCurrentVersion: boolean
 }) {
     if (isCurrentVersion || original === revised) {
-        return (
-            // It will fade in once loaded
-            <Suspense fallback={null}>
-                <CurrentCode code={original} />
-            </Suspense>
-        )
+        return <CurrentCode code={original} />
     }
 
     return <FileDiff original={original} revised={revised} />


### PR DESCRIPTION
### Description

Remove lazy loading a component, as it failed when publishing the plugin

### Testing

- [ ] CurrentCode loading in beta env 