### PR TITLE
Update HubSpot form URL

### DIFF
--- a/plugins/hubspot/src/pages/canvas/forms/index.tsx
+++ b/plugins/hubspot/src/pages/canvas/forms/index.tsx
@@ -24,12 +24,12 @@ export default function FormsPage() {
                     {forms.map((form, i) => (
                         <ComponentInsert
                             key={i}
-                            url="https://framer.com/m/HubSpot-Form-qRu7.js"
+                            url="https://framer.com/m/framer/hubspot.js"
                             attributes={{
                                 controls: {
                                     portalId: String(portalId),
                                     formId: form.id,
-                                    dataHostingLocation,
+                                    region: dataHostingLocation,
                                 },
                             }}
                         >


### PR DESCRIPTION
### Description

This pull request updates the HubSpot plugin to use the same HubSpot form component as the one in the insert menu. Currently, there are two separate HubSpot form components that do the same thing but slightly differently.

This component is better because:
- It has a Tracking ID property
- It recently got some bug fixes related to breakpoints
- Auto height works correctly

Component URL from https://github.com/framer/FramerStudio/pull/24717/files

### Testing

- [ ] Sign in to HubSpot
- [ ] Drag a form from the plugin into your project