### PR TITLE
Fix Ashby validation for `CompensationComponentSchema`

### DIFF
--- a/plugins/ashby/src/api-types.ts
+++ b/plugins/ashby/src/api-types.ts
@@ -11,9 +11,9 @@ const CompensationComponentSchema = v.object({
     summary: v.optional(v.string()),
     compensationType: v.string(),
     interval: v.string(),
-    currencyCode: v.nullable(v.string()),
-    minValue: v.nullable(v.number()),
-    maxValue: v.nullable(v.number()),
+    currencyCode: v.optional(v.nullable(v.string())),
+    minValue: v.optional(v.nullable(v.number())),
+    maxValue: v.optional(v.nullable(v.number())),
 })
 
 const CompensationTiersSchema = v.object({


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

Updated the `CompensationComponentSchema` in `api-types.ts` to make the `currencyCode`, `minValue`, and `maxValue` fields optional in addition to nullable. This allows the schema to properly validate:

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Confirm that both salary and equity compensation components now validate correctly