### PR TITLE
Google Sheets: add file type

### DIFF
--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -14,14 +14,15 @@ interface FieldTypeOption {
 }
 
 const fieldTypeOptions: FieldTypeOption[] = [
-    { type: "boolean", label: "Boolean" },
-    { type: "color", label: "Color" },
-    { type: "number", label: "Number" },
-    { type: "string", label: "String" },
+    { type: "string", label: "Plain Text" },
     { type: "formattedText", label: "Formatted Text" },
-    { type: "image", label: "Image" },
-    { type: "link", label: "Link" },
     { type: "date", label: "Date" },
+    { type: "link", label: "Link" },
+    { type: "image", label: "Image" },
+    { type: "color", label: "Color" },
+    { type: "boolean", label: "Toggle" },
+    { type: "number", label: "Number" },
+    { type: "file", label: "File" },
 ]
 
 const getInitialSlugColumn = (context: PluginContext, slugFields: ManagedCollectionFieldInput[]): string => {
@@ -232,6 +233,10 @@ export function MapSheetFieldsPage({
                 const maybeOverride = fieldNameOverrides[field.id]
                 if (maybeOverride) {
                     field.name = maybeOverride
+                }
+
+                if (field.type === "file") {
+                    field.allowedFileTypes = []
                 }
 
                 return field

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -312,6 +312,7 @@ function getFieldDataEntryInput(type: CollectionFieldType, cellValue: CellValue)
         case "enum":
         case "image":
         case "link":
+        case "file":
         case "formattedText":
         case "color":
         case "string": {


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request adds the File field type to Google Sheets and updates the names and order of field types to match the field editor in Framer.

<img width="437" height="235" alt="image" src="https://github.com/user-attachments/assets/3b956a26-dab7-4d25-8c91-c26d8729a33f" />

### Testing

- [ ] Change a column's type to File and sync