### PR TITLE
Improve duplicate slug errors in Notion and Airtable

### DIFF
--- a/plugins/airtable/src/FieldMapping.tsx
+++ b/plugins/airtable/src/FieldMapping.tsx
@@ -317,9 +317,12 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
                 })
             } catch (error) {
                 console.error(error)
-                framer.notify(`Failed to sync collection "${dataSource.tableName}". Check the logs for more details.`, {
-                    variant: "error",
-                })
+                framer.notify(
+                    error instanceof Error
+                        ? error.message
+                        : `Failed to sync collection “${dataSource.tableName ?? dataSource.tableId}”`,
+                    { variant: "error", durationMs: Infinity }
+                )
             } finally {
                 setStatus("mapping-fields")
             }

--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -21,7 +21,7 @@ import {
 } from "./api"
 import type { PossibleField } from "./fields"
 import { inferFields } from "./fields"
-import { assert, richTextToHTML } from "./utils"
+import { assert, formatListWithAnd, richTextToHTML } from "./utils"
 
 export const PLUGIN_KEYS = {
     BASE_ID: "airtablePluginBaseId",
@@ -485,6 +485,24 @@ export async function syncCollection(
         unsyncedItems.delete(item.id)
     }
 
+    // Find duplicate slugs and report error if any are found
+    const seenSlugs = new Set<string>()
+    const duplicateSlugs = new Set<string>()
+
+    for (const item of items) {
+        if (seenSlugs.has(item.slug)) {
+            duplicateSlugs.add(item.slug)
+        } else {
+            seenSlugs.add(item.slug)
+        }
+    }
+
+    if (duplicateSlugs.size > 0) {
+        const slugList = formatListWithAnd(Array.from(duplicateSlugs))
+        const pluralSuffix = duplicateSlugs.size > 1 ? "s" : ""
+        throw new Error(`Duplicate slug${pluralSuffix} found: ${slugList}. Each item must have a unique slug.`)
+    }
+
     await collection.removeItems(Array.from(unsyncedItems))
     await collection.addItems(items)
 
@@ -560,8 +578,10 @@ export async function syncExistingCollection(
     } catch (error) {
         console.error(error)
         framer.notify(
-            `Failed to sync collection “${previousTableName ?? "NULL"}”. Check browser console for more details.`,
-            { variant: "error" }
+            error instanceof Error
+                ? error.message
+                : `Failed to sync collection “${previousTableName ?? previousTableId}”`,
+            { variant: "error", durationMs: Infinity }
         )
         return { didSync: false }
     }

--- a/plugins/airtable/src/utils.ts
+++ b/plugins/airtable/src/utils.ts
@@ -31,6 +31,23 @@ export function richTextToHTML(cellValue: string): string {
     })
 }
 
+/**
+ * Formats an array of items into a grammatically correct list with "and" before the last item.
+ * Examples:
+ * - ["A"] -> "A"
+ * - ["A", "B"] -> "A and B"
+ * - ["A", "B", "C"] -> "A, B, and C"
+ */
+export function formatListWithAnd(items: string[]): string {
+    if (items.length === 0) return ""
+    if (items.length === 1) return items[0] ?? ""
+    if (items.length === 2) return `${items[0] ?? ""} and ${items[1] ?? ""}`
+
+    const lastItem = items[items.length - 1] ?? ""
+    const otherItems = items.slice(0, -1).join(", ")
+    return `${otherItems}, and ${lastItem}`
+}
+
 // Allowed file types for attachments
 export const ALLOWED_FILE_TYPES = [
     "jpg",

--- a/plugins/notion/src/App.tsx
+++ b/plugins/notion/src/App.tsx
@@ -53,7 +53,9 @@ export function App({
                 }
             } catch (error) {
                 console.error(error)
-                framer.notify(`Error opening plugin. Check the logs for more details.`, { variant: "error" })
+                framer.notify(`Error opening plugin: ${error instanceof Error ? error.message : "Unknown error"}`, {
+                    variant: "error",
+                })
             }
         }
 
