### PR TITLE
Google Sheets: hide all empty columns from field mapping

### DIFF
--- a/plugins/google-sheets/src/utils.ts
+++ b/plugins/google-sheets/src/utils.ts
@@ -80,6 +80,8 @@ export function generateUniqueNames(names: string[]): string[] {
     const nameCount = new Map<string, number>()
 
     return names.map(name => {
+        if (!name) return ""
+
         const count = nameCount.get(name) ?? 0
         nameCount.set(name, count + 1)
 


### PR DESCRIPTION
### Description

This pull request fixes a bug in the Google Sheets plugin where if multiple rows have an empty header cell, all but the first one would be visible in the field mapping UI.

Before: if there are 3 empty header cells, it shows field mapping rows for " 2" and " 3"
After: none of the empty header cells are shown

Closes https://github.com/framer/plugins/issues/471

### Testing

You can use this sheet to test: https://docs.google.com/spreadsheets/d/1KnN02FxW-Yf8hRnONUqGmquuIT_keKD9Rn3wgDKXtco/edit?gid=0#gid=0

- [x] Select a sheet with multiple rows with an empty header cell
- [x] Make sure none of them are visible in the field mapping UI