### PR TITLE
Global Search: remove items up to current indexer run

### DIFF
--- a/plugins/global-search/src/components/DevToolsScene.tsx
+++ b/plugins/global-search/src/components/DevToolsScene.tsx
@@ -162,6 +162,13 @@ export function DevToolsScene() {
                                         {selectedEntry.rootNodeName} ({selectedEntry.rootNodeType})
                                     </p>
                                 </div>
+
+                                <div>
+                                    <label className="block text-xs font-medium text-gray-700 mb-1">Indexer Run</label>
+                                    <pre className="text-sm bg-gray-50 p-2 rounded whitespace-pre-wrap">
+                                        {selectedEntry.addedInIndexRun}
+                                    </pre>
+                                </div>
                             </div>
                         </div>
                     ) : (

--- a/plugins/global-search/src/utils/indexer/indexer.ts
+++ b/plugins/global-search/src/utils/indexer/indexer.ts
@@ -1,6 +1,6 @@
 import {
     type AnyNode,
-    Collection,
+    type Collection,
     framer,
     isComponentNode,
     isFrameNode,
@@ -182,7 +182,7 @@ export class GlobalSearchIndexer {
             // this isn't a unnecassary static expression, as the value could change during the async loop
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
             if (!this.abortRequested) {
-                await this.db.clearEntriesFromBefore(lastIndexRun)
+                await this.db.clearEntriesFromBefore(currentIndexRun)
                 this.eventEmitter.emit("completed")
             }
         } catch (error) {


### PR DESCRIPTION
### Description

Delete all data up to (but not including) current run, before it was n-2

### Testing

- [ ] Check it deletes n-1
  - add text to a page
  - open the plugin, search for the text
  - remove the text
  - re-open the plugin
  - search for text: it should be gone now