### PR TITLE
Code Versions: Loading Spinner

### DIFF
--- a/plugins/code-versions/src/components/App.tsx
+++ b/plugins/code-versions/src/components/App.tsx
@@ -3,12 +3,12 @@ import { useEffect } from "react"
 import { isInitialLoading, RestoreState, useCodeFileVersions } from "../hooks/useCodeFileVersions"
 import { StatusTypes, useSelectedCodeFile } from "../hooks/useSelectedCodeFile"
 import { EmptyState } from "./EmptyState"
-import ErrorMessage from "./ErrorMessage"
+import { ErrorMessage } from "./ErrorMessage"
 import { Spinner } from "./Spinner"
 import { VersionColumn } from "./VersionColumn"
-import VersionsSidebar from "./VersionsSidebar"
+import { VersionsSidebar } from "./VersionsSidebar"
 
-export default function App() {
+export function App() {
     const { state: fileStatus } = useSelectedCodeFile()
     const { state, selectVersion, restoreVersion, clearErrors } = useCodeFileVersions()
 

--- a/plugins/code-versions/src/components/App.tsx
+++ b/plugins/code-versions/src/components/App.tsx
@@ -1,10 +1,12 @@
 import { framer } from "framer-plugin"
 import { useEffect } from "react"
-import { RestoreState, useCodeFileVersions } from "../hooks/useCodeFileVersions"
+import { isInitialLoading, RestoreState, useCodeFileVersions } from "../hooks/useCodeFileVersions"
 import { StatusTypes, useSelectedCodeFile } from "../hooks/useSelectedCodeFile"
-import CodeFileView from "./CodeFileView"
 import { EmptyState } from "./EmptyState"
 import ErrorMessage from "./ErrorMessage"
+import { Spinner } from "./Spinner"
+import { VersionColumn } from "./VersionColumn"
+import VersionsSidebar from "./VersionsSidebar"
 
 export default function App() {
     const { state: fileStatus } = useSelectedCodeFile()
@@ -31,45 +33,57 @@ export default function App() {
     // Handle error states
     if (fileStatus.type === StatusTypes.ERROR) {
         return (
-            <Layout>
+            <AppLayout>
                 <ErrorMessage errorMessage={fileStatus.error} onRetryButtonClick={undefined} />
-            </Layout>
+            </AppLayout>
         )
     }
 
     if (state.versions.error) {
         return (
-            <Layout>
+            <AppLayout>
                 <ErrorMessage errorMessage={state.versions.error} onRetryButtonClick={clearErrors} />
-            </Layout>
+            </AppLayout>
         )
     }
 
     if (!state.codeFile) {
         return (
-            <Layout>
+            <AppLayout>
                 <EmptyState />
-            </Layout>
+            </AppLayout>
         )
     }
 
     return (
-        <Layout>
-            <CodeFileView
-                state={state}
-                selectVersion={selectVersion}
-                restoreVersion={restoreVersion}
-                clearErrors={clearErrors}
-            />
-        </Layout>
+        <AppLayout>
+            {isInitialLoading(state.versions) ? (
+                <Spinner className="row-span-2" />
+            ) : (
+                <VersionsSidebar
+                    className="row-span-2"
+                    versions={state.versions.data}
+                    selectedId={state.selectedVersionId}
+                    onSelect={selectVersion}
+                />
+            )}
+
+            {isInitialLoading(state.content) ? (
+                <Spinner />
+            ) : (
+                <VersionColumn state={state} clearErrors={clearErrors} restoreVersion={restoreVersion} />
+            )}
+        </AppLayout>
     )
 }
 
-function Layout({ children }: { children: React.ReactNode }) {
+function AppLayout({ children }: { children: React.ReactNode }) {
     return (
         <div className="h-screen flex flex-col overflow-hidden scheme-light dark:scheme-dark">
             <hr className="ms-3 border-t border-framer-divider" />
-            {children}
+            <div className="grid grid-cols-[var(--width-versions)_1fr] grid-rows-[1fr_auto] h-screen bg-bg-base text-text-base">
+                {children}
+            </div>
         </div>
     )
 }

--- a/plugins/code-versions/src/components/Code.tsx
+++ b/plugins/code-versions/src/components/Code.tsx
@@ -1,0 +1,15 @@
+import CurrentCode from "./CurrentCode"
+import FileDiff from "./FileDiff"
+
+interface CodeProps {
+    original: string
+    revised: string
+    isCurrentVersion: boolean
+}
+
+export function Code({ original, revised, isCurrentVersion }: CodeProps) {
+    if (isCurrentVersion || original === revised) {
+        return <CurrentCode code={original} />
+    }
+    return <FileDiff original={original} revised={revised} />
+}

--- a/plugins/code-versions/src/components/Code.tsx
+++ b/plugins/code-versions/src/components/Code.tsx
@@ -1,5 +1,5 @@
-import CurrentCode from "./CurrentCode"
-import FileDiff from "./FileDiff"
+import { CurrentCode } from "./CurrentCode"
+import { FileDiff } from "./FileDiff"
 
 interface CodeProps {
     original: string

--- a/plugins/code-versions/src/components/CurrentCode.tsx
+++ b/plugins/code-versions/src/components/CurrentCode.tsx
@@ -14,7 +14,7 @@ interface CurrentCodeProps {
  * Code List of the current version, where no diff is shown
  * It shows all lines of the current version, and the one row of line numbers are shown on the left
  */
-export default function CurrentCode({ code }: CurrentCodeProps) {
+export function CurrentCode({ code }: CurrentCodeProps) {
     const codeRef = useRef<HTMLElement>(null)
 
     useEffect(() => {

--- a/plugins/code-versions/src/components/ErrorMessage.tsx
+++ b/plugins/code-versions/src/components/ErrorMessage.tsx
@@ -3,7 +3,7 @@ interface ErrorMessageProps {
     onRetryButtonClick: (() => void) | undefined
 }
 
-export default function ErrorMessage({ errorMessage, onRetryButtonClick }: ErrorMessageProps) {
+export function ErrorMessage({ errorMessage, onRetryButtonClick }: ErrorMessageProps) {
     return (
         <div className="h-full w-full flex flex-col items-center justify-center">
             <h2 className="mb-2 text-framer-text-primary font-semibold max-w-48">Cannot Load Data</h2>

--- a/plugins/code-versions/src/components/FileDiff.test.tsx
+++ b/plugins/code-versions/src/components/FileDiff.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
-import FileDiff from "./FileDiff"
+import { FileDiff } from "./FileDiff"
 
 const ADDED_CLASS_NAME = "bg-diff-add-bg/10"
 const REMOVED_CLASS_NAME = "bg-diff-remove-bg/10"

--- a/plugins/code-versions/src/components/FileDiff.tsx
+++ b/plugins/code-versions/src/components/FileDiff.tsx
@@ -8,7 +8,7 @@ interface FileDiffProps {
     revised: string
 }
 
-export default function FileDiff({ original, revised }: FileDiffProps) {
+export function FileDiff({ original, revised }: FileDiffProps) {
     const lines = getLineDiffWithEdges(original, revised)
 
     const rows = lines.map(line =>

--- a/plugins/code-versions/src/components/Spinner.tsx
+++ b/plugins/code-versions/src/components/Spinner.tsx
@@ -1,0 +1,18 @@
+import { cn } from "../utils"
+
+interface SpinnerProps {
+    className?: string
+}
+
+export function Spinner({ className }: SpinnerProps) {
+    return (
+        <div
+            className={cn(
+                "flex items-center justify-center z-10 animate-(--fade-in-animation) [animation-delay:800ms] opacity-0",
+                className
+            )}
+        >
+            <div className="framer-spinner" />
+        </div>
+    )
+}

--- a/plugins/code-versions/src/components/VersionColumn.tsx
+++ b/plugins/code-versions/src/components/VersionColumn.tsx
@@ -5,7 +5,7 @@ import {
     useCanRestoreVersion,
 } from "../hooks/useCodeFileVersions"
 import { Code } from "./Code"
-import ErrorMessage from "./ErrorMessage"
+import { ErrorMessage } from "./ErrorMessage"
 
 interface VersionColumnProps {
     state: CodeFileVersionsState["state"]

--- a/plugins/code-versions/src/components/VersionColumn.tsx
+++ b/plugins/code-versions/src/components/VersionColumn.tsx
@@ -4,41 +4,16 @@ import {
     RestoreState,
     useCanRestoreVersion,
 } from "../hooks/useCodeFileVersions"
-import CurrentCode from "./CurrentCode"
+import { Code } from "./Code"
 import ErrorMessage from "./ErrorMessage"
-import FileDiff from "./FileDiff"
-import VersionsSidebar from "./VersionsSidebar"
 
-interface CodeFileViewProps {
-    state: CodeFileVersionsState["state"]
-    selectVersion: CodeFileVersionsState["selectVersion"]
-    restoreVersion: CodeFileVersionsState["restoreVersion"]
-    clearErrors: CodeFileVersionsState["clearErrors"]
-}
-
-export default function CodeFileView({ state, selectVersion, restoreVersion, clearErrors }: CodeFileViewProps) {
-    return (
-        <div className="grid grid-cols-[var(--width-versions)_1fr] grid-rows-[1fr_auto] h-screen bg-bg-base text-text-base">
-            <VersionsSidebar
-                className="row-span-2"
-                versions={state.versions.data}
-                selectedId={state.selectedVersionId}
-                onSelect={selectVersion}
-            />
-            <VersionColumn state={state} clearErrors={clearErrors} restoreVersion={restoreVersion} />
-        </div>
-    )
-}
-
-function VersionColumn({
-    state,
-    clearErrors,
-    restoreVersion,
-}: {
+interface VersionColumnProps {
     state: CodeFileVersionsState["state"]
     clearErrors: CodeFileVersionsState["clearErrors"]
     restoreVersion: CodeFileVersionsState["restoreVersion"]
-}) {
+}
+
+export function VersionColumn({ state, clearErrors, restoreVersion }: VersionColumnProps) {
     const canRestoreVersion = useCanRestoreVersion()
     if (state.content.error) {
         return (
@@ -82,20 +57,4 @@ function VersionColumn({
             ) : null}
         </>
     )
-}
-
-function Code({
-    original,
-    revised,
-    isCurrentVersion,
-}: {
-    original: string
-    revised: string
-    isCurrentVersion: boolean
-}) {
-    if (isCurrentVersion || original === revised) {
-        return <CurrentCode code={original} />
-    }
-
-    return <FileDiff original={original} revised={revised} />
 }

--- a/plugins/code-versions/src/components/VersionsSidebar.tsx
+++ b/plugins/code-versions/src/components/VersionsSidebar.tsx
@@ -63,7 +63,7 @@ function HistoricalVersion({ version, isSelected, onSelect }: VersionProps) {
     )
 }
 
-export default function VersionsSidebar({
+export function VersionsSidebar({
     className,
     versions,
     selectedId,

--- a/plugins/code-versions/src/hooks/useCodeFileVersions.ts
+++ b/plugins/code-versions/src/hooks/useCodeFileVersions.ts
@@ -165,6 +165,16 @@ export enum VersionsActionType {
     OperationCancelled = "OPERATION_CANCELLED",
 }
 
+interface DataState<T> {
+    data: T | undefined
+    status: LoadingState
+    error?: string
+}
+
+export const isInitialLoading = <T>(state: DataState<T>) => {
+    return state.status === LoadingState.Initial
+}
+
 interface VersionsState {
     codeFile: CodeFile | undefined
     selectedVersionId: string | undefined

--- a/plugins/code-versions/src/main.tsx
+++ b/plugins/code-versions/src/main.tsx
@@ -3,7 +3,7 @@ import "./styles.css"
 import { framer } from "framer-plugin"
 import React from "react"
 import ReactDOM from "react-dom/client"
-import App from "./components/App.tsx"
+import { App } from "./components/App.tsx"
 
 const root = document.getElementById("root")
 if (!root) throw new Error("Root element not found")


### PR DESCRIPTION
### Description

Introducing loading spinners with a short delay to the Code Versions plugin UI.

- The spinner appears in the versions sidebar and/or content column when loading takes longer than 800ms, preventing flicker for fast loads and improving user feedback for slow operations.
- It also aligns all exports to be named exports

### Testing

- [ ] Spinner appears only after a delay when loading is slow
  - consider adding a `await new Promise((resolve) => setTimeout(resolve, 1_000))` to `useCodeFileVersions.tsx`
- [ ] No spinner appears on fast loads