@@ -86,7 +88,7 @@ export function App({
                     setHasAccessError(true)
                 } else {
                     framer.notify(
-                        `Error loading previously configured database "${previousDatabaseName ?? previousDatabaseId}". Check the logs for more details.`,
+                        `Error loading previously configured database "${previousDatabaseName ?? previousDatabaseId}": ${error instanceof Error ? error.message : "Unknown error"}`,
                         { variant: "error" }
                     )
                 }

--- a/plugins/notion/src/FieldMapping.tsx
+++ b/plugins/notion/src/FieldMapping.tsx
@@ -265,9 +265,12 @@ export function FieldMapping({
                 framer.closePlugin("Synchronization successful", { variant: "success" })
             } catch (error) {
                 console.error(error)
-                framer.notify(`Failed to sync collection “${dataSource.id}”. Check the logs for more details.`, {
-                    variant: "error",
-                })
+                framer.notify(
+                    error instanceof Error
+                        ? error.message
+                        : `Failed to sync collection “${dataSource.name ?? dataSource.id}”`,
+                    { variant: "error" }
+                )
             } finally {
                 setStatus("mapping-fields")
             }

--- a/plugins/notion/src/FieldMapping.tsx
+++ b/plugins/notion/src/FieldMapping.tsx
@@ -269,7 +269,7 @@ export function FieldMapping({
                     error instanceof Error
                         ? error.message
                         : `Failed to sync collection “${dataSource.name ?? dataSource.id}”`,
-                    { variant: "error" }
+                    { variant: "error", durationMs: Infinity }
                 )
             } finally {
                 setStatus("mapping-fields")

--- a/plugins/notion/src/Login.tsx
+++ b/plugins/notion/src/Login.tsx
@@ -55,7 +55,9 @@ export function Authenticate({ onAuthenticated }: AuthenticationProps) {
 
                 onAuthenticated()
             } catch (e) {
-                framer.notify(e instanceof Error ? e.message : "An unknown error ocurred")
+                framer.notify(`Error logging in: ${e instanceof Error ? e.message : "Unknown error"}`, {
+                    variant: "error",
+                })
             } finally {
                 setIsLoading(false)
             }

--- a/plugins/notion/src/SelectDataSource.tsx
+++ b/plugins/notion/src/SelectDataSource.tsx
@@ -78,9 +78,11 @@ export function SelectDataSource({ onSelectDataSource }: SelectDataSourceProps) 
             onSelectDataSource(dataSource)
         } catch (error) {
             console.error(error)
-            framer.notify(`Failed to load database “${selectedDatabaseId}”. Check the logs for more details.`, {
-                variant: "error",
-            })
+            const dataSource = dataSources.find(dataSource => dataSource.id === selectedDatabaseId)
+            framer.notify(
+                `Failed to load database “${dataSource?.name ?? selectedDatabaseId}”: ${error instanceof Error ? error.message : "Unknown error"}`,
+                { variant: "error" }
+            )
         } finally {
             setStatus(Status.Ready)
         }

--- a/plugins/notion/src/data.ts
+++ b/plugins/notion/src/data.ts
@@ -338,7 +338,7 @@ export async function syncExistingCollection(
             error instanceof Error
                 ? error.message
                 : `Failed to sync database “${previousDatabaseName ?? previousDatabaseId}”`,
-            { variant: "error" }
+            { variant: "error", durationMs: Infinity }
         )
         return { didSync: false }
     }

--- a/plugins/notion/src/data.ts
+++ b/plugins/notion/src/data.ts
@@ -25,7 +25,7 @@ import {
     richTextToPlainText,
 } from "./api"
 import { richTextToHtml } from "./blocksToHtml"
-import { formatDate, isNotNull, slugify, syncMethods } from "./utils"
+import { formatDate, formatListWithAnd, isNotNull, slugify, syncMethods } from "./utils"
 
 // Maximum number of concurrent requests to Notion API
 // This is to prevent rate limiting.
@@ -239,6 +239,24 @@ export async function syncCollection(
     const result = await Promise.all(promises)
     const items = result.filter(isNotNull)
 
+    // Find duplicate slugs and report error if any are found
+    const seenSlugs = new Set<string>()
+    const duplicateSlugs = new Set<string>()
+
+    for (const item of items) {
+        if (seenSlugs.has(item.slug)) {
+            duplicateSlugs.add(item.slug)
+        } else {
+            seenSlugs.add(item.slug)
+        }
+    }
+
+    if (duplicateSlugs.size > 0) {
+        const slugList = formatListWithAnd(Array.from(duplicateSlugs))
+        const pluralSuffix = duplicateSlugs.size > 1 ? "s" : ""
+        throw new Error(`Duplicate slug${pluralSuffix} found: ${slugList}. Each item must have a unique slug.`)
+    }
+
     const itemIdsToDelete = new Set(await collection.getItemIds())
     for (const itemId of seenItemIds) {
         itemIdsToDelete.delete(itemId)
@@ -317,7 +335,9 @@ export async function syncExistingCollection(
     } catch (error) {
         console.error(error)
         framer.notify(
-            `Failed to sync database “${previousDatabaseName ?? previousDatabaseId}”. Check browser console for more details.`,
+            error instanceof Error
+                ? error.message
+                : `Failed to sync database “${previousDatabaseName ?? previousDatabaseId}”`,
             { variant: "error" }
         )
         return { didSync: false }

--- a/plugins/notion/src/utils.ts
+++ b/plugins/notion/src/utils.ts
@@ -67,6 +67,23 @@ export function generateRandomId() {
     return id
 }
 
+/**
+ * Formats an array of items into a grammatically correct list with "and" before the last item.
+ * Examples:
+ * - ["A"] -> "A"
+ * - ["A", "B"] -> "A and B"
+ * - ["A", "B", "C"] -> "A, B, and C"
+ */
+export function formatListWithAnd(items: string[]): string {
+    if (items.length === 0) return ""
+    if (items.length === 1) return items[0] ?? ""
+    if (items.length === 2) return `${items[0] ?? ""} and ${items[1] ?? ""}`
+
+    const lastItem = items[items.length - 1] ?? ""
+    const otherItems = items.slice(0, -1).join(", ")
+    return `${otherItems}, and ${lastItem}`
+}
+
 export const syncMethods = [
     "ManagedCollection.removeItems",
     "ManagedCollection.addItems",


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request adds descriptive error messages for duplicate slugs in Notion and Airtable, and improves other error messages.

Closes https://github.com/framer/plugins/issues/467
Closes https://github.com/framer/plugins/issues/466

Before:
<img width="724" height="70" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/a040fccb-569d-4eed-a458-7ef557798577" />

After:
<img width="567" height="73" alt="image" src="https://github.com/user-attachments/assets/5947024f-97c9-4a90-82cf-8f6865f53fb6" />

The code in this PR was copied from https://github.com/framer/plugins/pull/468

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [ ] Sync a Notion database with duplicate slugs. [Testing database](https://www.notion.so/framer/1efadf6e8c9680888be6fa350bc0f369?v=1efadf6e8c968018b2b6000cffaa93ca)
- [ ] Sync an Airtable base with duplicate slugs