### PR TITLE
Global Search Add keyboard shortcuts to close the plugin

### DIFF
--- a/plugins/global-search/src/App.tsx
+++ b/plugins/global-search/src/App.tsx
@@ -7,6 +7,19 @@ import { SearchScene } from "./components/SearchScene"
 import { IndexerProvider } from "./utils/indexer/IndexerProvider"
 import { getPluginUiOptions } from "./utils/plugin-ui"
 
+// Close the plugin when "open combination" or "escape" is pressed
+document.addEventListener("keydown", event => {
+    const isModifierPressed = event.metaKey || event.ctrlKey
+    const isOwnOpenCombination = isModifierPressed && event.shiftKey && event.code === "KeyF"
+    const isEscape = event.key === "Escape"
+
+    if (!isEscape && !isOwnOpenCombination) return
+
+    // This will close the plugin, but also show a message that the plugin was closed.
+    // We might add a "silent" option later.
+    void framer.closePlugin()
+})
+
 void framer.showUI(getPluginUiOptions({ query: undefined, hasResults: false }))
 
 const projectInfo = await framer.getProjectInfo()


### PR DESCRIPTION
### Description

Add a keyboard shortcut to close the plugin:
- `esc`: that's natural
- `cmd+shift+f`: that will open the plugin, so it should close it as well

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] `esc` closes the plugin
- [x] `cmd+shift+f` closes the plugin
