### PR TITLE
Code Versions: Enhance error screens and state management

### DIFF
--- a/plugins/code-versions/src/components/App.tsx
+++ b/plugins/code-versions/src/components/App.tsx
@@ -4,6 +4,7 @@ import { MutationState, useCodeFileVersions } from "../hooks/useCodeFileVersions
 import { StatusTypes, useSelectedCodeFile } from "../hooks/useSelectedCodeFile"
 import CodeFileView from "./CodeFileView"
 import { EmptyState } from "./EmptyState"
+import ErrorMessage from "./ErrorMessage"
 
 export default function App() {
     const { state: fileStatus } = useSelectedCodeFile()
@@ -33,10 +34,15 @@ export default function App() {
     if (fileStatus.type === StatusTypes.ERROR) {
         return (
             <Layout>
-                <div className="text-center">
-                    <h2 className="text-lg font-semibold mb-2 text-red-600">Error</h2>
-                    <p className="text-sm text-gray-600 mb-4">{fileStatus.error}</p>
-                </div>
+                <ErrorMessage errorMessage={fileStatus.error} onRetryButtonClick={undefined} />
+            </Layout>
+        )
+    }
+
+    if (state.errors.versions) {
+        return (
+            <Layout>
+                <ErrorMessage errorMessage={state.errors.versions} onRetryButtonClick={clearErrors} />
             </Layout>
         )
     }
@@ -51,50 +57,12 @@ export default function App() {
 
     return (
         <Layout>
-            {/* Error banner for versions loading error */}
-            {state.errors.versions && (
-                <div className="sticky top-0 bg-white border-b border-framer-divider p-3">
-                    <div className="flex items-center justify-between">
-                        <div className="flex items-center">
-                            <span className="text-framer-text-primary text-sm font-medium">
-                                Failed to load versions:
-                            </span>
-                            <span className="text-framer-text-secondary text-sm ml-2">{state.errors.versions}</span>
-                        </div>
-                        <button
-                            onClick={clearErrors}
-                            className="text-framer-text-primary hover:text-framer-text-base text-sm font-medium w-min px-2"
-                        >
-                            Dismiss
-                        </button>
-                    </div>
-                </div>
-            )}
-
-            {/* Error banner for content loading error */}
-            {state.errors.content && (
-                <div className="border-b border-framer-divider p-3">
-                    <div className="flex items-center justify-between">
-                        <div className="flex items-center">
-                            <span className="text-framer-text-primary text-sm font-medium">
-                                Failed to load content:
-                            </span>
-                            <span className="text-framer-text-secondary text-sm ml-2">{state.errors.content}</span>
-                        </div>
-                        <button
-                            onClick={clearErrors}
-                            className="text-framer-text-primary hover:text-framer-text-base text-sm font-medium px-2"
-                        >
-                            Dismiss
-                        </button>
-                    </div>
-                </div>
-            )}
-
-            {/* Main content */}
-            <div className="flex-1">
-                <CodeFileView state={state} selectVersion={selectVersion} restoreVersion={restoreVersion} />
-            </div>
+            <CodeFileView
+                state={state}
+                selectVersion={selectVersion}
+                restoreVersion={restoreVersion}
+                clearErrors={clearErrors}
+            />
         </Layout>
     )
 }

--- a/plugins/code-versions/src/components/App.tsx
+++ b/plugins/code-versions/src/components/App.tsx
@@ -16,7 +16,12 @@ export default function App() {
                 variant: "success",
             })
         }
