### PR TITLE
perf(global-search): use `rootNode.getNodesWithType("TextNode")` instead of .walk()

### DIFF
--- a/plugins/global-search/src/utils/indexer/indexer.ts
+++ b/plugins/global-search/src/utils/indexer/indexer.ts
@@ -79,11 +79,12 @@ export class GlobalSearchIndexer {
 
         for (const rootNode of rootNodes) {
             const rootNodeName = await getNodeName(rootNode)
+            const nodes = await rootNode.getNodesWithType("TextNode")
 
-            for await (const node of rootNode.walk()) {
+            for (const node of nodes) {
                 if (this.abortRequested) return
 
-                if (!isIndexableNode(node) || !node.visible) continue
+                if (!node.visible) continue
 
                 const text = await this.getNodeText(node)
 

--- a/plugins/global-search/src/utils/indexer/types.ts
+++ b/plugins/global-search/src/utils/indexer/types.ts
@@ -1,21 +1,12 @@
-import {
-    type AnyNode,
-    ComponentInstanceNode,
-    ComponentNode,
-    isComponentInstanceNode,
-    isTextNode,
-    TextNode,
-    WebPageNode,
-} from "framer-plugin"
+import { type AnyNode, ComponentNode, isTextNode, TextNode, WebPageNode } from "framer-plugin"
 
 export type IndexNodeRootNode = ComponentNode | WebPageNode
 export type IndexNodeRootNodeType = IndexNodeRootNode["__class"]
 
-export type IndexableNode = Extract<AnyNode, TextNode | ComponentInstanceNode>
-export type IndexEntryType = AnyNode["__class"]
+export type IndexableNode = TextNode
+export type IndexEntryType = IndexableNode["__class"]
 
 export function isIndexableNode<T extends AnyNode>(value: T): value is T & IndexableNode {
-    if (isComponentInstanceNode(value)) return true
     if (isTextNode(value)) return true
 
     return false


### PR DESCRIPTION
### Description

Instead of "walking the tree" in the plugin and sending over unnecessary nodes, walk on the Vekter/Framer side and only receive what we need.

This shaved off two-thirds of the index time on the Framer project. But it comes with the (small) downside that it could delay indexing on HUGE root nodes.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Indexing of text nodes still works fine™ 
  - [x] Open the plugin on a page like Framer
  - [x] Search for things, find what you expect to find on the canvas (this change doesn't change the indexer for collections or code files)

<!-- Thank you for contributing! -->