### PR TITLE
Global search: Indexer watches for change

### DIFF
--- a/plugins/global-search/src/App.tsx
+++ b/plugins/global-search/src/App.tsx
@@ -28,7 +28,7 @@ export function App() {
 
     return (
         <ErrorBoundary FallbackComponent={ErrorScene}>
-            <IndexerProvider projectId={projectInfo.id}>
+            <IndexerProvider projectId={projectInfo.id} projectName={projectInfo.name}>
                 {activeScene === "dev-tools" && <DevToolsScene />}
                 {activeScene === "search" && <SearchScene />}
             </IndexerProvider>

--- a/plugins/global-search/src/components/SearchScene.tsx
+++ b/plugins/global-search/src/components/SearchScene.tsx
@@ -8,6 +8,7 @@ import type { RootNodeType } from "../utils/indexer/types"
 import { useIndexer } from "../utils/indexer/useIndexer"
 import { entries } from "../utils/object"
 import { getPluginUiOptions } from "../utils/plugin-ui"
+import { useMinimumDuration } from "../utils/useMinimumDuration"
 import { NoResults } from "./NoResults"
 import { ResultsList } from "./Results"
 import { SearchInput } from "./SearchInput"
@@ -20,6 +21,7 @@ export function SearchScene() {
     const [query, setQuery] = useState("")
     const { searchOptions, optionsMenuItems } = useOptionsMenuItems()
     const deferredQuery = useDeferredValue(query)
+    const isIndexingWithMinimumDuration = useMinimumDuration(isIndexing, 500)
 
     const { results, hasResults, error: filterError } = useAsyncFilter(deferredQuery, searchOptions, db, dataVersion)
 
@@ -46,15 +48,15 @@ export function SearchScene() {
                     )}
                 >
                     <SearchInput value={query} onChange={handleQueryChange} />
-                    {isIndexing && (
-                        // TODO: Discuss if we should add a tooltip to explain what's this.
-                        <span
-                            title="Indexing..."
-                            className="animate-[fade-in_150ms_forwards] [animation-delay:500ms] opacity-0"
-                        >
-                            <IconSpinner className="text-black dark:text-white animate-[spin_0.8s_linear_infinite]" />
-                        </span>
-                    )}
+
+                    <span
+                        title="Indexing..."
+                        className="aria-hidden:opacity-0 transition"
+                        aria-hidden={!isIndexingWithMinimumDuration}
+                    >
+                        <IconSpinner className="text-black dark:text-white animate-[spin_0.8s_linear_infinite]" />
+                    </span>
+
                     <Menu items={optionsMenuItems}>
                         <IconEllipsis className="text-framer-text-tertiary-light dark:text-framer-text-tertiary-dark" />
                     </Menu>

--- a/plugins/global-search/src/utils/db.ts
+++ b/plugins/global-search/src/utils/db.ts
@@ -20,8 +20,8 @@ export class GlobalSearchDatabase implements ResumableAsyncIterable<IndexEntry> 
     private db: IDBPDatabase<GlobalSearchDB> | null = null
     private readonly dbName: string
 
-    constructor(projectId: string) {
-        this.dbName = `global-search-${projectId}`
+    constructor(projectId: string, projectName: string) {
+        this.dbName = `global-search-${projectName}-${projectId}`
     }
 
     async open(): Promise<IDBPDatabase<GlobalSearchDB>> {

--- a/plugins/global-search/src/utils/db.ts
+++ b/plugins/global-search/src/utils/db.ts
@@ -11,6 +11,7 @@ interface GlobalSearchDB extends DBSchema {
             type: string
             rootNodeType: string
             addedInIndexRun: number
+            rootNodeIdVersion: [string, number]
         }
     }
 }
@@ -26,12 +27,20 @@ export class GlobalSearchDatabase implements ResumableAsyncIterable<IndexEntry> 
     async open(): Promise<IDBPDatabase<GlobalSearchDB>> {
         if (this.db) return this.db
 
-        this.db = await openDB<GlobalSearchDB>(this.dbName, 1, {
-            upgrade(db) {
-                const entriesStore = db.createObjectStore("entries", { keyPath: "id" })
-                entriesStore.createIndex("rootNodeType", "rootNodeType")
-                entriesStore.createIndex("type", "type")
-                entriesStore.createIndex("addedInIndexRun", "addedInIndexRun")
+        this.db = await openDB<GlobalSearchDB>(this.dbName, 2, {
+            upgrade(db, oldVersion, _newVersion, transaction) {
+                if (oldVersion < 1) {
+                    const entriesStore = db.createObjectStore("entries", { keyPath: "id" })
+                    entriesStore.createIndex("rootNodeType", "rootNodeType")
+                    entriesStore.createIndex("type", "type")
+                    entriesStore.createIndex("addedInIndexRun", "addedInIndexRun")
+                }
+
+                if (oldVersion < 2) {
+                    const entriesStore = transaction.objectStore("entries")
+                    // Add compound index for [rootNodeId, addedInIndexRun] - this is all we need
+                    entriesStore.createIndex("rootNodeIdVersion", ["rootNodeId", "addedInIndexRun"])
+                }
             },
         })
 
@@ -102,6 +111,27 @@ export class GlobalSearchDatabase implements ResumableAsyncIterable<IndexEntry> 
 
         // Delete all entries with addedInIndexRun < version
         let cursor = await index.openCursor(IDBKeyRange.upperBound(version, true))
+        while (cursor) {
+            await cursor.delete()
+            cursor = await cursor.continue()
+        }
+
+        await tx.done
+    }
+
+    /**
+     * Removes entries for a specific root node from a specific index run version.
+     *
+     * This is used for incremental updates when a specific canvas root changes.
+     */
+    async clearEntriesForRootNodeAndSpecificVersion(rootNodeId: string, version: number): Promise<void> {
+        const db = await this.open()
+        const tx = db.transaction("entries", "readwrite")
+        const store = tx.objectStore("entries")
+        const index = store.index("rootNodeIdVersion")
+
+        // Use compound index to efficiently find entries with exact [rootNodeId, version] match
+        let cursor = await index.openCursor(IDBKeyRange.only([rootNodeId, version]))
         while (cursor) {
             await cursor.delete()
             cursor = await cursor.continue()

--- a/plugins/global-search/src/utils/indexer/IndexerProvider.tsx
+++ b/plugins/global-search/src/utils/indexer/IndexerProvider.tsx
@@ -8,9 +8,17 @@ import { GlobalSearchIndexer } from "./indexer"
  * Creates database and indexer instances and provides them to the children.
  * The database manages its own version and the indexer depends on the database.
  */
-export function IndexerProvider({ children, projectId }: { children: React.ReactNode; projectId: string }) {
+export function IndexerProvider({
+    children,
+    projectId,
+    projectName,
+}: {
+    children: React.ReactNode
+    projectId: string
+    projectName: string
+}) {
     const dbRef = useRef<GlobalSearchDatabase>()
-    dbRef.current ??= new GlobalSearchDatabase(projectId)
+    dbRef.current ??= new GlobalSearchDatabase(projectId, projectName)
     const db = dbRef.current
 
     const indexerRef = useRef<GlobalSearchIndexer>()

--- a/plugins/global-search/src/utils/indexer/indexer.ts
+++ b/plugins/global-search/src/utils/indexer/indexer.ts
@@ -47,6 +47,8 @@ export interface IndexerEvents extends EventMap {
     completed: never
     restarted: never
     aborted: never
+    canvasRootChangeStarted: never
+    canvasRootChangeCompleted: never
 }
 
 export class GlobalSearchIndexer {
@@ -175,6 +177,8 @@ export class GlobalSearchIndexer {
         const abortController = new AbortController()
         this.currentCanvasRootChangeAbortController = abortController
 
+        this.eventEmitter.emit("canvasRootChangeStarted")
+
         try {
             if (abortController.signal.aborted) return
 
@@ -188,6 +192,7 @@ export class GlobalSearchIndexer {
             if (this.currentCanvasRootChangeAbortController === abortController) {
                 this.currentCanvasRootChangeAbortController = null
             }
+            this.eventEmitter.emit("canvasRootChangeCompleted")
         }
     }
 

--- a/plugins/global-search/src/utils/indexer/indexer.ts
+++ b/plugins/global-search/src/utils/indexer/indexer.ts
@@ -175,7 +175,8 @@ export class GlobalSearchIndexer {
         }
 
         try {
-            const currentIndexRun = await this.db.getLastIndexRun()
+            const lastIndexRun = await this.db.getLastIndexRun()
+            const currentIndexRun = lastIndexRun + 1
             let processed = 0
 
             for await (const batch of this.crawlNodes(currentIndexRun, [rootNode])) {
@@ -187,8 +188,7 @@ export class GlobalSearchIndexer {
 
                 this.eventEmitter.emit("progress", { processed })
             }
-
-            // FIXME: clear old entries
+            await this.db.clearEntriesForRootNode(rootNode.id, lastIndexRun)
         } catch (error) {
             this.eventEmitter.emit("error", { error: error instanceof Error ? error : new Error(String(error)) })
         }

--- a/plugins/global-search/src/utils/useMinimumDuration.test.ts
+++ b/plugins/global-search/src/utils/useMinimumDuration.test.ts
@@ -1,0 +1,107 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useMinimumDuration } from "./useMinimumDuration"
+
+function advanceTimersByTime(time: number) {
+    act(() => {
+        vi.advanceTimersByTime(time)
+    })
+}
+
+describe("useMinimumDuration", () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        vi.runOnlyPendingTimers()
+        vi.useRealTimers()
+    })
+
+    it("should delay returning false when input becomes false", () => {
+        const { result, rerender } = renderHook(({ value }) => useMinimumDuration(value, 1000), {
+            initialProps: { value: true },
+        })
+
+        expect(result.current).toBe(true)
+
+        rerender({ value: false })
+        expect(result.current).toBe(true)
+
+        advanceTimersByTime(500)
+
+        expect(result.current).toBe(true)
+
+        advanceTimersByTime(500)
+
+        expect(result.current).toBe(false)
+    })
+
+    it("should cancel delay when input becomes true again during delay period", () => {
+        const { result, rerender } = renderHook(({ value }) => useMinimumDuration(value, 1000), {
+            initialProps: { value: true },
+        })
+
+        expect(result.current).toBe(true)
+
+        rerender({ value: false })
+        expect(result.current).toBe(true)
+
+        advanceTimersByTime(500)
+
+        expect(result.current).toBe(true)
+
+        rerender({ value: true })
+        expect(result.current).toBe(true)
+
+        advanceTimersByTime(600)
+
+        expect(result.current).toBe(true)
+
+        rerender({ value: false })
+        expect(result.current).toBe(true)
+
+        advanceTimersByTime(1000)
+
+        expect(result.current).toBe(false)
+    })
+
+    it("should handle multiple rapid changes correctly", () => {
+        const { result, rerender } = renderHook(({ value }) => useMinimumDuration(value, 1000), {
+            initialProps: { value: false },
+        })
+
+        expect(result.current).toBe(false)
+
+        rerender({ value: true })
+        expect(result.current).toBe(true)
+
+        rerender({ value: false })
+        expect(result.current).toBe(true)
+
+        rerender({ value: true })
+        expect(result.current).toBe(true)
+
+        rerender({ value: false })
+        expect(result.current).toBe(true)
+
+        advanceTimersByTime(1000)
+
+        expect(result.current).toBe(false)
+    })
+
+    it("should clean up timeout on unmount to prevent memory leaks", () => {
+        const clearTimeoutSpy = vi.spyOn(global, "clearTimeout")
+
+        const { unmount, rerender } = renderHook(({ value }) => useMinimumDuration(value, 1000), {
+            initialProps: { value: true },
+        })
+
+        rerender({ value: false })
+        unmount()
+
+        expect(clearTimeoutSpy).toHaveBeenCalled()
+
+        clearTimeoutSpy.mockRestore()
+    })
+})

--- a/plugins/global-search/src/utils/useMinimumDuration.ts
+++ b/plugins/global-search/src/utils/useMinimumDuration.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef, useState } from "react"
+
+/**
+ * Hook that ensures a boolean value stays `true` for a minimum duration.
+ * When the input becomes `true`, it immediately returns `true`.
+ * When the input becomes `false`, it delays returning `false` for the specified duration.
+ * If the input becomes `true` again during the delay, the delay is cancelled.
+ *
+ * @param value - The boolean value to control
+ * @param minDuration - Minimum duration in milliseconds to keep the value `true`
+ * @returns The controlled boolean value
+ */
+export function useMinimumDuration(value: boolean, minDuration: number): boolean {
+    const [delayedValue, setDelayedValue] = useState(value)
+    const timeoutRef = useRef<number>()
+
+    useEffect(() => {
+        if (value) {
+            clearTimeout(timeoutRef.current)
+            setDelayedValue(true)
+        } else if (delayedValue) {
+            timeoutRef.current = window.setTimeout(() => {
+                setDelayedValue(false)
+            }, minDuration)
+        }
+
+        return () => {
+            clearTimeout(timeoutRef.current)
+        }
+    }, [value, delayedValue, minDuration])
+
+    return delayedValue
+}


### PR DESCRIPTION
### Description

Watch for changes in the current root node and index them. That will allow for real time index updates while the plugin is open.

- Adds the project name to the database name for easier identification in the development process
- Runs the indexer for nodes and collections now in parallel
- And as a bonus to this change: the current canvas indexes first
- The indexer spinner is shown 

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Edit something on the canvas as you search for something in the same node: it updates automatically
- [x] Do the same as above, but delete the node: it's gone from the index
- [x] The spinner is shown for a sensible time before hiding, signalling "i've updated everything"

<!-- Thank you for contributing! -->