### PR TITLE
Airtable: fix image and file types with lookup fields

### DIFF
--- a/plugins/airtable/src/data.ts
+++ b/plugins/airtable/src/data.ts
@@ -108,6 +108,10 @@ export function getFieldDataEntryForFieldSchema(
         case "link":
         case "image":
         case "file": {
+            if (Array.isArray(value) && typeof value[0] === "string") {
+                value = value[0]
+            }
+
             if (typeof value === "string") {
                 if (fieldSchema.airtableType === "email" || EMAIL_REGEX.test(value)) {
                     return {


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request fixes importing lookup fields with image, file, or array (gallery) types from Airtable.

Reported by a customer here: https://app.intercom.com/a/inbox/gmqktfjv/inbox/admin/8343678/conversation/215473146300745

### Changelog

- Fixed importing lookup fields with Image, File, or Gallery field types.

### Testing

This Airtable base has a lookup field with images in Table 1. Sign in with your framer.com email to get access.
https://airtable.com/invite/l?inviteId=invAEK4FPLlBtMFXE&inviteToken=f12c686f289d2bb8abecd75b03283b1db0c16d7d07c041afc24bb6730bfaef28&utm_medium=email&utm_source=product_team&utm_content=transactional-alerts

- [x] Sync an Airtable base with lookup field with images
- [x] Change type to file and import
- [x] Change type to gallery and import