### PR TITLE
Notion: preserve table header row and column

### DIFF
--- a/plugins/notion/src/blocksToHtml.ts
+++ b/plugins/notion/src/blocksToHtml.ts
@@ -112,7 +112,7 @@ export function blocksToHtml(blocks: BlockObjectResponse[]) {
                 tableHasRowHeader = block.table.has_row_header
                 tableHasColumnHeader = block.table.has_column_header
                 break
-            case "table_row":
+            case "table_row": {
                 // Check if this is the first row after a table block
                 const isFirstRow = blocks[i - 1]?.type === "table"
 
@@ -137,6 +137,7 @@ export function blocksToHtml(blocks: BlockObjectResponse[]) {
                     htmlContent += `</tbody></table>`
                 }
                 break
+            }
             case "video": {
                 if (block.video.type !== "external") {
                     break

--- a/plugins/notion/src/blocksToHtml.ts
+++ b/plugins/notion/src/blocksToHtml.ts
@@ -46,6 +46,9 @@ const YOUTUBE_ID_REGEX = /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/))(?<
 export function blocksToHtml(blocks: BlockObjectResponse[]) {
     let htmlContent = ""
 
+    let tableHasColumnHeader = false
+    let tableHasRowHeader = false
+
     for (let i = 0; i < blocks.length; i++) {
         const block = blocks[i]
         assert(block)
@@ -106,21 +109,29 @@ export function blocksToHtml(blocks: BlockObjectResponse[]) {
             }
             case "table":
                 htmlContent += `<table>`
+                tableHasRowHeader = block.table.has_row_header
+                tableHasColumnHeader = block.table.has_column_header
                 break
             case "table_row":
-                if (blocks[i - 1]?.type === "table") {
-                    htmlContent += `<thead><tr>`
-                    block.table_row.cells.forEach(cell => {
-                        htmlContent += `<th>${richTextToHtml(cell)}</th>`
-                    })
-                    htmlContent += `</tr></thead><tbody>`
-                } else {
-                    htmlContent += `<tr>`
-                    block.table_row.cells.forEach(cell => {
-                        htmlContent += `<td>${richTextToHtml(cell)}</td>`
-                    })
-                    htmlContent += `</tr>`
+                // Check if this is the first row after a table block
+                const isFirstRow = blocks[i - 1]?.type === "table"
+
+                if (isFirstRow) {
+                    htmlContent += `<tbody>`
                 }
+
+                htmlContent += `<tr>`
+                block.table_row.cells.forEach((cell, cellIndex) => {
+                    // Determine if this cell is a header
+                    const isHeaderCell = (isFirstRow && tableHasColumnHeader) || (cellIndex === 0 && tableHasRowHeader)
+
+                    if (isHeaderCell) {
+                        htmlContent += `<th>${richTextToHtml(cell)}</th>`
+                    } else {
+                        htmlContent += `<td>${richTextToHtml(cell)}</td>`
+                    }
+                })
+                htmlContent += `</tr>`
 
                 if (blocks[i + 1]?.type !== "table_row") {
                     htmlContent += `</tbody></table>`


### PR DESCRIPTION
### Description

This pull request makes the Notion plugin preserve the row and column headers from Notion when syncing with Framer.

<img width="296" height="117" alt="image" src="https://github.com/user-attachments/assets/79261e37-953a-4698-9e63-082f6dfbdbb4" />

Before: all tables have a header row in Framer
<img width="446" height="593" alt="image" src="https://github.com/user-attachments/assets/474587a2-3ddf-4fc0-a4fe-694fce8ed88d" />

After: the header row & column status is preserved when syncing from Notion to Framer

<img width="442" height="589" alt="image" src="https://github.com/user-attachments/assets/e0dc3fef-f069-434a-a6aa-7965a0957759" />

### Testing

This page ("Second" in the kitchen sink database) has all 4 possible combinations of table header row and columns.
https://www.notion.so/framer/224adf6e8c9680eca17fda0e00267005?v=224adf6e8c9680899fb5000c4fa462a1&p=224adf6e8c96802fb891dbff808263ff&pm=s

- [x] Sync database with tables into Framer, with each combination of headers

<!-- Thank you for contributing! -->