### PR TITLE
HubSpot: fix auth validation

### DIFF
--- a/plugins/hubspot/src/auth.ts
+++ b/plugins/hubspot/src/auth.ts
@@ -5,8 +5,7 @@ const TokensSchema = v.object({
     access_token: v.string(),
     refresh_token: v.string(),
     expires_in: v.number(),
-    scope: v.string(),
-    token_type: v.literal("Bearer"),
+    token_type: v.literal("bearer"),
 })
 
 type Tokens = v.InferOutput<typeof TokensSchema>
@@ -22,7 +21,6 @@ type StoredTokens = v.InferOutput<typeof StoredTokensSchema>
 
 const AuthorizeSchema = v.object({
     url: v.string(),
-    writeKey: v.string(),
     readKey: v.string(),
 })
 


### PR DESCRIPTION
### Description

This pull request fixes auth validation in the HubSpot plugin.

It was broken by this change which switched from using an interface to a valibot schema. The original interface was incorrect, but it wasn't enforced, so when switching to a validated schema auth started failing. A new version hasn't been released since this change, so it hasn't affected any users - it just needs to be merged before the next version is released.

https://github.com/framer/plugins/commit/2572d65f7e95bb342cce41cfbe7b7d8d43a05679#:~:text=plugins/hubspot/src/auth.ts

### Testing

- [x] Log into the HubSpot plugin
- [x] Close and re-open the plugin and verify that you are still signed in
- [x] Log out of the plugin