### PR TITLE
Revert to fetch.tools domain

### DIFF
--- a/plugins/airtable/src/auth.ts
+++ b/plugins/airtable/src/auth.ts
@@ -30,7 +30,7 @@ class Auth {
     constructor() {
         this.AUTH_URI = location.hostname.includes("localhost")
             ? "https://localhost:8787"
-            : "https://oauth.framer.wtf/airtable-plugin"
+            : "https://oauth.fetch.tools/airtable-plugin"
     }
 
     async logout() {

--- a/plugins/google-search-console/package.json
+++ b/plugins/google-search-console/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "run g:dev",
-        "build": "VITE_OAUTH_API_DOMAIN=https://oauth.framer.wtf/google-search-console-plugin run g:build",
+        "build": "VITE_OAUTH_API_DOMAIN=https://oauth.fetch.tools/google-search-console-plugin run g:build",
         "check-biome": "run g:check-biome",
         "check-eslint": "run g:check-eslint",
         "pack": "npx framer-plugin-tools@latest pack",

--- a/plugins/google-sheets/src/auth.ts
+++ b/plugins/google-sheets/src/auth.ts
@@ -33,7 +33,7 @@ class Auth {
     constructor() {
         this.AUTH_URI = location.hostname.includes("localhost")
             ? "https://localhost:8787"
-            : "https://oauth.framer.wtf/google-sheets-plugin"
+            : "https://oauth.fetch.tools/google-sheets-plugin"
     }
 
     async logout() {

--- a/plugins/hubspot/src/auth.ts
+++ b/plugins/hubspot/src/auth.ts
@@ -32,7 +32,7 @@ const pluginTokensKey = "hubspotTokens"
 
 const isLocal = () => window.location.hostname.includes("localhost")
 
-const AUTH_URI = isLocal() ? "https://localhost:8787" : "https://oauth.framer.wtf/hubspot-plugin"
+const AUTH_URI = isLocal() ? "https://localhost:8787" : "https://oauth.fetch.tools/hubspot-plugin"
 
 class Auth {
     storedTokens?: StoredTokens | null


### PR DESCRIPTION
### Description

This pull request reverts the OAuth worker domain from framer.wtf to fetch.tools. A few weeks ago fetch.tools couldn't be used, so the team switched to framer.wtf temporarily but now fetch.tools is back.

Currently fetch.tools and framer.wtf are the same.

### Testing

Check that these plugins work the same with the new domain:
- [x] Airtable
- [x] Search Console
- [x] Google Sheets
- [x] HubSpot