### PR TITLE
Make local oauth worker optional for Search Console

### DIFF
--- a/plugins/google-search-console/.env.example
+++ b/plugins/google-search-console/.env.example
@@ -1,1 +1,0 @@
-VITE_OAUTH_API_DOMAIN=https://localhost:8787

--- a/plugins/google-search-console/README.md
+++ b/plugins/google-search-console/README.md
@@ -3,3 +3,17 @@
 A plugin to show performance and indexing results for your site in Google Search Console.
 
 **By**: @benkingcode
+
+## Development
+
+Run with production oauth worker:
+
+```
+yarn dev
+```
+
+Run with local oauth worker:
+
+```
+VITE_LOCAL_OAUTH=true yarn dev
+```

--- a/plugins/google-search-console/src/auth.ts
+++ b/plugins/google-search-console/src/auth.ts
@@ -1,6 +1,10 @@
 import { createContext, useCallback, useEffect, useRef, useState } from "react"
 import type { GoogleToken } from "./types"
 
+const oauthUrl = import.meta.env.VITE_LOCAL_OAUTH
+    ? "https://localhost:8787"
+    : "https://oauth.framer.wtf/google-search-console-plugin"
+
 export const AuthContext = createContext<GoogleToken | null>(null)
 
 const STORAGE_KEY = "framer-search-console-tokens"
@@ -32,7 +36,7 @@ export function useGoogleToken() {
             window.setTimeout(reject, 60_000) // Timeout after 60 seconds
 
             pollInterval.current = setInterval(async () => {
-                const response = await fetch(`${import.meta.env.VITE_OAUTH_API_DOMAIN}/poll?readKey=${readKey}`, {
+                const response = await fetch(`${oauthUrl}/poll?readKey=${readKey}`, {
                     method: "POST",
                 })
 
@@ -66,7 +70,7 @@ export function useGoogleToken() {
             setLoading(true)
 
             // Retrieve the authorization URL & set of unique read/write keys
-            const response = await fetch(`${import.meta.env.VITE_OAUTH_API_DOMAIN}/authorize`, {
+            const response = await fetch(`${oauthUrl}/authorize`, {
                 method: "POST",
             })
             if (response.status !== 200) return
@@ -100,12 +104,9 @@ export function useGoogleToken() {
             }
 
             // Retrieve the authorization URL & set of unique read/write keys
-            const response = await fetch(
-                `${import.meta.env.VITE_OAUTH_API_DOMAIN}/refresh?code=${encodeURIComponent(refreshToken)}`,
-                {
-                    method: "POST",
-                }
-            )
+            const response = await fetch(`${oauthUrl}/refresh?code=${encodeURIComponent(refreshToken)}`, {
+                method: "POST",
+            })
 
             const tokens = await response.json()
 

--- a/plugins/google-search-console/src/vite-env.d.ts
+++ b/plugins/google-search-console/src/vite-env.d.ts
@@ -6,5 +6,5 @@ interface ViteTypeOptions {
 
 interface ImportMetaEnv {
     readonly VITE_MOCK_DATA?: string
-    readonly VITE_OAUTH_API_DOMAIN?: string
+    readonly VITE_LOCAL_OAUTH?: string
 }


### PR DESCRIPTION
### Description

It's not possible to run this plugin as an external contributor otherwise. And most of the time we run this as Framer devs we aren't also making changes to the oauth worker.

Is this reasonable? We can do this for all the other plugins too if so.

### Testing

- [ ] `yarn dev` uses production oauth
- [ ] `VITE_LOCAL_OAUTH=true yarn dev` uses local oauth worker
