### PR TITLE
fix(ci): update PR description check to use environment variable

### DIFF
--- a/.github/workflows/shippy.yml
+++ b/.github/workflows/shippy.yml
@@ -25,9 +25,10 @@ jobs:
     if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Check PR description
-        run: |
-          trimmed="$(echo "${{ github.event.pull_request.body }}" | xargs)"
-          if [ -z "$trimmed" ]; then
-            echo "❌ PR description is required."
-            exit 1
-          fi
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prBody = context.payload.pull_request.body?.trim()
+            if (!prBody) {
+              core.setFailed("❌ PR description is required.")
+            }


### PR DESCRIPTION
## Description
This pull request fixes a shell escaping issue in the Shippy workflow that caused PR description validation to fail when the PR body contained a `(`.

**Problem**: The workflow was directly expanding ${{ github.event.pull_request.body }} into a shell command, which broke when the PR body contained special characters like quotes, causing syntax errors.
**Solution**: Use JavaScript. Everything is better with JavaScript! No escaping issues when doing so.

## Testing
- [x] This (yeah, "this") check doesn't crash the check