### PR TITLE
[Urgent] Fix text search not opening on safari

### DIFF
--- a/plugins/global-search/src/utils/idle-utils.ts
+++ b/plugins/global-search/src/utils/idle-utils.ts
@@ -7,7 +7,6 @@ const idleTimeThreshold = 7
 const getIdleCallback =
     // Safari doesn't support requestIdleCallback, so we need to shim it
     // This affects Safari versions before 16.4 (released March 2023)
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     (typeof requestIdleCallback !== "undefined" ? requestIdleCallback : null) ??
     ((cb: IdleRequestCallback) => {
         const start = performance.now()

--- a/plugins/global-search/src/utils/idle-utils.ts
+++ b/plugins/global-search/src/utils/idle-utils.ts
@@ -5,9 +5,10 @@
 const idleTimeThreshold = 7
 
 const getIdleCallback =
-    // Unfortunately Safari doesn't support requestIdleCallback, so we need to shim it
+    // Safari doesn't support requestIdleCallback, so we need to shim it
+    // This affects Safari versions before 16.4 (released March 2023)
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    requestIdleCallback ??
+    (typeof requestIdleCallback !== "undefined" ? requestIdleCallback : null) ??
     ((cb: IdleRequestCallback) => {
         const start = performance.now()
         return setTimeout(() => {


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

**Problem**: Plugin failed to load in Safari with infinite spinner and no error messages.

**Root Cause**: Safari doesn't support requestIdleCallback in older versions, and the existing fallback detection wasn't robust enough.

**Solution**: Improved Safari detection for requestIdleCallback by using explicit typeof check instead of relying on nullish coalescing alone.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Plugin works on Safari
- [x] Plugin still works on other browser
<!-- Thank you for contributing! -->