### PR TITLE
Inject framer-plugin-packed.txt file into plugin.zip

### DIFF
--- a/packages/plugin-tools/src/lib.test.ts
+++ b/packages/plugin-tools/src/lib.test.ts
@@ -128,6 +128,24 @@ describe("zipPluginDistribution", () => {
         expect(zip.readAsText("framer-plugin-packed.txt")).toBe("true")
     })
 
+    it("overwrites dist framer-plugin-packed.txt with injected marker", () => {
+        const distDir = path.join(tmpDir, "dist")
+        fs.mkdirSync(distDir)
+        fs.writeFileSync(path.join(distDir, "framer-plugin-packed.txt"), "false or custom")
+        fs.writeFileSync(path.join(distDir, "index.js"), "")
+
+        zipPluginDistribution({
+            cwd: tmpDir,
+            distPath: "dist",
+            zipFileName: "plugin.zip",
+        })
+
+        const zip = new AdmZip(path.join(tmpDir, "plugin.zip"))
+        const entriesWithSameName = zip.getEntries().filter(e => e.entryName === "framer-plugin-packed.txt")
+        expect(entriesWithSameName).toHaveLength(1)
+        expect(zip.readAsText("framer-plugin-packed.txt")).toBe("true")
+    })
+
     it("throws error when dist directory does not exist", () => {
         expect(() =>
             zipPluginDistribution({

--- a/packages/plugin-tools/src/lib.ts
+++ b/packages/plugin-tools/src/lib.ts
@@ -3,6 +3,8 @@ import { exec } from "child_process"
 import fs from "fs"
 import path from "path"
 
+const markerFileName = "framer-plugin-packed.txt"
+
 /**
  * Naive package manager detection by checking for lock files in the current directory and parent directories.
  * @param cwd - The current working directory.
@@ -50,7 +52,8 @@ export function zipPluginDistribution(options: ZipPluginDistributionOptions): st
 
     const zip = new AdmZip()
     zip.addLocalFolder(distPath)
-    zip.addFile("framer-plugin-packed.txt", Buffer.from("true", "utf-8"))
+    zip.deleteFile(markerFileName)
+    zip.addFile(markerFileName, Buffer.from("true", "utf-8"))
     zip.writeZip(zipFilePath)
 
     return zipFilePath


### PR DESCRIPTION
### Description

This pull request updates `framer-plugin-tools` to insert a file named `framer-plugin-packed.txt` into the generated plugin.zip file. This is the first step of https://github.com/framer/creators/issues/2008

If a file named `framer-plugin-packed.txt` exists in the /dist folder it will be overwritten.

Slack: https://framer-team.slack.com/archives/C06L5H5ADK2/p1770746299070489

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Use `yarn run pack` to pack a plugin
- [x] In finder/file explorer, double click the plugin.zip to open it
- [x] Verify that a file named `framer-plugin-packed.txt` exists with `true` as the only content inside.

<!-- Thank you for contributing! -->