### PR TITLE
HubSpot: fix dates and alt text in blog CMS

### DIFF
--- a/plugins/hubspot/src/blog.ts
+++ b/plugins/hubspot/src/blog.ts
@@ -88,7 +88,11 @@ export async function getBlogPluginContext(): Promise<BlogPluginContext> {
     }
 }
 
-function getFieldDataEntryInput(field: ManagedCollectionFieldInput, value: unknown): FieldDataEntryInput | undefined {
+function getFieldDataEntryInput(
+    field: ManagedCollectionFieldInput,
+    value: unknown,
+    post?: BlogPost
+): FieldDataEntryInput | undefined {
     switch (field.type) {
         case "string": {
             if (typeof value !== "string") return undefined
@@ -101,7 +105,7 @@ function getFieldDataEntryInput(field: ManagedCollectionFieldInput, value: unkno
         }
 
         case "date": {
-            if (typeof value !== "number") return undefined
+            if (typeof value !== "string") return undefined
             return { type: "date", value: new Date(value).toUTCString() }
         }
 
@@ -117,6 +121,15 @@ function getFieldDataEntryInput(field: ManagedCollectionFieldInput, value: unkno
 
         case "image": {
             if (typeof value !== "string") return undefined
+
+            // Include alt text in featuredImage
+            if (field.id === "featuredImage" && post) {
+                const alt = post.featuredImageAltText
+                if (alt) {
+                    return { type: "image", value, alt }
+                }
+            }
+
             return { type: "image", value }
         }
 
@@ -171,7 +184,7 @@ function processPost({ post, fieldsById, unsyncedItemIds, status }: ProcessPostP
         // Not included in field mapping, skip
         if (!field) continue
 
-        const fieldDataEntryInput = getFieldDataEntryInput(field, propertyValue)
+        const fieldDataEntryInput = getFieldDataEntryInput(field, propertyValue, post)
         if (fieldDataEntryInput) {
             fieldData[propertyName] = fieldDataEntryInput
         } else {


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request fixes importing dates (Publish Date, Created, and Updated fields) and featured image alt text in the HubSpot plugin's blog CMS sync feature.

Previously these three dates were not imported due to a bug in date handling.

<img width="270" height="253" alt="image" src="https://github.com/user-attachments/assets/8ff73b35-85f2-4937-88aa-d3d1174268e7" />

Featured Image already included the alt text as a separate text field, but it was not also imported as alt text on the image itself. Now alt text is imported in both places.

<img width="648" height="538" alt="image" src="https://github.com/user-attachments/assets/0a7a4ffc-a44d-4762-b100-d57433ea94a6" />

### Testing

- [ ] Test syncing blog content from HubSpot and view the Publish Date, Created, and Updated fields in Framer
- [ ] Test syncing an article with a featured image with alt text and check the Feature Image field's alt text

Slack thread: https://framer-team.slack.com/archives/C06L5H5ADK2/p1754046054072969