### PR TITLE
HubSpot: keep plugin open after logging out

### DIFF
--- a/plugins/hubspot/src/App.tsx
+++ b/plugins/hubspot/src/App.tsx
@@ -182,6 +182,7 @@ export function App() {
             const isInCMSModes = mode === "syncManagedCollection" || mode === "configureManagedCollection"
 
             if (!isAuthenticated) {
+                void framer.setMenu([])
                 navigate("/")
                 return
             }
@@ -192,9 +193,6 @@ export function App() {
                     visible: true,
                     onAction: () => {
                         auth.logout()
-                        framer.closePlugin(
-                            "To fully remove the integration, uninstall the Framer app from the HubSpot integrations dashboard."
-                        )
                     },
                 },
             ])

--- a/plugins/hubspot/src/App.tsx
+++ b/plugins/hubspot/src/App.tsx
@@ -182,20 +182,9 @@ export function App() {
             const isInCMSModes = mode === "syncManagedCollection" || mode === "configureManagedCollection"
 
             if (!isAuthenticated) {
-                void framer.setMenu([])
                 navigate("/")
                 return
             }
-
-            void framer.setMenu([
-                {
-                    label: "Log Out",
-                    visible: true,
-                    onAction: () => {
-                        auth.logout()
-                    },
-                },
-            ])
 
             if (isInCMSModes) {
                 return handleCMSModes()
@@ -212,6 +201,22 @@ export function App() {
                 framer.closePlugin(error instanceof Error ? error.message : "Unknown error", { variant: "error" })
             )
     }, [navigate, isAuthenticated])
+
+    useEffect(() => {
+        if (isAuthenticated) {
+            void framer.setMenu([
+                {
+                    label: "Log Out",
+                    visible: true,
+                    onAction: () => {
+                        auth.logout()
+                    },
+                },
+            ])
+        } else {
+            void framer.setMenu([])
+        }
+    }, [isAuthenticated])
 
     if (isLoading) return null
 

--- a/plugins/hubspot/src/auth.ts
+++ b/plugins/hubspot/src/auth.ts
@@ -1,3 +1,4 @@
+import { framer } from "framer-plugin"
 import * as v from "valibot"
 import { PluginError } from "./PluginError"
 
@@ -98,6 +99,11 @@ class Auth {
 
     logout() {
         this.tokens.clear()
+        framer.notify(
+            "To fully remove the integration, uninstall the Framer app from the HubSpot integrations dashboard.",
+            { durationMs: 5000 }
+        )
+        window.location.reload()
     }
 
     public readonly tokens = {

--- a/plugins/hubspot/src/components/PageErrorBoundaryFallback.tsx
+++ b/plugins/hubspot/src/components/PageErrorBoundaryFallback.tsx
@@ -29,7 +29,6 @@ export const PageErrorBoundaryFallback = ({ children }: PropsWithChildren) => (
                                         onClick={e => {
                                             e.preventDefault()
                                             auth.logout()
-                                            void framer.closePlugin()
                                         }}
                                     >
                                         log out

--- a/plugins/hubspot/src/components/PageErrorBoundaryFallback.tsx
+++ b/plugins/hubspot/src/components/PageErrorBoundaryFallback.tsx
@@ -1,5 +1,4 @@
 import { QueryErrorResetBoundary } from "@tanstack/react-query"
-import { framer } from "framer-plugin"
 import type { PropsWithChildren } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 import * as v from "valibot"

--- a/plugins/hubspot/src/pages/canvas/Account.tsx
+++ b/plugins/hubspot/src/pages/canvas/Account.tsx
@@ -1,4 +1,3 @@
-import { framer } from "framer-plugin"
 import { useUserQuery } from "../../api"
 import auth from "../../auth"
 import { CenteredSpinner } from "../../components/CenteredSpinner"
@@ -8,9 +7,6 @@ export default function AccountPage() {
 
     const handleLogout = () => {
         auth.logout()
-        void framer.closePlugin(
-            "Uninstall the Framer app from the HubSpot integrations dashboard to complete the removal"
-        )
     }
 
     if (isLoadingUser) return <CenteredSpinner />


### PR DESCRIPTION
### Description

This pull request improves the log out UX in the HubSpot plugin.

Instead of closing the plugin, it reloads and shows a notification. This is consistent with all of our other plugins that have log out functionality.

Closes https://github.com/framer/plugins/issues/345

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [ ] Sign in with HubSpot
- [ ] Test log out button in menu
- [ ] Test log out button on account page