### PR TITLE
refactor(global-search): update plugin name and icon

### DIFF
--- a/plugins/global-search/framer.json
+++ b/plugins/global-search/framer.json
@@ -1,6 +1,6 @@
 {
     "id": "73ea97",
-    "name": "Global Search",
+    "name": "Text Search",
     "modes": ["canvas"],
     "icon": "/icon.svg"
 }

--- a/plugins/global-search/public/icon.svg
+++ b/plugins/global-search/public/icon.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
-  <path fill="#f3f3f3" d="M0 0h30v30H0Z"/>
-  <path fill="transparent" stroke="#999" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m12 11-4 4 4 4m6-8 4 4-4 4"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30"><path fill="#222" d="M0 0h30v30H0Z"/><path fill="transparent" stroke="#FFF" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3" d="M12.5 11v9M8 11h9"/><path fill="transparent" stroke="#FFF" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M21 8v15" opacity=".7"/></svg>


### PR DESCRIPTION
### Description

This pull request makes a minor update to the mainfest file for the global search plugin. 

- It modifies the display name from “Global Search” to “Text Search”, and
- replaces the icon with the actual plugin icon.

| ☀️ | 🌜 |
|--------|--------|
| <img width="560" height="200" alt="development framer com_projects_Elmar-s-Project--FEc2IBtiQFNzT35Gfi0B-3Lq3d_node=DeL0q0H0v" src="https://github.com/user-attachments/assets/4a35ed88-699e-4318-a7eb-ed1730d7a159" /> | <img width="560" height="200" alt="development framer com_projects_Elmar-s-Project--FEc2IBtiQFNzT35Gfi0B-3Lq3d_node=DeL0q0H0v (1)" src="https://github.com/user-attachments/assets/2431acd4-b434-453a-925e-bf5913c3388f" /> |



### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [ ] Icon and Text are shown in plugin

<!-- Thank you for contributing! -->

