### PR TITLE
Dither: add preferredImageRendering: "pixelated"

### DIFF
--- a/plugins/dither/src/App.tsx
+++ b/plugins/dither/src/App.tsx
@@ -160,6 +160,7 @@ function DitherImage({ image }: { image: ImageAsset | null }) {
                     bytes: bytes,
                     mimeType: "image/png",
                 },
+                preferredImageRendering: "pixelated",
             })
         } else {
             if (!image) return
@@ -170,6 +171,7 @@ function DitherImage({ image }: { image: ImageAsset | null }) {
                     bytes,
                     mimeType: originalImage.mimeType,
                 },
+                preferredImageRendering: "pixelated",
             })
         }
 


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request adds `preferredImageRendering: "pixelated"` to images inserted with the Dither plugin. This prevents the images from becoming blurry.

Mapped to this option in Framer:
<img width="244" height="52" alt="image" src="https://github.com/user-attachments/assets/1eb1f40b-77e9-457e-9afe-5896b5222c79" />

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Insert an image with dithering
- [x] Check the image rendering mode