### PR TITLE
Hide plugin close errors in Google Sheets and Airtable

### DIFF
--- a/plugins/airtable/src/FieldMapping.tsx
+++ b/plugins/airtable/src/FieldMapping.tsx
@@ -1,5 +1,5 @@
 import type { Field, ManagedCollection, ManagedCollectionFieldInput } from "framer-plugin"
-import { framer, useIsAllowedTo } from "framer-plugin"
+import { FramerPluginClosedError, framer, useIsAllowedTo } from "framer-plugin"
 import { memo, useEffect, useMemo, useState } from "react"
 import type { DataSource } from "./data"
 import { mergeFieldsWithExistingFields, syncCollection, syncMethods } from "./data"
@@ -316,6 +316,8 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
                     variant: "success",
                 })
             } catch (error) {
+                if (error instanceof FramerPluginClosedError) return
+
                 console.error(error)
                 framer.notify(
                     error instanceof Error

--- a/plugins/google-sheets/src/App.tsx
+++ b/plugins/google-sheets/src/App.tsx
@@ -1,4 +1,4 @@
-import { framer } from "framer-plugin"
+import { FramerPluginClosedError, framer } from "framer-plugin"
 import { useEffect, useLayoutEffect, useState } from "react"
 import auth from "./auth"
 import { logSyncResult, PLUGIN_LOG_SYNC_KEY } from "./debug"
@@ -225,6 +225,8 @@ export function App({ pluginContext }: AppProps) {
 
                 framer.closePlugin("Synchronization successful", { variant: "success" })
             } catch (error) {
+                if (error instanceof FramerPluginClosedError) return
+
                 console.error(error)
                 framer.closePlugin(
                     error instanceof Error ? error.message : "An error occurred while syncing the sheet",


### PR DESCRIPTION
### Description

This pull request makes the Google Sheets and Airtable plugins not log errors for plugin close errors. They are not real errors, but were still being logged as errors.

Slack thread: https://framer-team.slack.com/archives/C06L5H5ADK2/p1762356881634499

### Testing

- [x] Sync a Google Sheet in sync mode
- [x] Sync an Airtable base in manage mode