### PR TITLE
Google Sheets: fix scrolling in Safari and Firefox

### DIFF
--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -252,7 +252,7 @@ export function MapSheetFieldsPage({
                         ))}
                     </select>
                 </div>
-                <div className="grid grid-cols items-center grid-cols-field-picker gap-[10px] overflow-hidden pt-[5px] pb-[10px] mb-auto min-h-fit">
+                <div className="grid grid-cols items-center grid-cols-field-picker gap-[10px] overflow-hidden pt-[5px] pb-[10px] mb-auto min-h-fit shrink-0">
                     <span className="col-span-2">Column</span>
                     <span>Type</span>
                     <span>Name</span>


### PR DESCRIPTION
### Description

This pull request fixes scrolling in the map fields page in the Google Sheets plugin in Safari and Firefox.

Slack thread: https://framer-team.slack.com/archives/C06L5H5ADK2/p1763505536526719

### Testing

- [x] Open Framer in Safari
- [x] Connect a sheet that has more than 6 columns so the fields list is taller than the plugin window
- [x] Scroll down