### PR TITLE
Preserve draft status in CSV import

### DIFF
--- a/plugins/csv-import/src/utils/prepareImportPayload.ts
+++ b/plugins/csv-import/src/utils/prepareImportPayload.ts
@@ -230,7 +230,6 @@ export async function prepareImportPayload(opts: ProcessRecordsWithFieldMappingO
         }
     }
 
-    // TODO: QA draft functionality
     // Check if CSV has a draft column
     const firstRecord = opts.csvRecords[0]
     assert(firstRecord, "No records were found in your CSV.")
@@ -261,6 +260,12 @@ export async function prepareImportPayload(opts: ProcessRecordsWithFieldMappingO
             const draftValue = findRecordValue(record, ":draft")
             if (draftValue && draftValue.trim() !== "") {
                 draft = BOOLEAN_TRUTHY_VALUES.test(draftValue.trim())
+            }
+        } else {
+            // Preserve existing draft value if no draft column in CSV
+            const existingItem = existingItemsBySlug.get(slug)
+            if (existingItem) {
+                draft = existingItem.draft
             }
         }
 


### PR DESCRIPTION
### Description

This pull request fixes importing CSVs without a draft column.

Before: if the CSV does not have a :draft column, all updated draft items are removed from drafts.
After: if the CSV does not have a :draft column, draft status is not changed on any items.

### Testing

Use this Google Sheet:
https://docs.google.com/spreadsheets/d/1JuOKh_Wb0uIytKe4eE7uI6Js826i8V_uf2oFtyolDtA/edit?gid=1174080602#gid=1174080602

- [x] Copy and paste the whole table into CSV import to add some draft and non-draft items
- [x] Copy and paste the table minus the :draft column at the end to update the items. The items' draft status should not change.