### PR TITLE
Airtable: ensure there is only one protocol when sync email/phone fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,50 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
             - uses: actions/setup-node@v4
               with:
                   node-version-file: .tool-versions
 
-            - run: yarn
+            - name: Get changed files
+              id: changed-files
+              uses: tj-actions/changed-files@v45
+              with:
+                  files: |
+                      plugins/*/src/**
+                      plugins/*/test/**
+                      plugins/*/*.test.ts
+                      plugins/*/*.test.tsx
+                      plugins/*/vitest.config.ts
+                      plugins/*/test-setup.ts
 
-            - run: yarn turbo test
+            - name: Install dependencies
+              if: steps.changed-files.outputs.any_changed == 'true'
+              run: yarn
+
+            - name: Get changed plugins
+              if: steps.changed-files.outputs.any_changed == 'true'
+              id: changed-plugins
+              run: |
+                # Extract unique plugin names from changed files
+                PLUGINS=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" | \
+                  grep -E '^plugins/[^/]+/' | \
+                  cut -d'/' -f2 | \
+                  sort -u | \
+                  tr '\n' ' ')
+                echo "plugins=$PLUGINS" >> $GITHUB_OUTPUT
+                echo "Changed plugins: $PLUGINS"
+
+            - name: Run tests for changed plugins
+              if: steps.changed-files.outputs.any_changed == 'true' && steps.changed-plugins.outputs.plugins != ''
+              run: |
+                for plugin in ${{ steps.changed-plugins.outputs.plugins }}; do
+                  echo "Checking tests for plugin: $plugin"
+                  if [ -f "plugins/$plugin/package.json" ] && grep -q '"check-vitest"' "plugins/$plugin/package.json"; then
+                    yarn workspace $plugin check-vitest
+                  else
+                    echo "No check-vitest script found for $plugin, skipping..."
+                  fi
+                done

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "plugins/*"
     ],
     "scripts": {
-        "check": "turbo run --continue check-biome check-eslint check-prettier check-svelte check-typescript test",
+        "check": "turbo run --continue check-biome check-eslint check-prettier check-svelte check-typescript check-vitest",
         "dev": "turbo run dev --concurrency=40",
         "fix-biome": "turbo run --continue check-biome -- --write",
         "fix-eslint": "turbo run --continue check-eslint -- --fix",
@@ -18,6 +18,7 @@
         "g:check-biome": "biome check $INIT_CWD",
         "g:check-eslint": "cd $INIT_CWD && DEBUG='eslint:eslint' eslint --report-unused-disable-directives-severity error .",
         "g:check-typescript": "tsc --project $INIT_CWD",
+        "g:check-vitest": "cd $INIT_CWD && vitest run",
         "g:dev": "cd $INIT_CWD && run g:vite",
         "g:preview": "cd $INIT_CWD && run g:vite preview",
         "g:vite": "cd $INIT_CWD && NODE_OPTIONS='--no-warnings=ExperimentalWarning' vite --config $PROJECT_CWD/packages/vite-config/src/index.ts",

--- a/plugins/airtable/package.json
+++ b/plugins/airtable/package.json
@@ -10,7 +10,8 @@
         "check-eslint": "run g:check-eslint",
         "preview": "run g:preview",
         "pack": "npx framer-plugin-tools@latest pack",
-        "check-typescript": "run g:check-typescript"
+        "check-typescript": "run g:check-typescript",
+        "check-vitest": "vitest run"
     },
     "dependencies": {
         "framer-plugin": "^3.5.2",

--- a/plugins/airtable/package.json
+++ b/plugins/airtable/package.json
@@ -21,6 +21,8 @@
     },
     "devDependencies": {
         "@types/react": "^18.3.23",
-        "@types/react-dom": "^18.3.7"
+        "@types/react-dom": "^18.3.7",
+        "happy-dom": "^18.0.1",
+        "vitest": "^3.2.4"
     }
 }

--- a/plugins/airtable/src/data.test.ts
+++ b/plugins/airtable/src/data.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { getFieldDataEntryForFieldSchema } from "./data"
+import type { PossibleField } from "./fields"
+
+describe("getFieldDataEntryForFieldSchema", () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    const createEmailField = (): PossibleField => ({
+        id: "email_field",
+        name: "Email",
+        type: "link",
+        userEditable: true,
+        airtableType: "email",
+    })
+
+    const createPhoneField = (): PossibleField => ({
+        id: "phone_field",
+        name: "Phone",
+        type: "link",
+        userEditable: true,
+        airtableType: "phoneNumber",
+    })
+
+    describe("Email field processing", () => {
+        it("should add mailto: prefix to email without prefix", () => {
+            const result = getFieldDataEntryForFieldSchema(createEmailField(), "user@example.com")
+
+            expect(result).toEqual({
+                value: "mailto:user@example.com",
+                type: "link",
+            })
+        })
+
+        it("should preserve single mailto: prefix", () => {
+            const result = getFieldDataEntryForFieldSchema(createEmailField(), "mailto:user@example.com")
+
+            expect(result).toEqual({
+                value: "mailto:user@example.com",
+                type: "link",
+            })
+        })
+
+        it("should normalize multiple mailto: prefixes to one", () => {
+            const result = getFieldDataEntryForFieldSchema(createEmailField(), "mailto:mailto:user@example.com")
+
+            expect(result).toEqual({
+                value: "mailto:user@example.com",
+                type: "link",
+            })
+        })
+
+        it("should handle case insensitive mailto: prefix", () => {
+            const result = getFieldDataEntryForFieldSchema(createEmailField(), "MAILTO:user@example.com")
+
+            expect(result).toEqual({
+                value: "mailto:user@example.com",
+                type: "link",
+            })
+        })
+
+        it("should detect email by regex when field type is not email", () => {
+            const linkField: PossibleField = {
+                id: "link_field",
+                name: "Link",
+                type: "link",
+                userEditable: true,
+                airtableType: "url", // Not an email field type
+            }
+
+            const result = getFieldDataEntryForFieldSchema(linkField, "test@domain.co.uk")
+
+            expect(result).toEqual({
+                value: "mailto:test@domain.co.uk",
+                type: "link",
+            })
+        })
+    })
+
+    describe("Phone field processing", () => {
+        it("should add tel: prefix to phone without prefix", () => {
+            const result = getFieldDataEntryForFieldSchema(createPhoneField(), "+1234567890")
+
+            expect(result).toEqual({
+                value: "tel:+1234567890",
+                type: "link",
+            })
+        })
+
+        it("should preserve single tel: prefix", () => {
+            const result = getFieldDataEntryForFieldSchema(createPhoneField(), "tel:+1234567890")
+
+            expect(result).toEqual({
+                value: "tel:+1234567890",
+                type: "link",
+            })
+        })
+
+        it("should normalize multiple tel: prefixes to one", () => {
+            const result = getFieldDataEntryForFieldSchema(createPhoneField(), "tel:tel:+1234567890")
+
+            expect(result).toEqual({
+                value: "tel:+1234567890",
+                type: "link",
+            })
+        })
+
+        it("should handle case insensitive tel: prefix", () => {
+            const result = getFieldDataEntryForFieldSchema(createPhoneField(), "TEL:+1234567890")
+
+            expect(result).toEqual({
+                value: "tel:+1234567890",
+                type: "link",
+            })
+        })
+
+        it("should detect phone by regex when field type is not phoneNumber", () => {
+            const linkField: PossibleField = {
+                id: "link_field",
+                name: "Link",
+                type: "link",
+                userEditable: true,
+                airtableType: "url", // Not a phone field type
+            }
+
+            const result = getFieldDataEntryForFieldSchema(linkField, "1234567890")
+
+            expect(result).toEqual({
+                value: "tel:1234567890",
+                type: "link",
+            })
+        })
+    })
+})

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -65,6 +65,12 @@ export async function getTables(baseId: string, signal: AbortSignal): Promise<Ai
 const EMAIL_REGEX = /\S[^\s@]*@\S+\.\S+/
 const PHONE_REGEX = /^(\+?[0-9])[0-9]{7,14}$/
 
+const MAILTO_PREFIX = "mailto:"
+const TEL_PREFIX = "tel:"
+
+const MAILTO_REGEX = new RegExp(MAILTO_PREFIX, "gi")
+const TEL_REGEX = new RegExp(TEL_PREFIX, "gi")
+
 const NonEmptyArrayOfAttachmentsSchema = v.pipe(
     v.array(v.object({ type: v.optional(v.string()), id: v.string(), url: v.string() })),
     v.minLength(1)
@@ -73,7 +79,10 @@ const NonEmptyArrayOfAttachmentsSchema = v.pipe(
 const ArrayOfStringsSchema = v.array(v.string())
 const NonEmptyArrayOfStringsSchema = v.pipe(ArrayOfStringsSchema, v.minLength(1))
 
-function getFieldDataEntryForFieldSchema(fieldSchema: PossibleField, value: unknown): FieldDataEntryInput | null {
+export function getFieldDataEntryForFieldSchema(
+    fieldSchema: PossibleField,
+    value: unknown
+): FieldDataEntryInput | null {
     // If the field is a lookup field, only use the first value from the array.
     if (fieldSchema.originalAirtableType === "multipleLookupValues") {
         if (!Array.isArray(value)) return null
@@ -94,14 +103,14 @@ function getFieldDataEntryForFieldSchema(fieldSchema: PossibleField, value: unkn
             if (typeof value === "string") {
                 if (fieldSchema.airtableType === "email" || EMAIL_REGEX.test(value)) {
                     return {
-                        value: `mailto:${value}`,
+                        value: `${MAILTO_PREFIX}${value.replace(MAILTO_REGEX, "")}`,
                         type: "link",
                     }
                 }
 
                 if (fieldSchema.airtableType === "phoneNumber" || PHONE_REGEX.test(value)) {
                     return {
-                        value: `tel:${value}`,
+                        value: `${TEL_PREFIX}${value.replace(TEL_REGEX, "")}`,
                         type: "link",
                     }
                 }

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -65,11 +65,15 @@ export async function getTables(baseId: string, signal: AbortSignal): Promise<Ai
 const EMAIL_REGEX = /\S[^\s@]*@\S+\.\S+/
 const PHONE_REGEX = /^(\+?[0-9])[0-9]{7,14}$/
 
-const MAILTO_PREFIX = "mailto:"
-const TEL_PREFIX = "tel:"
-
-const MAILTO_REGEX = new RegExp(MAILTO_PREFIX, "gi")
-const TEL_REGEX = new RegExp(TEL_PREFIX, "gi")
+/**
+ * Helper function to ensure a value has the specified prefix,
+ * removing any existing instances of the prefix first
+ */
+function ensurePrefix(prefix: string, value: string): string {
+    const regex = new RegExp(prefix, "gi")
+    const result = value.replace(regex, "")
+    return `${prefix}${result}`
+}
 
 const NonEmptyArrayOfAttachmentsSchema = v.pipe(
     v.array(v.object({ type: v.optional(v.string()), id: v.string(), url: v.string() })),
@@ -103,14 +107,14 @@ export function getFieldDataEntryForFieldSchema(
             if (typeof value === "string") {
                 if (fieldSchema.airtableType === "email" || EMAIL_REGEX.test(value)) {
                     return {
-                        value: `${MAILTO_PREFIX}${value.replace(MAILTO_REGEX, "")}`,
+                        value: ensurePrefix("mailto:", value),
                         type: "link",
                     }
                 }
 
                 if (fieldSchema.airtableType === "phoneNumber" || PHONE_REGEX.test(value)) {
                     return {
-                        value: `${TEL_PREFIX}${value.replace(TEL_REGEX, "")}`,
+                        value: ensurePrefix("tel:", value),
                         type: "link",
                     }
                 }

--- a/plugins/airtable/test-setup.ts
+++ b/plugins/airtable/test-setup.ts
@@ -1,0 +1,8 @@
+import { vi } from "vitest"
+
+// Mock framer-plugin for tests
+vi.mock("framer-plugin", () => ({
+    framer: {
+        showUI: vi.fn(),
+    },
+}))

--- a/plugins/airtable/vitest.config.ts
+++ b/plugins/airtable/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+    test: {
+        environment: "happy-dom",
+        setupFiles: ["./test-setup.ts"],
+    },
+})

--- a/plugins/code-versions/package.json
+++ b/plugins/code-versions/package.json
@@ -11,7 +11,7 @@
         "preview": "run g:preview",
         "pack": "npx framer-plugin-tools@latest pack",
         "check-typescript": "run g:check-typescript",
-        "test": "vitest run",
+        "check-vitest": "run g:check-vitest",
         "test-watch": "vitest"
     },
     "dependencies": {

--- a/plugins/global-search/package.json
+++ b/plugins/global-search/package.json
@@ -11,7 +11,7 @@
         "preview": "run g:preview",
         "pack": "npx framer-plugin-tools@latest pack",
         "check-typescript": "run g:check-typescript",
-        "test": "vitest"
+        "check-vitest": "run g:check-vitest"
     },
     "dependencies": {
         "clsx": "^2.1.1",

--- a/turbo.json
+++ b/turbo.json
@@ -31,6 +31,6 @@
             "cache": false,
             "persistent": true
         },
