### PR TITLE
CSV Import: close plugin after error

### DIFF
--- a/plugins/csv-import/src/App.tsx
+++ b/plugins/csv-import/src/App.tsx
@@ -186,14 +186,14 @@ export function App({ collection }: { collection: Collection }) {
             } catch (error) {
                 console.error(error)
 
-                if (error instanceof ImportError) {
-                    framer.notify(error.message, {
+                if (error instanceof ImportError || error instanceof Error) {
+                    void framer.closePlugin(error.message, {
                         variant: "error",
                     })
                     return
                 }
 
-                framer.notify("Error processing CSV file. Check console for details.", {
+                void framer.closePlugin("Error processing CSV file. Check console for details.", {
                     variant: "error",
                 })
             }


### PR DESCRIPTION
### Description

This pull request makes the CSV Import plugin close is there's an error. Previously the plugin would stay open, resulting an an infinite loading spinner.

Closes https://github.com/framer/plugins/issues/305

It also makes the error message more descriptive by displaying the actual error message from the API.
<img width="662" height="82" alt="image" src="https://github.com/user-attachments/assets/1583a970-4fb8-4019-ab51-4882a1b55922" />

### Testing

Test CSV:
```
"Slug","Content"
"test","<img src=""https://www.hubspot.com/hubfs/Grow%20London/GROW22_logo_RGB_Grow%2022%20slogan.png"">"
```

- [x] Test copy and pasting into the plugin
- [x] Test saving it to a .csv file and uploading it