### PR TITLE
Code Versions: improve padding

### DIFF
--- a/plugins/code-versions/src/components/FileDiff.tsx
+++ b/plugins/code-versions/src/components/FileDiff.tsx
@@ -149,7 +149,7 @@ function getEdgeBorderClass(type: "add" | "remove", isTopEdge = false, isBottomE
 }
 
 function Mark({ children, className }: { children: React.ReactNode; className?: string }) {
-    return <mark className={cn("h-(--code-row-height) inline-block", className)}>{children}</mark>
+    return <mark className={cn("h-(--code-row-height) inline-block pr-3", className)}>{children}</mark>
 }
 
 function InlineDiffs({ parts, type }: { parts: readonly InlineDiff[]; type: "add" | "remove" }) {

--- a/plugins/code-versions/src/components/VersionColumn.tsx
+++ b/plugins/code-versions/src/components/VersionColumn.tsx
@@ -24,8 +24,8 @@ export function VersionColumn({ state, clearErrors, restoreVersion }: VersionCol
     return (
         <>
             <div className="bg-code-area-light dark:bg-code-area-dark relative overflow-hidden">
-                <div className="absolute inset-0 mx-3 mt-3">
-                    <div className="overflow-auto scrollbar-hidden h-full pb-3">
+                <div className="absolute inset-0">
+                    <div className="overflow-auto scrollbar-hidden h-full py-3 pl-3">
                         {state.content.data === undefined || currentContent === undefined ? null : (
                             <Code
                                 original={state.content.data}


### PR DESCRIPTION
### Description

This pull request moves the padding in the code viewer inside the scrollable area, allowing the code to be visible to the edges.

| Before | After |
| --- | --- |
| Code is clipped by 15px padding on top and sides | Padding is inside the scrollable area |
| <img width="787" height="554" alt="Pasted Graphic 8" src="https://github.com/user-attachments/assets/04b7aaa9-5deb-4e26-9b4c-cab3f1aa34ee" /> | <img width="787" height="554" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/8c11fde6-a57b-4f08-8524-6493948419c8" /> |
| <img width="787" height="554" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/e0e3774e-9937-4cc8-996b-2412769e5d63" /> | <img width="787" height="554" alt="Pasted Graphic 7" src="https://github.com/user-attachments/assets/647aec5f-6d0a-46b0-bfba-879e3fb48930" /> |