-        "test": {}
+        "check-vitest": {}
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3187,10 +3187,12 @@ __metadata:
     "@types/react": "npm:^18.3.23"
     "@types/react-dom": "npm:^18.3.7"
     framer-plugin: "npm:^3.5.2"
+    happy-dom: "npm:^18.0.1"
     marked: "npm:^16.1.1"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     valibot: "npm:^1.1.0"
+    vitest: "npm:^3.2.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

This pull request adds unit tests for the Airtable plugin's email and phone number field processing. It improves the handling of `mailto:` and `tel:` prefixes by normalizing them to ensure proper formatting regardless of input format. The implementation now correctly handles:

- Adding appropriate prefixes when missing
- Preserving single prefixes
- Normalizing multiple prefixes to a single one
- Supporting case-insensitive prefixes
- Detecting email and phone formats via regex

The PR also sets up the testing infrastructure with Vitest and Happy-DOM for the Airtable plugin.

See https://framer-team.slack.com/archives/C06L5H5ADK2/p1754387147011229

### QA

- [x] Email field processing
  - Verify `mailto:` prefix is added to emails without prefix
  - Verify single `mailto:` prefix is preserved
  - Verify multiple `mailto:` prefixes are normalized to one
  - Verify case-insensitive `mailto:` prefix handling works
  - Verify email detection by regex works for non-email field types
- [x] Phone field processing
  - Verify `tel:` prefix is added to phone numbers without prefix
  - Verify single `tel:` prefix is preserved
  - Verify multiple `tel:` prefixes are normalized to one
  - Verify case-insensitive `tel:` prefix handling works
  - Verify phone detection by regex works for non-phone field types