### PR TITLE
Code versions: showUI as early as possible

### DIFF
--- a/plugins/code-versions/src/components/App.tsx
+++ b/plugins/code-versions/src/components/App.tsx
@@ -5,18 +5,16 @@ import { StatusTypes, useSelectedCodeFile } from "../hooks/useSelectedCodeFile"
 import CodeFileView from "./CodeFileView"
 import { EmptyState } from "./EmptyState"
 
-export default function App() {
-    useEffect(() => {
-        framer.showUI({
-            width: 760,
-            height: 480,
-            minWidth: 600,
-            minHeight: 360,
-            resizable: true,
-            position: "center",
-        })
-    }, [])
+framer.showUI({
+    width: 760,
+    height: 480,
+    minWidth: 600,
+    minHeight: 360,
+    resizable: true,
+    position: "center",
+})
 
+export default function App() {
     const { state: fileStatus } = useSelectedCodeFile()
     const { state, selectVersion, restoreVersion, clearErrors } = useCodeFileVersions()
 

--- a/plugins/code-versions/src/components/App.tsx
+++ b/plugins/code-versions/src/components/App.tsx
@@ -5,15 +5,6 @@ import { StatusTypes, useSelectedCodeFile } from "../hooks/useSelectedCodeFile"
 import CodeFileView from "./CodeFileView"
 import { EmptyState } from "./EmptyState"
 
-framer.showUI({
-    width: 760,
-    height: 480,
-    minWidth: 600,
-    minHeight: 360,
-    resizable: true,
-    position: "center",
-})
-
 export default function App() {
     const { state: fileStatus } = useSelectedCodeFile()
     const { state, selectVersion, restoreVersion, clearErrors } = useCodeFileVersions()

--- a/plugins/code-versions/src/components/EmptyState.tsx
+++ b/plugins/code-versions/src/components/EmptyState.tsx
@@ -1,6 +1,6 @@
 export function EmptyState() {
     return (
-        <div className="flex flex-col items-center justify-center space-y-3 h-screen w-screen animate-(--fade-in-animation) animation-delay-200 opacity-0">
+        <div className="flex flex-col items-center justify-center space-y-3 h-screen w-screen animate-(--fade-in-animation) opacity-0">
             <img src="/logo.svg" className="rounded-lg" />
 
             <div className="space-y-2 text-center max-w-36">

--- a/plugins/code-versions/src/components/EmptyState.tsx
+++ b/plugins/code-versions/src/components/EmptyState.tsx
@@ -1,7 +1,7 @@
 export function EmptyState() {
     return (
         <div className="flex flex-col items-center justify-center space-y-3 h-screen w-screen animate-(--fade-in-animation) opacity-0">
-            <img src="/logo.svg" className="rounded-lg" />
+            <img src="/logo.svg" className="rounded-lg size-6" />
 
             <div className="space-y-2 text-center max-w-36">
                 <h2 className="font-semibold text-framer-text-primary text-xs leading-[1.2]">Code Versions</h2>

--- a/plugins/code-versions/src/main.tsx
+++ b/plugins/code-versions/src/main.tsx
@@ -1,12 +1,21 @@
 import "./styles.css"
 
+import { framer } from "framer-plugin"
 import React from "react"
 import ReactDOM from "react-dom/client"
-
 import App from "./components/App.tsx"
 
 const root = document.getElementById("root")
 if (!root) throw new Error("Root element not found")
+
+framer.showUI({
+    width: 760,
+    height: 480,
+    minWidth: 600,
+    minHeight: 360,
+    resizable: true,
+    position: "center",
+})
 
 ReactDOM.createRoot(root).render(
     <React.StrictMode>

--- a/plugins/code-versions/src/styles.css
+++ b/plugins/code-versions/src/styles.css
@@ -58,9 +58,6 @@
     --color-selection-text: light-dark(#ffffff, #222222);
     --code-row-height: 19px;
     --text-code: 11px;
-    --animation-delay-0: 0ms;
-    --animation-delay-100: 100ms;
-    --animation-delay-200: 200ms;
 }
 
 @layer base {
@@ -95,13 +92,4 @@
         opacity: 1;
         animation-timing-function: bezier(0.5, 0, 0.5, 1);
     }
-}
-
-@utility animation-delay-* {
-    /*
-        biome fails currently in `*`
-        as a workaround, escape the * with \* works for now and tailwind handles it correctly as well
-        https://github.com/biomejs/biome/discussions/3195
-     */
-    animation-delay: --value(--animation-delay-\*);
 }


### PR DESCRIPTION
### Description

- Call `framer.showUI({ ... })` early on, so it doesn't resize afterwards anymore
- Remove the animation delay to hide the jump
- Additionally, set the size of the logo statically.

### Testing

- [ ] Opening the Plugin w/o selection doesn't have visual jump
  - [ ] Open the plugin on the canvas, without selection
  - [ ] Nothing jumps, consider validation with a screen recording
