### PR TITLE
Truncate button text

### DIFF
--- a/plugins/airtable/src/App.css
+++ b/plugins/airtable/src/App.css
@@ -188,6 +188,11 @@ select:not(:disabled) {
     pointer-events: none;
 }
 
+.import-button {
+    white-space: nowrap;
+    display: inline-block;
+}
+
 /* Login */
 
 .login-steps {

--- a/plugins/airtable/src/FieldMapping.tsx
+++ b/plugins/airtable/src/FieldMapping.tsx
@@ -418,6 +418,7 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
             <footer>
                 <hr className="sticky-top" />
                 <button
+                    className="import-button"
                     type="submit"
                     disabled={isSyncing || !isAllowedToManage}
                     tabIndex={0}

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -309,6 +309,7 @@ export function MapSheetFieldsPage({
                     <button
                         disabled={!isAllowedToManage}
                         title={isAllowedToManage ? undefined : "Insufficient permissions"}
+                        className="whitespace-nowrap inline-block"
                     >
                         {isPending ? <div className="framer-spinner" /> : `Import from ${sheetTitle}`}
                     </button>

--- a/plugins/notion/src/App.css
+++ b/plugins/notion/src/App.css
@@ -244,6 +244,11 @@ select:not(:disabled) {
     cursor: pointer;
 }
 
+.import-button {
+    white-space: nowrap;
+    display: inline-block;
+}
+
 /* Login */
 
 .login {

--- a/plugins/notion/src/FieldMapping.tsx
+++ b/plugins/notion/src/FieldMapping.tsx
@@ -368,6 +368,7 @@ export function FieldMapping({
                 <footer>
                     <hr className="sticky-top" />
                     <button
+                        className="import-button"
                         disabled={!isAllowedToManage}
                         tabIndex={0}
                         title={!isAllowedToManage ? "Insufficient permissions" : undefined}


### PR DESCRIPTION
### Description

This pull request makes the button text in Notion, Airtable, Google Sheets truncate to 1 line instead of wrapping to multiple lines.

Closes https://github.com/framer/plugins/issues/578

<img width="377" height="496" alt="image" src="https://github.com/user-attachments/assets/42fe552a-2513-4ac6-881e-e01cdf9c15c4" />

### Changelog

- Button text is now truncated to one line for long database names.

### Testing

- [ ] QA test