### PR TITLE
Make comparison to slug column case insensitive

### DIFF
--- a/plugins/csv-import/src/routes/FieldMapper.tsx
+++ b/plugins/csv-import/src/routes/FieldMapper.tsx
@@ -37,6 +37,9 @@ function calculatePossibleSlugFields(mappings: FieldMappingItem[], csvRecords: R
     return mappings.filter(m => isValidSlugColumn(m.inferredField.columnName, csvRecords)).map(m => m.inferredField)
 }
 
+const caseInsensitiveEquals = (a: string | undefined | null, b: string | undefined | null) =>
+    a?.toLocaleLowerCase() === b?.toLocaleLowerCase()
+
 export function FieldMapper({ collection, csvRecords, onSubmit }: FieldMapperProps) {
     const [existingFields, setExistingFields] = useState<Field[]>([])
     const [mappings, setMappings] = useState<FieldMappingItem[]>([])
@@ -58,7 +61,8 @@ export function FieldMapper({ collection, csvRecords, onSubmit }: FieldMapperPro
 
                 // Existing Slug field match against CSV column if any
                 const matchedSlugColumnName = collection.slugFieldName
-                    ? inferredFields.find(field => field.columnName === collection.slugFieldName)?.columnName
+                    ? inferredFields.find(field => caseInsensitiveEquals(field.columnName, collection.slugFieldName))
+                          ?.columnName
                     : undefined
 
                 // Column we will suggest as slug field on the UI


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request fixes: https://framer-team.slack.com/archives/C06L5H5ADK2/p1769597296118989

Essentially we auto-match the slug column like before, bug it may have been case-insensitive before

### Testing

[people_with_slug.csv](https://github.com/user-attachments/files/24908815/people_with_slug.csv)

- [x] Upload a CSV with lowercase slug and check it matches by default

<!-- Thank you for contributing! -->