### PR TITLE
Add ability to choose alt text fields to notion

### DIFF
--- a/plugins/notion/src/App.css
+++ b/plugins/notion/src/App.css
@@ -194,7 +194,7 @@ form {
 }
 
 .mapping .field-type {
-    width: 100%;
+    font-weight: 500;
 }
 
 .mapping footer {
@@ -288,4 +288,32 @@ select:not(:disabled) {
 .action-button {
     flex: 1;
     width: 100%;
+}
+
+.field-type-button {
+    width: 100%;
+    flex-shrink: 1;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    text-align: left;
+    overflow: hidden;
+}
+
+.field-type-button[disabled] {
+    opacity: 0.5;
+}
+
+.field-type-button-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+}
+
+.field-type-button-chevron {
+    margin-left: 8px;
+    flex-shrink: 0;
 }

--- a/plugins/notion/src/App.tsx
+++ b/plugins/notion/src/App.tsx
@@ -17,6 +17,7 @@ interface AppProps {
     previousLastSynced: string | null
     previousIgnoredFieldIds: string | null
     previousDatabaseName: string | null
+    previousAltTextMappings: string | null
     existingCollectionDatabaseIdMap: DatabaseIdMap
 }
 
@@ -27,6 +28,7 @@ export function App({
     previousLastSynced,
     previousIgnoredFieldIds,
     previousDatabaseName,
+    previousAltTextMappings,
     existingCollectionDatabaseIdMap,
 }: AppProps) {
     const [dataSource, setDataSource] = useState<DataSource | null>(null)
@@ -146,6 +148,7 @@ export function App({
             initialSlugFieldId={previousSlugFieldId}
             previousLastSynced={previousLastSynced}
             previousIgnoredFieldIds={previousIgnoredFieldIds}
+            previousAltTextMappings={previousAltTextMappings}
             databaseIdMap={databaseIdMap}
         />
     )

--- a/plugins/notion/src/api.ts
+++ b/plugins/notion/src/api.ts
@@ -18,6 +18,7 @@ export const PLUGIN_KEYS = {
     SLUG_FIELD_ID: "notionPluginSlugId",
     DATABASE_NAME: "notionDatabaseName",
     BEARER_TOKEN: "notionBearerToken",
+    ALT_TEXT_MAPPINGS: "notionPluginAltTextMappings",
 } as const
 
 // This is the most recent date when the page content formatted text importing was updated.
@@ -34,6 +35,7 @@ export interface FieldInfo {
     type: ManagedCollectionField["type"] | null
     allowedTypes: ManagedCollectionField["type"][]
     notionProperty: NotionProperty | null
+    altTextForImageFieldId?: string | null
 }
 
 export type NotionProperty = GetDatabaseResponse["properties"][string]

--- a/plugins/notion/src/main.tsx
+++ b/plugins/notion/src/main.tsx
@@ -37,6 +37,7 @@ const [
     previousLastSynced,
     previousIgnoredFieldIds,
     previousDatabaseName,
+    previousAltTextMappings,
     existingCollectionDatabaseIdMap,
 ] = await Promise.all([
     activeCollection.getPluginData(PLUGIN_KEYS.DATABASE_ID),
@@ -44,6 +45,7 @@ const [
     activeCollection.getPluginData(PLUGIN_KEYS.LAST_SYNCED),
     activeCollection.getPluginData(PLUGIN_KEYS.IGNORED_FIELD_IDS),
     activeCollection.getPluginData(PLUGIN_KEYS.DATABASE_NAME),
+    activeCollection.getPluginData(PLUGIN_KEYS.ALT_TEXT_MAPPINGS),
     getExistingCollectionDatabaseIdMap(),
 ])
 
@@ -54,6 +56,7 @@ const { didSync } = await syncExistingCollection(
     previousIgnoredFieldIds,
     previousLastSynced,
     previousDatabaseName,
+    previousAltTextMappings,
     existingCollectionDatabaseIdMap
 )
 
@@ -71,6 +74,7 @@ if (didSync) {
                 previousLastSynced={previousLastSynced}
                 previousIgnoredFieldIds={previousIgnoredFieldIds}
                 previousDatabaseName={previousDatabaseName}
+                previousAltTextMappings={previousAltTextMappings}
                 existingCollectionDatabaseIdMap={existingCollectionDatabaseIdMap}
             />
         </React.StrictMode>


### PR DESCRIPTION
### Description

You can now set the field type for a notion field to being the alt text for any other image field.

https://github.com/user-attachments/assets/060f3a3d-aaa2-42a8-9bf2-be3f141679a9

Closes https://github.com/framer/plugins/issues/424

### Testing

- [ ] First sync works as expected
  - Run this plugin
  - Authenticate and give access to this page https://www.notion.so/framer/Images-with-alt-text-269adf6e8c96801da179d4939c4d44c5?source=copy_link
  - Sync "Cats"
  - Check type selection works as expected
    - Ignore "Cover" field
    - Change type for "Some Alt Text" and confirm there's nothing in there about alt text, because "An Image" is set to "File" by default
    - Set "An Image" field to "Image" type
    - Change type of "Some Alt Text" and now you should be able to select "Alt Text..."->"An Image"
    - Change "An Image" type back to "File" and confirm that "Some Alt Text" reverts to plain text
    - Revert to image and alt text.
  - Imports work consistently
    - Import the collection
    - Collection should be set up as expected:
      - Cover should not be a field
      - An Image should be a field
      - Some Alt Text should not be a field
      - Values for An Image should include the relevant alt text
    - Subsequent imports don't break things
      - Press "Manage" and import the collection again and confirm nothing broke
      - Press "Sync" and check the same
    - Updating alt text works
      - Update the alt text of a row on notion
      - Sync and confirm the alt text updated