### PR TITLE
Text Search: Update copy: No Results → No Search Results

### DIFF
--- a/plugins/global-search/src/components/SearchScene.tsx
+++ b/plugins/global-search/src/components/SearchScene.tsx
@@ -88,7 +88,7 @@ export function SearchScene() {
                 </div>
                 <div className="px-3 flex flex-col flex-1 scrollbar-hidden">
                     {hasResults && <ResultsList groups={results} />}
-                    {showNoResults && <ResultMessage>No Results</ResultMessage>}
+                    {showNoResults && <ResultMessage>No Search Results</ResultMessage>}
                 </div>
             </SelectionProvider>
         </main>
@@ -140,7 +140,7 @@ function useOptionsMenuItems() {
 }
 
 /**
- * Debounces the "no results" visibility based on the previous state
+ * Debounces the "no search results" visibility based on the previous state
  */
 function useNoResults({
     query,


### PR DESCRIPTION
Updated the empty state message in the global search plugin to be more specific and aligned with product terminology.

## Changes

Changed "No Results" to "No Search Results" in the global search plugin to provide clearer context about what type of results are missing.

## Details

- Updated the UI message in SearchScene.tsx
- Updated the corresponding comment for consistency

## QA 

- [x] noop