### PR TITLE
Improve performance of CMS Export plugin with large collections

### DIFF
--- a/plugins/cms-export/src/App.tsx
+++ b/plugins/cms-export/src/App.tsx
@@ -11,6 +11,8 @@ export function App() {
     const [isLoading, setIsLoading] = useState(true)
     const [collections, setCollections] = useState<Collection[]>([])
     const [selectedCollection, setSelectedCollection] = useState<Collection | null>(null)
+    const [copyLoading, setCopyLoading] = useState(false)
+    const [exportLoading, setExportLoading] = useState(false)
 
     useEffect(() => {
         void framer.showUI({
@@ -35,13 +37,29 @@ export function App() {
 
     const exportCSV = () => {
         if (!selectedCollection) return
-        void exportCollectionAsCSV(selectedCollection, selectedCollection.name)
+
+        const task = async () => {
+            setExportLoading(true)
+
+            try {
+                await exportCollectionAsCSV(selectedCollection, selectedCollection.name)
+            } catch (error) {
+                console.error("Failed to export CSV:", error)
+                framer.notify("Failed to export CSV", { variant: "error" })
+            }
+
+            setExportLoading(false)
+        }
+
+        void task()
     }
 
     const copyCSVtoClipboard = () => {
         if (!selectedCollection) return
 
         const task = async () => {
+            setCopyLoading(true)
+
             const csv = await convertCollectionToCSV(selectedCollection)
 
             try {
@@ -51,6 +69,8 @@ export function App() {
                 console.error("Failed to copy CSV:", error)
                 framer.notify("Failed to copy CSV to clipboard", { variant: "error" })
             }
+
+            setCopyLoading(false)
         }
 
         void task()
@@ -97,10 +117,10 @@ export function App() {
 
                 <div className="footer-actions">
                     <button disabled={!selectedCollection} onClick={copyCSVtoClipboard}>
-                        Copy
+                        {copyLoading ? <div className="framer-spinner" /> : "Copy"}
                     </button>
                     <button disabled={!selectedCollection} onClick={exportCSV}>
-                        Export
+                        {exportLoading ? <div className="framer-spinner" /> : "Export"}
                     </button>
                 </div>
             </div>

--- a/plugins/cms-export/src/PreviewTable.tsx
+++ b/plugins/cms-export/src/PreviewTable.tsx
@@ -6,6 +6,8 @@ import { getDataForCSV } from "./csv"
 
 import "./PreviewTable.css"
 
+const PREVIEW_ROW_LIMIT = 25
+
 const cellTitleOverrides: Record<string, string> = {
     ":draft": "Is Draft?",
 }
@@ -32,7 +34,7 @@ export function PreviewTable({ collection }: Props) {
             const fields = await collection.getFields()
             const items = await collection.getItems()
 
-            setPreviewCSV(getDataForCSV(collection.slugFieldName, fields, items))
+            setPreviewCSV(getDataForCSV(collection.slugFieldName, fields, items, PREVIEW_ROW_LIMIT))
         }
 
         const resize = () => {
@@ -77,7 +79,7 @@ export function PreviewTable({ collection }: Props) {
                                 <tr key={`${rowIndex}`}>
                                     {row.map((cell, columnIndex) => (
                                         <td key={`${rowIndex}-${columnIndex}`} title={cell}>
-                                            {cell}
+                                            {getFirstLine(cell)}
                                         </td>
                                     ))}
                                 </tr>
@@ -92,4 +94,8 @@ export function PreviewTable({ collection }: Props) {
             <div className="preview-table-border" />
         </div>
     )
+}
+
+function getFirstLine(text: string) {
+    return text.split("\n", 2)[0] || text
 }

--- a/plugins/cms-export/src/PreviewTable.tsx
+++ b/plugins/cms-export/src/PreviewTable.tsx
@@ -24,12 +24,6 @@ export function PreviewTable({ collection }: Props) {
     const [showGradient, setShowGradient] = useState(false)
 
     useEffect(() => {
-        void framer.showUI({
-            width: 340,
-            height: 370,
-            resizable: false,
-        })
-
         const load = async () => {
             const fields = await collection.getFields()
             const items = await collection.getItems()
@@ -78,7 +72,7 @@ export function PreviewTable({ collection }: Props) {
                             return (
                                 <tr key={`${rowIndex}`}>
                                     {row.map((cell, columnIndex) => (
-                                        <td key={`${rowIndex}-${columnIndex}`} title={cell}>
+                                        <td key={`${rowIndex}-${columnIndex}`} title={limitTitle(cell)}>
                                             {getFirstLine(cell)}
                                         </td>
                                     ))}
@@ -98,4 +92,10 @@ export function PreviewTable({ collection }: Props) {
 
 function getFirstLine(text: string) {
     return text.split("\n", 2)[0] || text
+}
+
+function limitTitle(text: string) {
+    if (text.length <= 500) return text
+
+    return text.substring(0, 500) + "…"
 }

--- a/plugins/cms-export/src/PreviewTable.tsx
+++ b/plugins/cms-export/src/PreviewTable.tsx
@@ -1,6 +1,5 @@
 import type { Collection } from "framer-plugin"
 
-import { framer } from "framer-plugin"
 import { useEffect, useRef, useState } from "react"
 import { getDataForCSV } from "./csv"
 
@@ -72,8 +71,8 @@ export function PreviewTable({ collection }: Props) {
                             return (
                                 <tr key={`${rowIndex}`}>
                                     {row.map((cell, columnIndex) => (
-                                        <td key={`${rowIndex}-${columnIndex}`} title={limitTitle(cell)}>
-                                            {getFirstLine(cell)}
+                                        <td key={`${rowIndex}-${columnIndex}`} title={limitCellTitle(cell)}>
+                                            {limitCellContent(cell)}
                                         </td>
                                     ))}
                                 </tr>
@@ -90,12 +89,14 @@ export function PreviewTable({ collection }: Props) {
     )
 }
 
-function getFirstLine(text: string) {
-    return text.split("\n", 2)[0] || text
+function limitCellContent(text: string) {
+    if (text.length <= 100) return text
+
+    return `${text.substring(0, 100)}…`
 }
 
-function limitTitle(text: string) {
+function limitCellTitle(text: string) {
     if (text.length <= 500) return text
 
-    return text.substring(0, 500) + "…"
+    return `${text.substring(0, 500)}…`
 }

--- a/plugins/cms-export/src/PreviewTable.tsx
+++ b/plugins/cms-export/src/PreviewTable.tsx
@@ -6,6 +6,8 @@ import { getDataForCSV } from "./csv"
 import "./PreviewTable.css"
 
 const PREVIEW_ROW_LIMIT = 25
+const MAX_CONTENT_LENGTH = 100
+const MAX_TITLE_LENGTH = 500
 
 const cellTitleOverrides: Record<string, string> = {
     ":draft": "Is Draft?",
@@ -90,13 +92,13 @@ export function PreviewTable({ collection }: Props) {
 }
 
 function limitCellContent(text: string) {
-    if (text.length <= 100) return text
+    if (text.length <= MAX_CONTENT_LENGTH) return text
 
-    return `${text.substring(0, 100)}…`
+    return `${text.substring(0, MAX_CONTENT_LENGTH)}…`
 }
 
 function limitCellTitle(text: string) {
-    if (text.length <= 500) return text
+    if (text.length <= MAX_TITLE_LENGTH) return text
 
-    return `${text.substring(0, 500)}…`
+    return `${text.substring(0, MAX_TITLE_LENGTH)}…`
 }

--- a/plugins/cms-export/src/csv.ts
+++ b/plugins/cms-export/src/csv.ts
@@ -54,9 +54,15 @@ function isFieldSupported(field: Field): field is SupportedField {
     }
 }
 
-export function getDataForCSV(slugFieldName: string | null, fields: Field[], items: CollectionItem[]): Rows {
+export function getDataForCSV(
+    slugFieldName: string | null,
+    fields: Field[],
+    items: CollectionItem[],
+    limit?: number
+): Rows {
     const rows: Rows = []
     const supportedFields = fields.filter(isFieldSupported)
+    const limitedItems = typeof limit === "number" ? items.slice(0, limit) : items
     const hasDraftItems = items.some(item => item.draft)
 
     // Add header row with slug field at the start.
@@ -78,7 +84,7 @@ export function getDataForCSV(slugFieldName: string | null, fields: Field[], ite
     rows.push(header)
 
     // Add all the data rows.
-    for (const item of items) {
+    for (const item of limitedItems) {
         const columns: Columns = []
 
         // Add the slug cell.


### PR DESCRIPTION
### Description

This pull request fixes the severe lag when opening the CMS Export plugin in a large collections.

Closes https://github.com/framer/plugins/issues/84

The problem was that it generates a preview table row for all items, so if there's 2,000 items and 10 columns, that's over 20K HTML elements being generated at once.

**Changes:**
* Limit preview to 25 rows.
* Limit cell content and title length in preview.
* Added loading spinners to copy and export buttons.

https://github.com/user-attachments/assets/83a49e41-4971-4396-8cca-9e171fd0c068

### Testing

Here's a test project with about 1000 items, each with long content.
https://framer.com/remix/6ZXOm01Lt6vCpZgTM8qV

- [ ] Open the [CMS Export plugin](https://www.framer.com/marketplace/plugins/cms-export/)
- [ ] Run this PR locally and open the development plugin
- [ ] Compare speed of opening and rendering content between versions
- [ ] Check that only 25 rows are rendered in the preview
- [ ] Test copying and exporting CSV