### PR TITLE
Tidy Up: fix number inputs, allow any integer gap

### DIFF
--- a/plugins/tidyup/src/App.tsx
+++ b/plugins/tidyup/src/App.tsx
@@ -339,7 +339,7 @@ const SortingSchema = v.union(allSortings.map(sorting => v.literal(sorting)))
 type Sorting = v.InferOutput<typeof SortingSchema>
 
 const ColumnCountSchema = v.pipe(v.number(), v.integer(), v.minValue(1))
-const GapSchema = v.pipe(v.number(), v.integer(), v.minValue(0), v.multipleOf(10))
+const GapSchema = v.pipe(v.number(), v.integer(), v.minValue(0))
 
 export function App() {
     const isAllowedToSetAttributes = useIsAllowedTo("setAttributes")

--- a/plugins/tidyup/src/Stepper.tsx
+++ b/plugins/tidyup/src/Stepper.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react"
 import { isNumber } from "./isNumber"
 
 import "./Stepper.css"
@@ -36,8 +37,33 @@ function clamp(value: number, min: number, max: number) {
 }
 
 export function Stepper({ value = 0, min = 0, step: stepAmount = 1, onChange }: Props) {
+    const [inputValue, setInputValue] = useState<string>(() => String(value))
+
+    useEffect(() => {
+        setInputValue(String(value))
+    }, [value])
+
     const step = (direction: -1 | 1) => {
-        onChange(clamp(value + stepAmount * direction, 0, Infinity))
+        onChange(clamp(value + stepAmount * direction, min, Infinity))
+    }
+
+    const commitInput = () => {
+        const trimmed = inputValue.trim()
+        if (trimmed === "") {
+            setInputValue(String(value))
+            return
+        }
+
+        const parsed = Number(trimmed)
+        if (!isNumber(parsed)) {
+            setInputValue(String(value))
+            return
+        }
+
+        const snapped = Math.round(clamp(parsed, min, Infinity))
+
+        setInputValue(String(snapped))
+        onChange(snapped)
     }
 
     return (
@@ -45,14 +71,17 @@ export function Stepper({ value = 0, min = 0, step: stepAmount = 1, onChange }: 
             <input
                 className="stepper-input"
                 type="number"
-                value={value}
+                value={inputValue}
                 min={min}
                 step={stepAmount}
                 onChange={event => {
-                    const numberValue = event.currentTarget.valueAsNumber
-                    const value = isNumber(numberValue) ? numberValue : 0
-
-                    onChange(value)
+                    setInputValue(event.currentTarget.value)
+                }}
+                onBlur={commitInput}
+                onKeyDown={event => {
+                    if (event.key === "Enter") {
+                        commitInput()
+                    }
                 }}
             />
 


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request fixes the gap input in the Tidy Up plugin and updates it to allow any integer value for gap, not just multiples of 10. The plus and minus buttons still add/subtract 10.

You can't see my key presses in the recording, but in the first part when using the current version of Tidy Up, pressing backspace or typing a number doesn't work unless the resulting value is a multiple of 10. In the new version, you can type anything and the value is only validated/committed when you press enter or unfocus the input.

https://github.com/user-attachments/assets/91639133-da37-4972-815c-4bdf4bb9698a

### Testing

- [x] Test gap and column count inputs in Tidy Up