### PR TITLE
Phosphor: fix drag and drop

### DIFF
--- a/plugins/phosphor/src/App.tsx
+++ b/plugins/phosphor/src/App.tsx
@@ -108,26 +108,26 @@ function IconGrid(props: { searchQuery: string; weight: IconWeight }) {
                 const { Icon } = entry
 
                 return (
-                    <button
-                        className="icon-parent"
-                        onClick={() => {
-                            if (!isAllowedToAddSVG) return
-                            void handleIconClick(entry)
-                        }}
-                        disabled={!isAllowedToAddSVG}
-                        title={isAllowedToAddSVG ? undefined : "Insufficient permissions"}
+                    <Draggable
+                        data={() => ({
+                            type: "svg",
+                            name: "Icon",
+                            svg: renderToStaticMarkup(<Icon size={32} color={"black"} weight={weight} />),
+                        })}
+                        key={entry.name}
                     >
-                        <Draggable
-                            data={() => ({
-                                type: "svg",
-                                name: "Icon",
-                                svg: renderToStaticMarkup(<Icon size={32} color={"black"} weight={weight} />),
-                            })}
-                            key={entry.name}
+                        <button
+                            className="icon-parent"
+                            onClick={() => {
+                                if (!isAllowedToAddSVG) return
+                                void handleIconClick(entry)
+                            }}
+                            disabled={!isAllowedToAddSVG}
+                            title={isAllowedToAddSVG ? undefined : "Insufficient permissions"}
                         >
                             <Icon size={32} color={"var(--framer-color-text)"} weight={weight} />
-                        </Draggable>
-                    </button>
+                        </button>
+                    </Draggable>
                 )
             })}
         </div>


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request fixes drag and drop in the Phosphor plugin.

It was broken due to `<Draggable>` being inside a `<button>`, which used to work but at some point that pattern stopped working. This PR just swaps the elements moving the button inside Draggable.

### Testing

- [x] Test dragging icons into the canvas
- [x] Test clicking icons to insert