### PR TITLE
Global search: limit filterer rerun

### DIFF
--- a/plugins/global-search/src/components/SearchScene.tsx
+++ b/plugins/global-search/src/components/SearchScene.tsx
@@ -31,7 +31,12 @@ export function SearchScene() {
         results,
         running: isFilterRunning,
         error: filterError,
-    } = useAsyncFilter(queryToUse, searchOptions, db, dataVersion)
+    } = useAsyncFilter(
+        queryToUse,
+        searchOptions,
+        db,
+        isInitialIndexing ? { restartOnVersionChange: true, dataVersion } : { restartOnVersionChange: false }
+    )
     const isFilterRunningWithMinimumDuration = useMinimumDuration(isFilterRunning, 500)
 
     const hasResults = results.length > 0

--- a/plugins/global-search/src/utils/filter/useAsyncFilter.ts
+++ b/plugins/global-search/src/utils/filter/useAsyncFilter.ts
@@ -18,7 +18,9 @@ export function useAsyncFilter(
     query: string,
     rootNodes: readonly RootNodeType[],
     database: GlobalSearchDatabase,
-    dataVersion: number
+    {
+        dataVersion,
+    }: { restartOnVersionChange: true; dataVersion: number } | { restartOnVersionChange: false; dataVersion?: never }
 ): AsyncFilterState {
     const processorRef = useRef<IdleCallbackAsyncProcessor<Result> | null>(null)
     /** If this matches the current query and root nodes, we don't update the results with each progress update but instead wait for the completed event */
@@ -92,7 +94,6 @@ export function useAsyncFilter(
         })
     }
 
-    // start processing
     useEffect(() => {
         const processor = processorRef.current
         if (!processor) return


### PR DESCRIPTION
### Description

Limit re-running the filterer based on the indexer state:

- When it's the **initial run**:
  - Restart the filterer on data change. Lots of new items might come in
- When it's not, and the data updates because of an edit:
  - Only the query triggers the filterer to update

### Testing

- [x] Fresh project updates the query (hit: use a large project)
  - Clear the indexedDB, open the plugin again
  - Very quickly, search for something
  - You should see the result and don't end up on "no results" (this might be hard to see, it's a success if you see 
- [x] On a fully indexed project
  - Open the plugin, search for something on the page
  - Remove that something from the TextNode
  - The plugin will still show the now "outdated" search result -> no more flickering when lots of changes happen

<!-- Thank you for contributing! -->