### PR TITLE
Refresh Notion databases on window focus

### DIFF
--- a/plugins/notion/src/App.css
+++ b/plugins/notion/src/App.css
@@ -108,6 +108,17 @@ form {
     color: var(--framer-color-text-secondary);
 }
 
+.collection-label {
+    position: relative;
+}
+
+.collection-label .framer-spinner {
+    position: absolute;
+    right: 26px;
+    top: 9px;
+    pointer-events: none;
+}
+
 .setup select {
     width: 100%;
 }

--- a/plugins/notion/src/SelectDataSource.tsx
+++ b/plugins/notion/src/SelectDataSource.tsx
@@ -10,6 +10,7 @@ enum Status {
     Loading = "loading",
     Ready = "ready",
     Error = "error",
+    Refreshing = "refreshing",
 }
 
 export function SelectDataSource({ onSelectDataSource }: SelectDataSourceProps) {
@@ -18,9 +19,9 @@ export function SelectDataSource({ onSelectDataSource }: SelectDataSourceProps) 
     const [dataSources, setDataSources] = useState<DataSource[]>([])
     const isFirstFocusRef = useRef(true)
 
-    const fetchDataSources = useCallback(async () => {
+    const fetchDataSources = useCallback(async (status: Status) => {
         try {
-            setStatus(Status.Loading)
+            setStatus(status)
             const dataSources = await getDataSources()
             setDataSources(dataSources)
             setStatus(Status.Ready)
@@ -49,11 +50,11 @@ export function SelectDataSource({ onSelectDataSource }: SelectDataSourceProps) 
                 isFirstFocusRef.current = false
                 return
             }
-            void fetchDataSources()
+            void fetchDataSources(Status.Refreshing)
         }
 
         window.addEventListener("focus", handleWindowFocus)
-        void fetchDataSources()
+        void fetchDataSources(Status.Loading)
 
         return () => {
             window.removeEventListener("focus", handleWindowFocus)
@@ -96,7 +97,7 @@ export function SelectDataSource({ onSelectDataSource }: SelectDataSourceProps) 
             </div>
 
             <form onSubmit={handleSubmit}>
-                <label htmlFor="collection">
+                <label htmlFor="collection" className="collection-label">
                     <select
                         id="collection"
                         onChange={event => {
@@ -114,6 +115,7 @@ export function SelectDataSource({ onSelectDataSource }: SelectDataSourceProps) 
                             </option>
                         ))}
                     </select>
+                    {status === Status.Refreshing && <div className="framer-spinner" />}
                 </label>
                 <button disabled={!selectedDatabaseId || status === Status.Loading}>
                     {status === Status.Loading ? <div className="framer-spinner" /> : "Next"}


### PR DESCRIPTION
### Description

This pull request updates the Notion plugin to refresh the databases list when the window is refocused.

Closes https://github.com/framer/plugins/issues/432

Slack: https://framer-team.slack.com/archives/C06L5H5ADK2/p1757427154222629

### Testing

- [x] Connect Notion account
- [x] Switch to another window and refocus the Notion plugin window to verify that the databases list refreshes