### PR TITLE
Global search/results flickering

### DIFF
--- a/plugins/global-search/src/utils/filter/useAsyncFilter.ts
+++ b/plugins/global-search/src/utils/filter/useAsyncFilter.ts
@@ -21,6 +21,8 @@ export function useAsyncFilter(
     dataVersion: number
 ): AsyncFilterState {
     const processorRef = useRef<IdleCallbackAsyncProcessor<Result> | null>(null)
+    /** If this matches the current query and root nodes, we don't update the results with each progress update but instead wait for the completed event */
+    const finalisedResultsForQueryRef = useRef<[string, readonly RootNodeType[]] | null>(null)
     const groupingAbortControllerRef = useRef<AbortController | null>(null)
 
     const [state, setState] = useState<AsyncFilterState>({
@@ -49,6 +51,10 @@ export function useAsyncFilter(
         })
 
         processor.on("progress", ({ results }) => {
+            const [finalisedQuery, finalisedRootNodes] = finalisedResultsForQueryRef.current ?? [null, null]
+            // Final = we can wait for the completed event. There is already a lot of results to look through
+            if (finalisedQuery === query && Object.is(finalisedRootNodes, rootNodes)) return
+
             groupingAbortControllerRef.current?.abort()
             const controller = new AbortController()
             groupingAbortControllerRef.current = controller
@@ -73,6 +79,7 @@ export function useAsyncFilter(
 
                 void groupResults(results, controller.signal).then(results => {
                     startTransition(() => {
+                        finalisedResultsForQueryRef.current = [query, rootNodes]
                         setState(state => ({ ...state, results, running: false }))
                     })
                 })

--- a/plugins/global-search/src/utils/filter/useAsyncFilter.ts
+++ b/plugins/global-search/src/utils/filter/useAsyncFilter.ts
@@ -65,9 +65,17 @@ export function useAsyncFilter(
             })
         })
 
-        processor.on("completed", () => {
+        processor.on("completed", results => {
             startTransition(() => {
-                setState(state => ({ ...state, running: false }))
+                groupingAbortControllerRef.current?.abort()
+                const controller = new AbortController()
+                groupingAbortControllerRef.current = controller
+
+                void groupResults(results, controller.signal).then(results => {
+                    startTransition(() => {
+                        setState(state => ({ ...state, results, running: false }))
+                    })
+                })
             })
         })
 


### PR DESCRIPTION
### Description

Opting out "streaming" data in when the current set was marked as "final" already. That prevents "jumping" result sets when the database changes

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Results don't jump anymore
  - open the plugin on the Framer project
  - search for a term (like "switch")
  - watch the result list to NOT jump around anymore

<!-- Thank you for contributing! -->