### PR TITLE
Airtable: add error handling to base selection page

### DIFF
--- a/plugins/airtable/src/App.css
+++ b/plugins/airtable/src/App.css
@@ -82,6 +82,19 @@ select:not(:disabled) {
     width: 100%;
 }
 
+.setup-error {
+    align-items: center;
+}
+
+.setup-error span {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    align-items: center;
+    justify-content: center;
+}
+
 .mapping {
     padding-bottom: 0;
 }

--- a/plugins/airtable/src/App.css
+++ b/plugins/airtable/src/App.css
@@ -75,6 +75,13 @@ select:not(:disabled) {
     width: 164px;
 }
 
+.setup-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+}
+
 .mapping {
     padding-bottom: 0;
 }

--- a/plugins/airtable/src/SelectDataSource.tsx
+++ b/plugins/airtable/src/SelectDataSource.tsx
@@ -1,5 +1,5 @@
 import { framer, type ManagedCollection } from "framer-plugin"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import auth from "./auth"
 import type { AirtableBase, AirtableTable, DataSource } from "./data"
 import { getTables, getUserBases } from "./data"
@@ -21,6 +21,9 @@ export function SelectDataSource({ collection, onSelectDataSource }: SelectDataS
     const [selectedTableId, setSelectedTableId] = useState<string>("")
     const [isLoading, setIsLoading] = useState(false)
 
+    const basesLoadedRef = useRef(false)
+    const lastBaseIdRef = useRef<string>("")
+
     const selectedBase = bases.find(base => base.id === selectedBaseId)
 
     const loadBases = async () => {
@@ -38,13 +41,16 @@ export function SelectDataSource({ collection, onSelectDataSource }: SelectDataS
     }
 
     useEffect(() => {
+        if (basesLoadedRef.current) return
+        basesLoadedRef.current = true
         void loadBases()
     }, [])
 
     useEffect(() => {
         const abortController = new AbortController()
 
-        if (selectedBaseId) {
+        if (selectedBaseId && selectedBaseId !== lastBaseIdRef.current) {
+            lastBaseIdRef.current = selectedBaseId
             setStatus("loading-tables")
             setTables([])
             setSelectedTableId("")

--- a/plugins/airtable/src/SelectDataSource.tsx
+++ b/plugins/airtable/src/SelectDataSource.tsx
@@ -20,6 +20,8 @@ export function SelectDataSource({ collection, onSelectDataSource }: SelectDataS
     const [selectedTableId, setSelectedTableId] = useState<string>("")
     const [isLoading, setIsLoading] = useState(false)
 
+    const selectedBase = bases.find(base => base.id === selectedBaseId)
+
     useEffect(() => {
         setStatus("loading-bases")
 
@@ -58,7 +60,7 @@ export function SelectDataSource({ collection, onSelectDataSource }: SelectDataS
                     console.error(error)
                     setStatus("error-tables")
 
-                    const baseName = bases.find(base => base.id === selectedBaseId)?.name ?? selectedBaseId
+                    const baseName = selectedBase?.name ?? selectedBaseId
                     framer.notify(`Failed to load tables for base "${baseName}". Check the logs for more details.`, {
                         variant: "error",
                     })
@@ -71,7 +73,7 @@ export function SelectDataSource({ collection, onSelectDataSource }: SelectDataS
         return () => {
             abortController.abort()
         }
-    }, [selectedBaseId])
+    }, [selectedBaseId, selectedBase])
 
     const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault()

--- a/plugins/airtable/src/SelectDataSource.tsx
+++ b/plugins/airtable/src/SelectDataSource.tsx
@@ -5,6 +5,14 @@ import type { AirtableBase, AirtableTable, DataSource } from "./data"
 import { getTables, getUserBases } from "./data"
 import { inferFields } from "./fields"
 
+const STATUS_MAP = {
+    "loading-bases": { bases: "Loading…", tables: "Choose…" },
+    "error-bases": { bases: "Error", tables: "Error" },
+    "loading-tables": { bases: "Choose…", tables: "Loading…" },
+    "error-tables": { bases: "Choose…", tables: "Error" },
+    ready: { bases: "Choose…", tables: "Choose…" },
+}
+
 interface SelectDataSourceProps {
     collection: ManagedCollection
     onSelectDataSource: (dataSource: DataSource) => void
@@ -25,6 +33,7 @@ export function SelectDataSource({ collection, onSelectDataSource }: SelectDataS
     const lastBaseIdRef = useRef<string>("")
 
     const selectedBase = bases.find(base => base.id === selectedBaseId)
+    const { bases: basesPlaceholderText, tables: tablesPlaceholderText } = STATUS_MAP[status]
 
     const loadBases = async () => {
         setStatus("loading-bases")
@@ -125,32 +134,6 @@ export function SelectDataSource({ collection, onSelectDataSource }: SelectDataS
     const handleLogout = () => {
         void auth.logout()
     }
-
-    const [basesPlaceholderText, tablesPlaceholderText] = useMemo(() => {
-        let basesText = "Choose…"
-        let tablesText = "Choose…"
-
-        switch (status) {
-            case "loading-bases":
-                basesText = "Loading…"
-                break
-            case "error-bases":
-                basesText = "Error"
-                break
-        }
-
-        switch (status) {
-            case "loading-tables":
-                tablesText = "Loading…"
-                break
-            case "error-bases":
-            case "error-tables":
-                tablesText = "Error"
-                break
-        }
-
-        return [basesText, tablesText]
-    }, [status])
 
     if (status === "error-bases") {
         return (

--- a/plugins/airtable/src/SelectDataSource.tsx
+++ b/plugins/airtable/src/SelectDataSource.tsx
@@ -1,5 +1,5 @@
 import { framer, type ManagedCollection } from "framer-plugin"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import auth from "./auth"
 import type { AirtableBase, AirtableTable, DataSource } from "./data"
 import { getTables, getUserBases } from "./data"

--- a/plugins/airtable/src/SelectDataSource.tsx
+++ b/plugins/airtable/src/SelectDataSource.tsx
@@ -1,5 +1,5 @@
 import { framer, type ManagedCollection } from "framer-plugin"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import type { AirtableBase, AirtableTable, DataSource } from "./data"
 import { getTables, getUserBases } from "./data"
 import { inferFields } from "./fields"
@@ -110,6 +110,32 @@ export function SelectDataSource({ collection, onSelectDataSource }: SelectDataS
         void task()
     }
 
+    const [basesPlaceholderText, tablesPlaceholderText] = useMemo(() => {
+        let basesText = "Choose…"
+        let tablesText = "Choose…"
+
+        switch (status) {
+            case "loading-bases":
+                basesText = "Loading…"
+                break
+            case "error-bases":
+                basesText = "Error"
+                break
+        }
+
+        switch (status) {
+            case "loading-tables":
+                tablesText = "Loading…"
+                break
+            case "error-bases":
+            case "error-tables":
+                tablesText = "Error"
+                break
+        }
+
+        return [basesText, tablesText]
+    }, [status])
+
     return (
         <form className="framer-hide-scrollbar setup" onSubmit={handleSubmit}>
             <div className="logo">
@@ -128,7 +154,7 @@ export function SelectDataSource({ collection, onSelectDataSource }: SelectDataS
                         disabled={status === "loading-bases" || status === "error-bases"}
                     >
                         <option value="" disabled>
-                            {status === "loading-bases" ? "Loading…" : status === "error-bases" ? "Error" : "Choose…"}
+                            {basesPlaceholderText}
                         </option>
                         {bases.map(({ id, name }) => (
                             <option key={id} value={id}>
@@ -154,11 +180,7 @@ export function SelectDataSource({ collection, onSelectDataSource }: SelectDataS
                         }
                     >
                         <option value="" disabled>
-                            {status === "loading-tables"
-                                ? "Loading…"
-                                : status === "error-tables" || status === "error-bases"
-                                  ? "Error"
-                                  : "Choose…"}
+                            {tablesPlaceholderText}
                         </option>
                         {tables.map(({ id, name }) => (
                             <option key={id} value={id}>


### PR DESCRIPTION
### Description

This pull request adds error handling for API calls to the base selection page.

Closes https://github.com/framer/plugins/issues/366

The Airtable base I was using for testing somehow became corrupted, and it won't open in Airtable. API calls to get the base info also fail, which is how I found out that if there's an API error, it says "Loading..." forever and doesn't tell you there was an error.

**Changes:**
* Show a notification and show "Error" if the tables or bases API call fails.
* Reduced the spacing between the select rows from 15px to 10px.

Left: fetching list of all bases fails
Right: fetching info for the selected base fails
<img width="1366" height="848" alt="image" src="https://github.com/user-attachments/assets/30ca7d1a-fb21-4be7-ac35-31fccd8f4f8f" />

<img width="1190" height="168" alt="image" src="https://github.com/user-attachments/assets/0bcc6373-c5d9-4979-a87c-f592bb73c813" />

### Testing

To simulate an API error, add `throw new Error()` to the top of the `getUserBases` and `getTables` functions (not at the same time). This has the same effect as it failing to fetch from the API.

- [x] Test bases failing to load
- [x] Test tables failing to load