### PR TITLE
Code Versions: Fix wrong LoadingState being set when version are updated

### DIFF
--- a/plugins/code-versions/src/hooks/useCodeFileVersions.ts
+++ b/plugins/code-versions/src/hooks/useCodeFileVersions.ts
@@ -264,7 +264,7 @@ function versionsReducer(state: VersionsState, action: VersionsAction): Versions
             ...state,
             versions: {
                 ...state.versions,
-                status: LoadingState.Initial,
+                status: state.versions.status === LoadingState.Initial ? LoadingState.Initial : LoadingState.Refreshing,
                 error: undefined,
             },
         }))


### PR DESCRIPTION
### Description

Fixes a bug where, when the versions got refreshed, it triggers a loading state.

https://github.com/user-attachments/assets/502366de-384f-4e5b-9067-e7ed7400a947

Resolved by detecting the previous state and pick the status depending on that.

### Testing

- [x] Saving a Code File no longer triggers a loading animation
  - [x] Open a code file in the editor
  - [x] Open the Code Versions plugin
  - [x] Change it, save it
  - [x] You don't see the versions list to fade in
- [x] Switching to a different file does fade in the verisons
  - [x] Open a code file in the editor
  - [x] Open the Code Versions plugin
  - [x] Change to a different code file
  - [x] fade-in appears