### PR TITLE
feat(global-search): nicer error boundary

### DIFF
--- a/plugins/global-search/src/App.tsx
+++ b/plugins/global-search/src/App.tsx
@@ -2,6 +2,7 @@ import { framer } from "framer-plugin"
 import { useEffect, useState } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 import { DevToolsScene } from "./components/DevToolsScene"
+import { ErrorScene } from "./components/ErrorScene"
 import { SearchScene } from "./components/SearchScene"
 import { IndexerProvider } from "./utils/indexer/IndexerProvider"
 import { getPluginSize } from "./utils/plugin-size"
@@ -26,14 +27,7 @@ export function App() {
     })
 
     return (
-        <ErrorBoundary
-            fallbackRender={({ error, resetErrorBoundary }) => (
-                <div>
-                    {error.message}
-                    <button onClick={resetErrorBoundary}>Reset</button>
-                </div>
-            )}
-        >
+        <ErrorBoundary FallbackComponent={ErrorScene}>
             <IndexerProvider>
                 {activeScene === "dev-tools" && <DevToolsScene />}
                 {activeScene === "search" && <SearchScene />}

--- a/plugins/global-search/src/components/ErrorScene.tsx
+++ b/plugins/global-search/src/components/ErrorScene.tsx
@@ -1,0 +1,32 @@
+import { framer } from "framer-plugin"
+import { useEffect } from "react"
+import { getPluginSize } from "../utils/plugin-size"
+
+export function ErrorScene() {
+    useEffect(() => {
+        framer.showUI({ ...getPluginSize({ query: "error", hasResults: false }), resizable: false })
+    }, [])
+    return (
+        <div className="flex-1 flex justify-center items-center select-none py-1 px-4">
+            <div className="text-center text-tertiary-light dark:text-tertiary-dark text-xs space-y-4">
+                <p>
+                    The plugin crashed.
+                    <br />
+                    Please close and reopen it.
+                </p>
+                <p>
+                    If it happens again,{" "}
+                    <a
+                        href="https://www.framer.com/contact"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline"
+                    >
+                        contact support
+                    </a>
+                    .
+                </p>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
### Description

Just making sure the error boundary is okay in case everything explodes.

| ☀️ | 🌜 |
|--------|--------|
| <img width="560" height="380" alt="development framer com_projects_Elmar-s-Project--FEc2IBtiQFNzT35Gfi0B-3Lq3d_node=AyDfzo1YR tunnel=" src="https://github.com/user-attachments/assets/dfe8b112-5781-478c-8f54-1fa82b6e4775" /> | <img width="560" height="380" alt="development framer com_projects_Elmar-s-Project--FEc2IBtiQFNzT35Gfi0B-3Lq3d_node=AyDfzo1YR tunnel= (1)" src="https://github.com/user-attachments/assets/2f446328-e66c-4d06-be85-7aa1e678e831" /> |


### Testing

- [x] The ErrorBoundary actually hits and looks okay
  -  put a `throw new Error` somewhere in the render flow