### PR TITLE
Notion: add single reference support

### DIFF
--- a/plugins/notion/src/api.ts
+++ b/plugins/notion/src/api.ts
@@ -78,7 +78,7 @@ export const supportedCMSTypeByNotionPropertyType = {
     email: ["formattedText", "string"],
     phone_number: ["string", "link"],
     files: ["file", "image", "array"],
-    relation: ["multiCollectionReference"],
+    relation: ["multiCollectionReference", "collectionReference"],
     unique_id: ["string", "number"],
 } satisfies Partial<Record<NotionProperty["type"], ReadonlyArray<ManagedCollectionField["type"]>>>
 

--- a/plugins/notion/src/data.ts
+++ b/plugins/notion/src/data.ts
@@ -349,7 +349,8 @@ export async function fieldsInfoToCollectionFields(
                 })
                 break
             }
-            case "multiCollectionReference": {
+            case "multiCollectionReference":
+            case "collectionReference": {
                 assertFieldTypeMatchesPropertyType(property.type, fieldType)
 
                 if (property.type === "relation") {
@@ -358,7 +359,7 @@ export async function fieldsInfoToCollectionFields(
                         const collectionId = databaseIdMap.get(databaseId)
                         if (collectionId) {
                             fields.push({
-                                type: "multiCollectionReference",
+                                type: fieldType,
                                 id: fieldInfo.id,
                                 name: fieldName,
                                 collectionId,
@@ -451,7 +452,13 @@ export function getFieldDataEntryForProperty(
             return { type: "date", value: property.date?.start ?? null }
         }
         case "relation": {
-            return { type: "multiCollectionReference", value: property.relation.map(({ id }) => id) }
+            if (field.type === "multiCollectionReference") {
+                return { type: "multiCollectionReference", value: property.relation.map(({ id }) => id) }
+            } else if (field.type === "collectionReference") {
+                return { type: "collectionReference", value: property.relation[0]?.id ?? null }
+            }
+
+            return null
         }
         case "files": {
             if (field.type === "array") {


### PR DESCRIPTION
### Description

This pull request adds the ability to sync relations as reference fields. Before this, you can only sync relations as multi-references.

Notion has a "Limit: 1" option on relation properties to limit it to 1 selected item, essentially turning it into a single reference, but it's not exposed to the API.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

The Users and Kitchen Sink databases here have relation properties:
https://www.notion.so/framer/Plugin-Testing-11badf6e8c96804cba51ca8641eb4571

- [ ] Sync a relation as multi-reference.
- [ ] Sync a relation as reference.

<!-- Thank you for contributing! -->