### PR TITLE
HubSpot: fix log out error

### DIFF
--- a/plugins/hubspot/src/auth.ts
+++ b/plugins/hubspot/src/auth.ts
@@ -103,7 +103,7 @@ class Auth {
             "To fully remove the integration, uninstall the Framer app from the HubSpot integrations dashboard.",
             { durationMs: 5000 }
         )
-        window.location.reload()
+        window.location.pathname = "/"
     }
 
     public readonly tokens = {


### PR DESCRIPTION
### Description

This pull request fixes the error that shows after logging out. This error was introduced by https://github.com/framer/plugins/pull/376, but does not happen when running on localhost with `yarn dev` so it wasn't caught before being merged.

Closes https://github.com/framer/plugins/issues/389

<img width="291" height="189" alt="image" src="https://github.com/user-attachments/assets/1580e852-d6ff-4091-bed1-d283df8ce70f" />

Here's a version that has the error (packed from https://github.com/framer/plugins/pull/376).
https://framer.com/projects/new?plugin=7ihrkelk9u6rtcrt0rbd0e78n&pluginVersion=7cbfs6io44zfgqlhatkh3r57mtuyqwdv

### Testing

- [x] Switch to using the production OAuth worker by opening `auth.ts` and replacing line 32 with this code. This avoids having to set up the worker running locally.

```js
const isLocal = () => false // window.location.hostname.includes("localhost")
```

- [x] Run `yarn build`
- [x] Add this code in a new `server.py` file in the /dist folder: https://gist.github.com/madebyisaacr/973dd1b36765d62a93596cfa19340e2f
- [x] Run `cd dist` followed by `python server.py` or `python3 server.py`
- [x] In Framer, open development plugin -> `http://localhost:8000`
- [x] Log in to HubSpot
- [x] Log out
- [x] You should see this screen:
<img width="293" height="425" alt="image" src="https://github.com/user-attachments/assets/600212a7-dc49-435e-8864-7678ba243e5f" />