### PR TITLE
Fix code-link CLI appearing stalled during cert generation

### DIFF
--- a/packages/code-link-cli/src/controller.ts
+++ b/packages/code-link-cli/src/controller.ts
@@ -1095,8 +1095,6 @@ async function executeEffect(
  * Starts the sync controller with the given configuration
  */
 export async function start(config: Config): Promise<void> {
-    status("Waiting for Plugin connection...")
-
     const hashTracker = createHashTracker()
     const fileMetadataCache = new FileMetadataCache()
     const pendingRenameConfirmations = new Map<string, PendingRenameConfirmation>()
@@ -1162,6 +1160,8 @@ export async function start(config: Config): Promise<void> {
         info("")
         throw new Error("TLS certificate generation failed")
     }
+
+    status("Waiting for Plugin connection...")
 
     // WebSocket Connection (always WSS)
     const connection = await initConnection(config.port, certs)

--- a/packages/code-link-cli/src/helpers/certs.ts
+++ b/packages/code-link-cli/src/helpers/certs.ts
@@ -91,6 +91,7 @@ export async function getOrCreateCerts(): Promise<CertBundle | null> {
 
         status("Generating local certificates to connect securely. You may be asked for your password.")
         await generateCerts(mkcertPath)
+        status("Successfully generated certificates.")
 
         const key = await fs.readFile(SERVER_KEY_PATH, "utf-8")
         const cert = await fs.readFile(SERVER_CERT_PATH, "utf-8")


### PR DESCRIPTION
## Summary
- Move "Waiting for Plugin connection..." to after certificate setup so it doesn't appear while certs are still being generated
- Add "Successfully generated certificates." confirmation after cert generation completes

Before (appears stalled after sudo prompt):
```
⚡ Code Link v0.18.0

Waiting for Plugin connection...
Downloading mkcert for certificate generation...
Generating local certificates to connect securely. You may be asked for your password.
Sudo password:
```

After:
```
⚡ Code Link v0.18.0

Downloading mkcert for certificate generation...
Generating local certificates to connect securely. You may be asked for your password.
Sudo password: ****
Successfully generated certificates.
Waiting for Plugin connection...
```

## Test plan
- [x] Existing cert tests pass (17/17)