### PR TITLE
Unsplash: move random image to plugin menu

### DIFF
--- a/plugins/unsplash/package.json
+++ b/plugins/unsplash/package.json
@@ -17,7 +17,7 @@
         "@tanstack/react-query": "^5.81.5",
         "blurhash": "^2.0.5",
         "classnames": "^2.5.1",
-        "framer-plugin": "^3.3.2",
+        "framer-plugin": "3.5.2",
         "react": "^18.3.1",
         "react-blurhash": "^0.3.0",
         "react-dom": "^18.3.1",

--- a/plugins/unsplash/src/App.tsx
+++ b/plugins/unsplash/src/App.tsx
@@ -65,8 +65,21 @@ export function App() {
         },
     })
 
+    useEffect(() => {
+        framer.setMenu([
+            {
+                label: "Random Image",
+                enabled: isAllowedToUpsertImage,
+                onAction: () => {
+                    if (!isAllowedToUpsertImage) return
+                    addRandomMutation.mutate(query)
+                },
+            },
+        ])
+    }, [isAllowedToUpsertImage, addRandomMutation, query])
+
     return (
-        <div className="flex flex-col gap-0 pb-4 h-full">
+        <div className="flex flex-col gap-0 h-full">
             <div className="bg-primary mb-[15px] z-10 relative px-[15px]">
                 <input
                     type="text"
@@ -86,19 +99,6 @@ export function App() {
             <AppErrorBoundary>
                 <PhotosList query={debouncedQuery} />
             </AppErrorBoundary>
-            <div className="mt-[15px] px-[15px]">
-                <button
-                    className="items-center flex justify-center relative"
-                    onClick={() => {
-                        if (!isAllowedToUpsertImage) return
-                        addRandomMutation.mutate(query)
-                    }}
-                    disabled={!isAllowedToUpsertImage}
-                    title={isAllowedToUpsertImage ? undefined : "Insufficient permissions"}
-                >
-                    {addRandomMutation.isPending ? <Spinner size="normal" inheritColor /> : "Random Image"}
-                </button>
-            </div>
         </div>
     )
 }
@@ -227,7 +227,7 @@ const PhotosList = memo(function PhotosList({ query }: { query: string }) {
 
     return (
         <div
-            className="overflow-auto relative flex-1 rounded-[8px] mx-[15px] no-scrollbar"
+            className="overflow-auto relative flex-1 rounded-t-[8px] mx-[15px] no-scrollbar"
             ref={scrollRef}
             onScroll={handleScroll}
         >

--- a/yarn.lock
+++ b/yarn.lock
@@ -4655,6 +4655,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"framer-plugin@npm:3.5.2, framer-plugin@npm:^3.5.2":
+  version: 3.5.2
+  resolution: "framer-plugin@npm:3.5.2"
+  peerDependencies:
+    react: ^18.2.0
+    react-dom: ^18.2.0
+  checksum: 10/4f2ad2e782b3a18bb827b809366bd5e0c9250917155ba4db762e65e404dff61bb3729f8ffc892bbb7a355c3c82ed7438a0d4b381228b01df47e9c76ad3a80124
+  languageName: node
+  linkType: hard
+
 "framer-plugin@npm:^3.3.2":
   version: 3.3.2
   resolution: "framer-plugin@npm:3.3.2"
@@ -4672,16 +4682,6 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
   checksum: 10/3d03cf88840f9f193489c29256c97f5df4e8dbac1b7b7769b54da8375687e2e6a509c0fefcd37f6de173d2a101ceb469dd513fac7a7ea28612ce5b473ba7c7d1
-  languageName: node
-  linkType: hard
-
-"framer-plugin@npm:^3.5.2":
-  version: 3.5.2
-  resolution: "framer-plugin@npm:3.5.2"
-  peerDependencies:
-    react: ^18.2.0
-    react-dom: ^18.2.0
-  checksum: 10/4f2ad2e782b3a18bb827b809366bd5e0c9250917155ba4db762e65e404dff61bb3729f8ffc892bbb7a355c3c82ed7438a0d4b381228b01df47e9c76ad3a80124
   languageName: node
   linkType: hard
 
@@ -7213,7 +7213,7 @@ __metadata:
     "@types/react-dom": "npm:^18.3.7"
     blurhash: "npm:^2.0.5"
     classnames: "npm:^2.5.1"
-    framer-plugin: "npm:^3.3.2"
+    framer-plugin: "npm:3.5.2"
     react: "npm:^18.3.1"
     react-blurhash: "npm:^0.3.0"
     react-dom: "npm:^18.3.1"


### PR DESCRIPTION
### Description

This pull request moves the "Random Image" button to the plugin menu in Unsplash to save 60px of vertical space.

https://framer-team.slack.com/archives/C06L5H5ADK2/p1753724409466209

Before and after:

<img width="1136" height="1348" alt="image" src="https://github.com/user-attachments/assets/7899d412-094f-4f85-9167-62a72d59afa0" />
<img width="2520" height="1362" alt="image" src="https://github.com/user-attachments/assets/423e6554-8b77-458f-86bd-fa38a763d951" />
