### PR TITLE
Fix leading space in code-link directory names from emoji project names

### DIFF
--- a/packages/code-link-cli/src/utils/project.test.ts
+++ b/packages/code-link-cli/src/utils/project.test.ts
@@ -23,6 +23,11 @@ describe("toDirectoryName", () => {
         expect(toDirectoryName(" -Project")).toBe("Project")
         expect(toDirectoryName("Project- ")).toBe("Project")
     })
+
+    it("handles emoji prefixed names", () => {
+        expect(toDirectoryName("🧠 Logic")).toBe("Logic")
+        expect(toDirectoryName("🎨 Design System")).toBe("Design System")
+    })
 })
 
 describe("findOrCreateProjectDirectory", () => {

--- a/packages/code-link-cli/src/utils/project.ts
+++ b/packages/code-link-cli/src/utils/project.ts
@@ -23,6 +23,7 @@ export function toDirectoryName(name: string): string {
         .replace(/[^a-zA-Z0-9 -]/g, "-")
         .trim()
         .replace(/^-+|-+$/g, "")
+        .trim()
         .replace(/-+/g, "-")
 }
 


### PR DESCRIPTION
### Description

Project names with emoji prefixes like "🧠 Logic" produce directory names with a leading space. The emoji gets replaced with hyphens by the sanitization regex, then boundary hyphen removal strips those hyphens — revealing a space that wasn't at the boundary before. Adding a second `trim()` after boundary hyphen removal fixes this.

### Changelog

- Fixed code-link CLI creating directories with leading spaces when project names contain emoji prefixes

### Testing

- [x] Emoji-prefixed project names produce clean directory names
  - [x] Create a project named "🧠 Logic" and sync via code-link
  - [x] Verify the directory is named "Logic" (no leading space)
- [x] Existing name sanitization still works
  - [x] Run `npx vitest run src/utils/project.test.ts` — all 10 tests pass