### PR TITLE
CSV Import: fix top divider width

### DIFF
--- a/plugins/csv-import/src/App.css
+++ b/plugins/csv-import/src/App.css
@@ -320,10 +320,8 @@ select:not(:disabled) {
 .field-mapper .sticky-divider {
     position: sticky;
     top: 0;
-    left: 0;
-    right: 0;
     margin-left: 15px;
-    margin-right: 15px;
+    width: calc(100% - 30px);
     border: none;
     border-top: 1px solid var(--framer-color-divider);
 }


### PR DESCRIPTION
### Description

This pull request fixes the top divider width in CSV import.

Before: divider has 15px padding on left and none on right.
<img width="576" height="76" alt="Pasted Graphic 7" src="https://github.com/user-attachments/assets/5396937c-c164-4c5b-8f8e-f2b5cccc88db" />

After: divider has 15px padding on both sides.
<img width="579" height="79" alt="image" src="https://github.com/user-attachments/assets/0739b2ae-0649-4ab9-8df1-65c8ebf6fcff" />

### Testing

- [ ] Open CSV Import, upload a CSV, and look at the top divider