### PR TITLE
CSV Import: createCollection permission

### DIFF
--- a/plugins/csv-import/src/App.tsx
+++ b/plugins/csv-import/src/App.tsx
@@ -17,12 +17,7 @@ import { ImportError, type ImportItem, prepareImportPayload } from "./utils/prep
 
 export function App({ initialCollection }: { initialCollection: Collection | null }) {
     const [collection, setCollection] = useState<Collection | null>(initialCollection)
-    const hasAllPermissions = useIsAllowedTo(
-        "Collection.addItems",
-        "Collection.addFields",
-        "Collection.removeFields",
-        "createCollection"
-    )
+    const hasAllPermissions = useIsAllowedTo("Collection.addItems", "Collection.addFields", "Collection.removeFields")
 
     const { currentRoute, navigate } = useMiniRouter()
 

--- a/plugins/csv-import/src/utils/importCSV.ts
+++ b/plugins/csv-import/src/utils/importCSV.ts
@@ -1,4 +1,4 @@
-import { Collection, framer } from "framer-plugin"
+import { type Collection, framer } from "framer-plugin"
 
 import { assert } from "./assert"
 import type { ImportPayload } from "./prepareImportPayload"

--- a/plugins/csv-import/src/utils/prepareImportPayload.ts
+++ b/plugins/csv-import/src/utils/prepareImportPayload.ts
@@ -1,6 +1,6 @@
 import {
-    Collection,
-    CollectionItem,
+    type Collection,
+    type CollectionItem,
     type CollectionItemInput,
     type Field,
     type FieldDataEntryInput,


### PR DESCRIPTION
### Description

This pull request removes the createCollection requirement from importing CSV files, so users with permission to edit collections but not create new ones can use CSV import. createCollection is still checked for creating new collections in the plugin, but not for importing into existing collections.

### Testing

- [x] Import a CSV into a project where you have access to edit collections but not create new collections. 