### PR TITLE
Global Search: Select the right item

### DIFF
--- a/plugins/global-search/src/components/Results.tsx
+++ b/plugins/global-search/src/components/Results.tsx
@@ -115,6 +115,9 @@ function Match({
         framer
             .navigateTo(targetId, {
                 scrollTo: collectionFieldId ? { collectionFieldId } : undefined,
+                zoomIntoView: {
+                    maxZoom: 1,
+                },
             })
             .catch((error: unknown) => {
                 framer.notify(`Failed to go to item. ${error instanceof Error ? error.message : "Unknown error"}`)


### PR DESCRIPTION
### Description

Before, the selected item wasn’t the actual item clicked, but the first one on the page. You didn’t scroll to the right item because you were using the wrong variable, which was responsible for the group heading, instead of the matching real item.

### Testing

- [x] Navigation, zoom, and selection work
  - Add two times the same text (in different nodes) to a page.
  - Search for them and click them.
  - They are individually highlighted.
- [x] Zoom goes only to 100%.
