### PR TITLE
Warn that imported data is public

### DIFF
--- a/plugins/csv-import/src/App.css
+++ b/plugins/csv-import/src/App.css
@@ -657,3 +657,10 @@ select:not(:disabled) {
     grid-column: span 2;
     width: 100%;
 }
+
+.public-data-note {
+    padding-top: 1em;
+    font-size: 0.75em;
+    color: var(--framer-color-text-tertiary);
+    text-align: center;
+}

--- a/plugins/csv-import/src/components/SelectCSVFile.tsx
+++ b/plugins/csv-import/src/components/SelectCSVFile.tsx
@@ -166,6 +166,12 @@ export function SelectCSVFile({ onFileSelected, disabled }: SelectCSVFileProps) 
                         >
                             Upload File
                         </button>
+
+                        <p className="public-data-note">
+                            CMS data is publicly viewable.
+                            <br />
+                            Avoid importing personal data.
+                        </p>
                     </div>
                 </>
             )}


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

People [CSV-imported personally identifiable information](https://framer-team.slack.com/archives/C068W7EDVMY/p1769158051518329) into the CMS and were surprised it was visible to the internet.
Wdyt about warning about this here, and then potentially also for other import avenues?
We were also thinking about warning about this in the app UI because people might also enter such data manually, but aren't sure yet if we have a good place. Via import people are probably most likely to carelessly do this without thinking about it.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [ ] Look at the UI

<!-- Thank you for contributing! -->

