### PR TITLE
Notion: add formula support

### DIFF
--- a/plugins/google-sheets/package.json
+++ b/plugins/google-sheets/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@tanstack/react-query": "^5.81.5",
         "classnames": "^2.5.1",
-        "framer-plugin": "^3.3.2",
+        "framer-plugin": "^3.4.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-error-boundary": "^6.0.0",

--- a/plugins/notion/src/api.ts
+++ b/plugins/notion/src/api.ts
@@ -80,6 +80,7 @@ export const supportedCMSTypeByNotionPropertyType = {
     files: ["file", "image", "array"],
     relation: ["multiCollectionReference"],
     unique_id: ["string", "number"],
+    formula: ["string", "number", "boolean", "date", "link", "color"],
 } satisfies Partial<Record<NotionProperty["type"], ReadonlyArray<ManagedCollectionField["type"]>>>
 
 // Naive implementation to be authenticated, a token could be expired.

--- a/plugins/notion/src/data.ts
+++ b/plugins/notion/src/data.ts
@@ -130,9 +130,53 @@ export async function syncCollection(
                 if (fieldEntry) {
                     fieldData[field.id] = fieldEntry
                 } else {
-                    console.warn(
-                        `Skipping item at index ${index} because it doesn't have a valid value for field ${field.name}`
-                    )
+                    switch (field.type) {
+                        case "string":
+                        case "formattedText":
+                            fieldData[field.id] = {
+                                value: "",
+                                type: field.type,
+                            }
+                            break
+                        case "enum": {
+                            const firstCase = field.cases[0]
+                            if (!firstCase) {
+                                console.warn(
+                                    `Skipping item “${item.id}” because enum field “${field.name}” has no cases.`
+                                )
+                                continue
+                            }
+                            fieldData[field.id] = {
+                                value: firstCase.id,
+                                type: "enum",
+                            }
+                            break
+                        }
+                        case "boolean":
+                            fieldData[field.id] = {
+                                value: false,
+                                type: "boolean",
+                            }
+                            break
+                        case "number":
+                            fieldData[field.id] = {
+                                value: 0,
+                                type: "number",
+                            }
+                            break
+                        case "image":
+                        case "file":
+                        case "link":
+                        case "date":
+                        case "color":
+                        case "collectionReference":
+                        case "multiCollectionReference":
+                            fieldData[field.id] = {
+                                value: null,
+                                type: field.type,
+                            }
+                            break
+                    }
                 }
             }
 
@@ -402,21 +446,13 @@ export function getFieldDataEntryForProperty(
         }
         case "select": {
             if (field.type !== "enum") return null
-
-            if (!property.select) {
-                const firstCase = field.cases?.[0]?.id
-                return firstCase ? { type: "enum", value: firstCase } : null
-            }
+            if (!property.select) return null
 
             return { type: "enum", value: property.select.id }
         }
         case "status": {
             if (field.type !== "enum") return null
-
-            if (!property.status) {
-                const firstCase = field.cases?.[0]?.id
-                return firstCase ? { type: "enum", value: firstCase } : null
-            }
+            if (!property.status) return null
 
             return { type: "enum", value: property.status.id }
         }
@@ -520,6 +556,65 @@ export function getFieldDataEntryForProperty(
             }
 
             return { type: "string", value: phoneNumber }
+        }
+        case "formula": {
+            const formula = property.formula
+
+            if (!formula) return null
+
+            let value = null
+            switch (formula.type) {
+                case "string":
+                    value = formula.string
+                    break
+                case "number":
+                    value = formula.number
+                    break
+                case "boolean":
+                    value = formula.boolean
+                    break
+                case "date":
+                    value = formula.date
+                    break
+            }
+
+            if (value === null) return null
+
+            switch (field.type) {
+                case "string":
+                case "color":
+                case "link":
+                    return {
+                        type: field.type,
+                        value: String(value),
+                    }
+                case "number": {
+                    const number = Number(value)
+                    if (isNaN(number)) return null
+
+                    return {
+                        type: "number",
+                        value: number,
+                    }
+                }
+                case "date": {
+                    if (formula.type !== "date" || !formula.date || !formula.date.start) return null
+
+                    const date = new Date(formula.date.start)
+
+                    return {
+                        type: "date",
+                        value: date.toISOString(),
+                    }
+                }
+                case "boolean":
+                    return {
+                        type: "boolean",
+                        value: Boolean(value),
+                    }
+                default:
+                    return null
+            }
         }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4808,7 +4808,7 @@ __metadata:
     "@types/react": "npm:^18.3.23"
     "@types/react-dom": "npm:^18.3.7"
     classnames: "npm:^2.5.1"
-    framer-plugin: "npm:^3.3.2"
+    framer-plugin: "npm:^3.4.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     react-error-boundary: "npm:^6.0.0"


### PR DESCRIPTION
### Description

This pull request adds support for syncing formula fields from Notion, and improves importing null values.

### Testing

This database has one of each type of formula.
https://www.notion.so/framer/231adf6e8c96808eb382f0d0f53ec6d7?v=231adf6e8c9680269e43000c4105e5da&source=copy_link

- [ ] Select a field type for each formula. All formulas have plain text as the default field type, but you can select number, toggle, color, link, or date.
- [ ] Test changing values and field types for each formula.