-    }, [state.restoreCompleted])
+        if (state.errors.restore) {
+            framer.closePlugin("Couldn't restore version", {
+                variant: "error",
+            })
+        }
+    }, [state.restoreCompleted, state.errors.restore])
 
     useEffect(() => {
         if (state.restoreLoading === MutationState.Mutating) {
@@ -75,26 +80,6 @@ export default function App() {
                                 Failed to load content:
                             </span>
                             <span className="text-framer-text-secondary text-sm ml-2">{state.errors.content}</span>
-                        </div>
-                        <button
-                            onClick={clearErrors}
-                            className="text-framer-text-primary hover:text-framer-text-base text-sm font-medium px-2"
-                        >
-                            Dismiss
-                        </button>
-                    </div>
-                </div>
-            )}
-
-            {/* Error banner for restore error */}
-            {state.errors.restore && (
-                <div className="border-b border-framer-divider p-3">
-                    <div className="flex items-center justify-between">
-                        <div className="flex items-center">
-                            <span className="text-framer-text-primary text-sm font-medium">
-                                Failed to restore version:
-                            </span>
-                            <span className="text-framer-text-secondary text-sm ml-2">{state.errors.restore}</span>
                         </div>
                         <button
                             onClick={clearErrors}

--- a/plugins/code-versions/src/components/CodeFileView.tsx
+++ b/plugins/code-versions/src/components/CodeFileView.tsx
@@ -1,7 +1,7 @@
 import {
     type CodeFileVersionsState,
     LoadingState,
-    MutationState,
+    RestoreState,
     useCanRestoreVersion,
 } from "../hooks/useCodeFileVersions"
 import CurrentCode from "./CurrentCode"
@@ -21,7 +21,7 @@ export default function CodeFileView({ state, selectVersion, restoreVersion, cle
         <div className="grid grid-cols-[var(--width-versions)_1fr] grid-rows-[1fr_auto] h-screen bg-bg-base text-text-base">
             <VersionsSidebar
                 className="row-span-2"
-                versions={state.versions}
+                versions={state.versions.data}
                 selectedId={state.selectedVersionId}
                 onSelect={selectVersion}
             />
@@ -40,10 +40,10 @@ function VersionColumn({
     restoreVersion: CodeFileVersionsState["restoreVersion"]
 }) {
     const canRestoreVersion = useCanRestoreVersion()
-    if (state.errors.content) {
+    if (state.content.error) {
         return (
             <div className="bg-code-area-light dark:bg-code-area-dark relative overflow-hidden">
-                <ErrorMessage errorMessage={state.errors.content} onRetryButtonClick={clearErrors} />
+                <ErrorMessage errorMessage={state.content.error} onRetryButtonClick={clearErrors} />
             </div>
         )
     }
@@ -56,11 +56,11 @@ function VersionColumn({
             <div className="bg-code-area-light dark:bg-code-area-dark relative overflow-hidden">
                 <div className="absolute inset-0 mx-3 mt-3">
                     <div className="overflow-auto scrollbar-hidden h-full pb-3">
-                        {state.contentLoading === LoadingState.Initial ||
-                        state.versionContent === undefined ||
+                        {state.content.status === LoadingState.Initial ||
+                        state.content.data === undefined ||
                         currentContent === undefined ? null : (
                             <Code
-                                original={state.versionContent}
+                                original={state.content.data}
                                 revised={currentContent}
                                 isCurrentVersion={isCurrentVersion}
                             />
@@ -74,7 +74,7 @@ function VersionColumn({
                         className="px-6 py-2 rounded-lg bg-tint text-framer-text-primary font-medium disabled:cursor-not-allowed w-full hover:bg-framer-button-hover-light dark:hover:bg-framer-button-hover-dark"
                         onClick={restoreVersion}
                         // We hide the plugin when we restore, this is just a safety measure
-                        disabled={state.restoreLoading === MutationState.Mutating}
+                        disabled={state.restore.status === RestoreState.Mutating}
                     >
                         Restore
                     </button>

--- a/plugins/code-versions/src/components/CodeFileView.tsx
+++ b/plugins/code-versions/src/components/CodeFileView.tsx
@@ -5,6 +5,7 @@ import {
     useCanRestoreVersion,
 } from "../hooks/useCodeFileVersions"
 import CurrentCode from "./CurrentCode"
+import ErrorMessage from "./ErrorMessage"
 import FileDiff from "./FileDiff"
 import VersionsSidebar from "./VersionsSidebar"
 
@@ -12,14 +13,10 @@ interface CodeFileViewProps {
     state: CodeFileVersionsState["state"]
     selectVersion: CodeFileVersionsState["selectVersion"]
     restoreVersion: CodeFileVersionsState["restoreVersion"]
+    clearErrors: CodeFileVersionsState["clearErrors"]
 }
 
-export default function CodeFileView({ state, selectVersion, restoreVersion }: CodeFileViewProps) {
-    const currentContent = state.codeFile?.content
-
-    const isCurrentVersion = state.codeFile?.versionId === state.selectedVersionId
-    const canRestoreVersion = useCanRestoreVersion()
-
+export default function CodeFileView({ state, selectVersion, restoreVersion, clearErrors }: CodeFileViewProps) {
     return (
         <div className="grid grid-cols-[var(--width-versions)_1fr] grid-rows-[1fr_auto] h-screen bg-bg-base text-text-base">
             <VersionsSidebar
@@ -28,6 +25,34 @@ export default function CodeFileView({ state, selectVersion, restoreVersion }: C
                 selectedId={state.selectedVersionId}
                 onSelect={selectVersion}
             />
+            <VersionColumn state={state} clearErrors={clearErrors} restoreVersion={restoreVersion} />
+        </div>
+    )
+}
+
+function VersionColumn({
+    state,
+    clearErrors,
+    restoreVersion,
+}: {
+    state: CodeFileVersionsState["state"]
+    clearErrors: CodeFileVersionsState["clearErrors"]
+    restoreVersion: CodeFileVersionsState["restoreVersion"]
+}) {
+    const canRestoreVersion = useCanRestoreVersion()
+    if (state.errors.content) {
+        return (
+            <div className="bg-code-area-light dark:bg-code-area-dark relative overflow-hidden">
+                <ErrorMessage errorMessage={state.errors.content} onRetryButtonClick={clearErrors} />
+            </div>
+        )
+    }
+
+    const currentContent = state.codeFile?.content
+    const isCurrentVersion = state.codeFile?.versionId === state.selectedVersionId
+
+    return (
+        <>
             <div className="bg-code-area-light dark:bg-code-area-dark relative overflow-hidden">
                 <div className="absolute inset-0 mx-3 mt-3">
                     <div className="overflow-auto scrollbar-hidden h-full pb-3">
@@ -55,7 +80,7 @@ export default function CodeFileView({ state, selectVersion, restoreVersion }: C
                     </button>
                 </div>
             ) : null}
-        </div>
+        </>
     )
 }
 

--- a/plugins/code-versions/src/components/ErrorMessage.tsx
+++ b/plugins/code-versions/src/components/ErrorMessage.tsx
@@ -1,0 +1,21 @@
+interface ErrorMessageProps {
+    errorMessage: string
+    onRetryButtonClick: (() => void) | undefined
+}
+
+export default function ErrorMessage({ errorMessage, onRetryButtonClick }: ErrorMessageProps) {
+    return (
+        <div className="h-full w-full flex flex-col items-center justify-center">
+            <h2 className="mb-2 text-framer-text-primary font-semibold max-w-48">Cannot Load Data</h2>
+            <p className="mb-3 text-framer-text-secondary font-medium max-w-48">{errorMessage}</p>
+            {onRetryButtonClick && (
+                <button
+                    onClick={onRetryButtonClick}
+                    className="w-min px-2 py-[8px] rounded-lg bg-tint text-framer-text-primary font-medium hover:bg-framer-button-hover-light dark:hover:bg-framer-button-hover-dark text-xs"
+                >
+                    Reload
+                </button>
+            )}
+        </div>
+    )
+}

--- a/plugins/code-versions/src/hooks/useCodeFileVersions.ts
+++ b/plugins/code-versions/src/hooks/useCodeFileVersions.ts
@@ -14,7 +14,7 @@ export function useCodeFileVersions(): CodeFileVersionsState {
 
     // Derived state
     // this happens on every render, but should be fast enough, as useMemo isn't free either
-    const selectedVersion = state.versions.find(version => version.id === state.selectedVersionId)
+    const selectedVersion = state.versions.data.find(version => version.id === state.selectedVersionId)
 
     // Handle file selection changes
     useEffect(() => {
@@ -87,18 +87,18 @@ export function useCodeFileVersions(): CodeFileVersionsState {
     }, [])
 
     const restoreVersion = useCallback(async () => {
-        if (!state.versionContent || !state.codeFile) return
+        if (!state.content.data || !state.codeFile) return
 
         dispatch({ type: VersionsActionType.RestoreStarted })
 
         try {
-            await state.codeFile.setFileContent(state.versionContent)
+            await state.codeFile.setFileContent(state.content.data)
             dispatch({ type: VersionsActionType.RestoreCompleted })
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : "Failed to restore version"
             dispatch({ type: VersionsActionType.RestoreError, payload: { error: errorMessage } })
         }
-    }, [state.versionContent, state.codeFile])
+    }, [state.content.data, state.codeFile])
 
     const clearErrors = useCallback(() => {
         versionsAbortControllerRef.current?.abort()
@@ -116,23 +116,10 @@ export function useCodeFileVersions(): CodeFileVersionsState {
             loadVersionContent(dispatch, selectedVersion, abortController)
         }
         dispatch({ type: VersionsActionType.ErrorsCleared })
-
-        return () => {
-            abortController.abort()
-        }
     }, [state.codeFile, selectedVersion])
 
     return {
-        state: {
-            codeFile: state.codeFile,
-            versions: state.versions,
-            selectedVersionId: state.selectedVersionId,
-            versionContent: state.versionContent,
-            contentLoading: state.contentLoading,
-            restoreLoading: state.restoreLoading,
-            restoreCompleted: state.restoreCompleted,
-            errors: state.errors,
-        },
+        state,
 
         // Actions
         selectVersion,
@@ -151,10 +138,11 @@ export enum LoadingState {
     Refreshing,
 }
 
-export enum MutationState {
+export enum RestoreState {
     Idle,
     Mutating,
-    Done,
+    Succeeded,
+    Failed,
 }
 
 // Use event-based naming for actions
@@ -179,16 +167,23 @@ export enum VersionsActionType {
 
 interface VersionsState {
     codeFile: CodeFile | undefined
-    versions: readonly CodeFileVersion[]
     selectedVersionId: string | undefined
-    versionContent: string | undefined
-    contentLoading: LoadingState
-    restoreLoading: MutationState
-    restoreCompleted: boolean
-    errors: {
-        versions?: string
-        content?: string
-        restore?: string
+
+    versions: {
+        data: readonly CodeFileVersion[]
+        status: LoadingState
+        error?: string
+    }
+
+    content: {
+        data: string | undefined
+        status: LoadingState
+        error?: string
+    }
+
+    restore: {
+        status: RestoreState
+        error?: string
     }
 }
 
@@ -227,12 +222,21 @@ function versionsReducer(state: VersionsState, action: VersionsAction): Versions
                 return {
                     ...state,
                     codeFile: payload.codeFile,
-                    versions: [],
+                    versions: {
+                        data: [],
+                        status: LoadingState.Initial,
+                        error: undefined,
+                    },
                     selectedVersionId: undefined,
-                    versionContent: undefined,
-                    contentLoading: LoadingState.Initial,
-                    restoreLoading: MutationState.Idle,
-                    errors: {},
+                    content: {
+                        data: undefined,
+                        status: LoadingState.Initial,
+                        error: undefined,
+                    },
+                    restore: {
+                        status: RestoreState.Idle,
+                        error: undefined,
+                    },
                 }
             } else {
                 // Only update the codeFile reference
@@ -244,65 +248,111 @@ function versionsReducer(state: VersionsState, action: VersionsAction): Versions
         })
         .with({ type: VersionsActionType.VersionsLoadStarted }, () => ({
             ...state,
-            errors: { ...state.errors, versions: undefined },
+            versions: {
+                ...state.versions,
+                status: LoadingState.Initial,
+                error: undefined,
+            },
         }))
         .with({ type: VersionsActionType.VersionsLoaded }, ({ payload }) => ({
             ...state,
-            versions: payload.versions,
+            versions: {
+                ...state.versions,
+                data: payload.versions,
+                status: LoadingState.Idle,
+                error: undefined,
+            },
             selectedVersionId: !state.selectedVersionId
                 ? getDefaultSelectedVersionId(payload.versions)
                 : state.selectedVersionId,
-            errors: { ...state.errors, versions: undefined },
         }))
         .with({ type: VersionsActionType.VersionSelected }, ({ payload }) => ({
             ...state,
             selectedVersionId: payload.versionId,
-            versionContent: state.selectedVersionId === payload.versionId ? state.versionContent : undefined,
-            errors: { ...state.errors, content: undefined },
+            content: {
+                ...state.content,
+                data: state.selectedVersionId === payload.versionId ? state.content.data : undefined,
+                error: undefined,
+            },
         }))
         .with({ type: VersionsActionType.ContentLoadStarted }, () => ({
             ...state,
-            contentLoading: state.versionContent == null ? LoadingState.Initial : LoadingState.Refreshing,
-            errors: { ...state.errors, content: undefined },
+            content: {
+                ...state.content,
+                status: state.content.data == null ? LoadingState.Initial : LoadingState.Refreshing,
+                error: undefined,
+            },
         }))
         .with({ type: VersionsActionType.VersionContentLoaded }, ({ payload }) => ({
             ...state,
-            versionContent: payload.content,
-            contentLoading: LoadingState.Idle,
-            errors: { ...state.errors, content: "Failed to load version content" },
+            content: {
+                ...state.content,
+                data: payload.content,
+                status: LoadingState.Idle,
+                error: undefined,
+            },
         }))
         .with({ type: VersionsActionType.VersionsError }, ({ payload }) => ({
             ...state,
-            errors: { ...state.errors, versions: payload.error },
+            versions: {
+                ...state.versions,
+                status: LoadingState.Idle,
+                error: payload.error,
+            },
         }))
         .with({ type: VersionsActionType.ContentError }, ({ payload }) => ({
             ...state,
-            contentLoading: LoadingState.Idle,
-            errors: { ...state.errors, content: payload.error },
+            content: {
+                ...state.content,
+                status: LoadingState.Idle,
+                error: payload.error,
+            },
         }))
         .with({ type: VersionsActionType.RestoreStarted }, () => ({
             ...state,
-            restoreLoading: MutationState.Mutating,
-            errors: { ...state.errors, restore: undefined },
+            restore: {
+                ...state.restore,
+                status: RestoreState.Mutating,
+                error: undefined,
+            },
         }))
         .with({ type: VersionsActionType.RestoreCompleted }, () => ({
             ...state,
-            restoreLoading: MutationState.Done,
-            restoreCompleted: true,
+            restore: {
+                ...state.restore,
+                status: RestoreState.Succeeded,
+            },
         }))
         .with({ type: VersionsActionType.RestoreError }, ({ payload }) => ({
             ...state,
-            restoreLoading: MutationState.Done,
-            errors: { ...state.errors, restore: payload.error },
+            restore: {
+                ...state.restore,
+                status: RestoreState.Failed,
+                error: payload.error,
+            },
         }))
         .with({ type: VersionsActionType.ErrorsCleared }, () => ({
             ...state,
-            errors: {},
+            versions: {
+                ...state.versions,
+                error: undefined,
+            },
+            content: {
+                ...state.content,
+                error: undefined,
+            },
+            restore: {
+                ...state.restore,
+                error: undefined,
+            },
         }))
         .with({ type: VersionsActionType.StateResetCompleted }, () => initialState)
         .with({ type: VersionsActionType.OperationCancelled }, ({ payload }) => ({
             ...state,
-            contentLoading: payload.operation === "content" ? LoadingState.Idle : state.contentLoading,
+            content: {
+                ...state.content,
+                status: payload.operation === "content" ? LoadingState.Idle : state.content.status,
+            },
         }))
         .exhaustive()
 }
@@ -320,7 +370,7 @@ const RETRY_OPTIONS = {
     minTimeout: 250,
 }
 
-// Helper function to load versions with abort controller and retry logic
+// Helper function to load versions with abort controller and retry logic and retry logic
 async function loadVersions(
     dispatch: React.Dispatch<VersionsAction>,
     codeFile: CodeFile,
@@ -376,11 +426,19 @@ async function loadVersionContent(
 
 const initialState: VersionsState = {
     codeFile: undefined,
-    versions: [],
     selectedVersionId: undefined,
-    versionContent: undefined,
-    contentLoading: LoadingState.Idle,
-    restoreLoading: MutationState.Idle,
-    restoreCompleted: false,
-    errors: {},
+    versions: {
+        data: [],
+        status: LoadingState.Idle,
+        error: undefined,
+    },
+    content: {
+        data: undefined,
+        status: LoadingState.Idle,
+        error: undefined,
+    },
+    restore: {
+        status: RestoreState.Idle,
+        error: undefined,
+    },
 }


### PR DESCRIPTION
### Description

This pull request enhances the error screens and error handling logic in the code-versions plugin. It introduces a reusable ErrorMessage component and refactors restore state management. UI feedback for errors and restore actions is now more consistent.

<img width="678" height="544" alt="image" src="https://github.com/user-attachments/assets/cfdbde9e-97e5-4486-b5d4-123a1914a829" />

<img width="689" height="542" alt="image" src="https://github.com/user-attachments/assets/2bb55f5a-87c9-4449-ba84-fab6e2f60380" />

### Testing

- [x] Error screen appears when loading versions fails
  - [x] Step 1: Trigger a versions load failure (e.g., by adding `throw new Error("Connection Error")` in `loadVersions()` )
  - [x] Step 2: Observe the new error screen and retry button

- [x] Error screen appears when loading content fails
  - [x] Step 1: Trigger a content load failure (e.g., by adding `throw new Error("Connection Error")` in `loadVersionContent()` )
  - [x] Step 2: Observe the error UI and retry
