### PR TITLE
Global search/new line on linebreaks

### DIFF
--- a/plugins/global-search/src/utils/indexer/indexer.ts
+++ b/plugins/global-search/src/utils/indexer/indexer.ts
@@ -57,7 +57,8 @@ export class GlobalSearchIndexer {
 
     private async getNodeText(node: AnyNode): Promise<string | null> {
         if (includedAttributes.includes("text") && isTextNode(node)) {
-            return await node.getText()
+            const html = await node.getHTML()
+            return html ? stripMarkup(html) : null
         }
         return null
     }

--- a/plugins/global-search/src/utils/indexer/strip-markup.test.ts
+++ b/plugins/global-search/src/utils/indexer/strip-markup.test.ts
@@ -54,4 +54,15 @@ describe("stripMarkup(text)", () => {
         expect(stripMarkup("Try to make<br/>ends meet")).toBe("Try to make ends meet")
         expect(stripMarkup("Image: <img src='test.jpg' alt='test'/>")).toBe("Image:")
     })
+
+    it("should add spaces when content is broken up in multiple block elements", () => {
+        expect(stripMarkup("<p>Been down</p><p>Ever been down</p>")).toBe("Been down Ever been down")
+        expect(stripMarkup("<div>Been down</div><div>Ever been down</div>")).toBe("Been down Ever been down")
+    })
+
+    it("shouldn't add a space when it's an inline element", () => {
+        expect(stripMarkup("<p>I <span>c</span>an change</p><p>I ca<span>n</span> change</p>")).toBe(
+            "I can change I can change"
+        )
+    })
 })

--- a/plugins/global-search/src/utils/indexer/strip-markup.ts
+++ b/plugins/global-search/src/utils/indexer/strip-markup.ts
@@ -7,13 +7,15 @@ const parser = new DOMParser()
  * stripMarkup("Hello <b>world</b>") // "Hello world"
  */
 export function stripMarkup(text: string) {
-    // Normalize explicit line breaks and hr's before parsing so words don't collapse
-    const normalized = text.replace(/<(br|hr)\s*\/?>(?=\s*|$)/gi, "\n")
+    const normalized = text
+        // Normalize explicit line breaks and hr's before parsing so words don't collapse
+        .replace(/<(br|hr)\s*\/?>/gi, " ")
+        // Add spaces before closing block element tags to prevent words from merging
+        .replace(/<\/(p|div|h[1-6]|li|section|article|header|footer|nav|aside|blockquote)>/gi, " ")
 
     const document = parser.parseFromString(normalized, "text/html")
 
     if (!document.body.textContent) return ""
-
     // all new lines and multiple spaces to single space
     return document.body.textContent.replaceAll("\n", " ").replaceAll(/\s+/g, " ").trim()
 }


### PR DESCRIPTION
### Description

Introducing a space when block-elements follow each other.

While the code feels a bit hacky, this is probably the "cheapest" way to do it and don't want to rely on an external library.

| Before | After |
|--------|--------|
| <img width="260" height="370" alt="framer com_projects_Global-Search-Plugin--uhfPsMgB4ewInUmNYYcJ-7rWF4_node=augiA20Il" src="https://github.com/user-attachments/assets/51d056d7-c155-42aa-9b9f-4840f3179be9" /> | <img width="260" height="299" alt="framer com_projects_Global-Search-Plugin--uhfPsMgB4ewInUmNYYcJ-7rWF4_node=augiA20Il (2)" src="https://github.com/user-attachments/assets/96ce5921-ac31-49f7-87bd-49e8fbbd0a4a" />|


### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Two `p` elements in one node have a space between them

<!-- Thank you for contributing! -->