### PR TITLE
CSV Import: Skip companion columns during field inference

### DIFF
--- a/plugins/csv-import/src/utils/typeInference.ts
+++ b/plugins/csv-import/src/utils/typeInference.ts
@@ -153,8 +153,13 @@ export function inferFieldsFromCSV(records: Record<string, string>[]): InferredF
     const inferredFields: InferredField[] = []
 
     for (const fieldName of fieldNames) {
-        // Skip special fields
+        // Skip special fields (e.g., `:draft`)
         if (fieldName.startsWith(":")) {
+            continue
+        }
+
+        // Skip companion columns (e.g., `Image:alt` provides alt text for `Image`)
+        if (fieldName.endsWith(":alt")) {
             continue
         }
 


### PR DESCRIPTION
### Description

This pull request adds support for skipping companion columns during CSV import field inference. Specifically, it ignores columns with the `:alt` suffix (e.g., `Image:alt`), which provide alt text for corresponding fields like `Image`. This prevents these companion columns from being incorrectly inferred as separate fields.

### Testing

- [x] Test CSV import with companion columns
  - In a new project add the default Blog collection
  - Use the CMS Export plugin to get the CSV
  - Update an image alt
  - Use the CSV Import plugin to import the CSV
  - [x] Verify that only the `Image` field is inferred, and you do not see `Image:alt` anymore
  - [x] Import and verify that the alt is updated