### PR TITLE
Add enum field support to Google Sheets sync

### DIFF
--- a/plugins/google-sheets/src/enumCases.ts
+++ b/plugins/google-sheets/src/enumCases.ts
@@ -1,0 +1,76 @@
+import { generateHashId, isDefined } from "./utils"
+
+type EnumCaseLike = {
+    id: string
+    name: string
+}
+
+type EnumCaseCellValue = string | number | boolean | null
+
+export function getEnumCasesForColumn(
+    rows: ReadonlyArray<ReadonlyArray<EnumCaseCellValue>>,
+    colIndex: number
+): EnumCaseLike[] {
+    const cases: EnumCaseLike[] = []
+    const seenValues = new Set<string>()
+
+    for (const row of rows) {
+        const rawValue = row[colIndex]
+        if (!isDefined(rawValue)) continue
+
+        const normalizedValue = String(rawValue).trim()
+        if (!normalizedValue || seenValues.has(normalizedValue)) continue
+
+        seenValues.add(normalizedValue)
+        cases.push({
+            id: generateHashId(normalizedValue),
+            name: normalizedValue,
+        })
+    }
+
+    return cases
+}
+
+export function mergeEnumCases(
+    existingCases: readonly EnumCaseLike[] | undefined,
+    derivedCases: readonly EnumCaseLike[]
+): EnumCaseLike[] {
+    const mergedCases: EnumCaseLike[] = []
+    const seenCaseNames = new Set<string>()
+
+    for (const existingCase of existingCases ?? []) {
+        if (seenCaseNames.has(existingCase.name)) continue
+
+        seenCaseNames.add(existingCase.name)
+        mergedCases.push(existingCase)
+    }
+
+    for (const derivedCase of derivedCases) {
+        if (seenCaseNames.has(derivedCase.name)) continue
+
+        seenCaseNames.add(derivedCase.name)
+        mergedCases.push(derivedCase)
+    }
+
+    return mergedCases
+}
+
+export function areEnumCasesEqual(
+    leftCases: readonly EnumCaseLike[] | undefined,
+    rightCases: readonly EnumCaseLike[] | undefined
+): boolean {
+    const left = leftCases ?? []
+    const right = rightCases ?? []
+
+    if (left.length !== right.length) return false
+
+    for (let i = 0; i < left.length; i++) {
+        const leftCase = left[i]
+        const rightCase = right[i]
+
+        if (!leftCase || !rightCase) return false
+        if (leftCase.id !== rightCase.id || leftCase.name !== rightCase.name) return false
+    }
+
+    return true
+}

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -3,25 +3,41 @@ import { framer, useIsAllowedTo } from "framer-plugin"
 import { Fragment, useMemo, useState } from "react"
 import { CheckboxTextfield } from "../components/CheckboxTextField"
 import { IconChevron } from "../components/Icons"
-import type {
-    CellValue,
-    HeaderRow,
-    PluginContext,
-    Row,
-    SheetCollectionFieldInput,
-    SyncMutationOptions,
-    VirtualFieldType,
-} from "../sheets"
-import { generateUniqueNames, isDefined, syncMethods } from "../utils"
+import type { CellValue, HeaderRow, PluginContext, PluginContextUpdate, Row, SyncMutationOptions } from "../sheets"
+import { generateHashId, generateUniqueNames, isDefined, syncMethods } from "../utils"
+
+type FieldType =
+    | "string"
+    | "number"
+    | "boolean"
+    | "formattedText"
+    | "enum"
+    | "date"
+    | "dateTime"
+    | "link"
+    | "image"
+    | "color"
+    | "file"
+    | "collectionReference"
+    | "multiCollectionReference"
+    | "array"
 
 interface FieldTypeOption {
-    type: VirtualFieldType
+    type: FieldType
     label: string
+}
+
+interface EditableField {
+    id: string
+    name: string
+    type: FieldType
+    cases?: { id: string; name: string }[]
 }
 
 const fieldTypeOptions: FieldTypeOption[] = [
     { type: "string", label: "Plain Text" },
     { type: "formattedText", label: "Formatted Text" },
+    { type: "enum", label: "Option" },
     { type: "date", label: "Date" },
     { type: "dateTime", label: "Date & Time" },
     { type: "link", label: "Link" },
@@ -32,12 +48,17 @@ const fieldTypeOptions: FieldTypeOption[] = [
     { type: "file", label: "File" },
 ]
 
-const getInitialSlugColumn = (context: PluginContext, slugFields: SheetCollectionFieldInput[]): string => {
-    if (context.type === "update" && context.slugColumn) {
+function isUpdateContext(context: PluginContext): context is PluginContextUpdate {
+    return context.type === "update"
+}
+
+const getInitialSlugColumn = (context: PluginContext, slugFields: EditableField[]): string => {
+    if (isUpdateContext(context) && context.slugColumn) {
         return context.slugColumn
     }
 
-    return slugFields[0]?.id ?? ""
+    const firstSlugField = slugFields[0]
+    return firstSlugField?.id ?? ""
 }
 
 const getLastSyncedTime = (context: PluginContext, slugColumn: string): string | null => {
@@ -54,7 +75,7 @@ const getLastSyncedTime = (context: PluginContext, slugColumn: string): string |
     return context.lastSyncedTime
 }
 
-const inferFieldType = (cellValue: CellValue): VirtualFieldType => {
+const inferFieldType = (cellValue: CellValue): FieldType => {
     if (typeof cellValue === "boolean") return "boolean"
     if (typeof cellValue === "number") return "number"
 
@@ -102,9 +123,9 @@ const inferFieldType = (cellValue: CellValue): VirtualFieldType => {
     return "string"
 }
 
-const getFieldType = (context: PluginContext, columnId: string, cellValue?: CellValue): VirtualFieldType => {
+const getFieldType = (context: PluginContext, columnId: string, cellValue?: CellValue): FieldType => {
     // Determine if the field type is already configured
-    if ("collectionFields" in context) {
+    if (isUpdateContext(context)) {
         const field = context.collectionFields.find(field => field.id === columnId)
         return field?.type ?? "string"
     }
@@ -118,24 +139,27 @@ const createFieldConfig = (
     uniqueColumnNames: string[],
     context: PluginContext,
     row?: Row
-): SheetCollectionFieldInput[] => {
-    return headerRow
-        .map((_, columnIndex) => {
-            const sanitizedName = uniqueColumnNames[columnIndex]
-            if (!sanitizedName) return null
+): EditableField[] => {
+    const fields: EditableField[] = []
 
-            return {
-                id: sanitizedName,
-                name: sanitizedName,
-                type: getFieldType(context, sanitizedName, row?.[columnIndex]),
-            } as SheetCollectionFieldInput
+    for (const [columnIndex] of headerRow.entries()) {
+        const sanitizedName = uniqueColumnNames[columnIndex]
+        if (!sanitizedName) continue
+        const initialType: FieldType = getFieldType(context, sanitizedName, row?.[columnIndex])
+
+        fields.push({
+            id: sanitizedName,
+            name: sanitizedName,
+            type: initialType,
         })
-        .filter(isDefined)
+    }
+
+    return fields
 }
 
 const getFieldNameOverrides = (context: PluginContext): Record<string, string> => {
     const result: Record<string, string> = {}
-    if (context.type !== "update") return result
+    if (!isUpdateContext(context)) return result
 
     for (const field of context.collectionFields) {
         result[field.id] = field.name
@@ -144,7 +168,7 @@ const getFieldNameOverrides = (context: PluginContext): Record<string, string> =
     return result
 }
 
-const getPossibleSlugFields = (fieldConfig: SheetCollectionFieldInput[]): SheetCollectionFieldInput[] => {
+const getPossibleSlugFields = (fieldConfig: EditableField[]): EditableField[] => {
     return fieldConfig.filter(field => field.type === "string")
 }
 
@@ -168,11 +192,11 @@ export function MapSheetFieldsPage({
     rows,
 }: Props) {
     const uniqueColumnNames = useMemo(() => generateUniqueNames(headerRow), [headerRow])
-    const [fieldConfig, setFieldConfig] = useState<SheetCollectionFieldInput[]>(() =>
+    const [fieldConfig, setFieldConfig] = useState<EditableField[]>(() =>
         createFieldConfig(headerRow, uniqueColumnNames, pluginContext, rows[0])
     )
-    const [disabledColumns, setDisabledColumns] = useState(
-        () => new Set<string>(pluginContext.type === "update" ? pluginContext.ignoredColumns : [])
+    const [disabledColumns, setDisabledColumns] = useState<Set<string>>(
+        () => new Set<string>(isUpdateContext(pluginContext) ? pluginContext.ignoredColumns : [])
     )
     const slugFields = useMemo(() => getPossibleSlugFields(fieldConfig), [fieldConfig])
     const [slugColumn, setSlugColumn] = useState<string>(() => getInitialSlugColumn(pluginContext, slugFields))
@@ -199,18 +223,16 @@ export function MapSheetFieldsPage({
         }))
     }
 
-    const handleFieldTypeChange = (id: string, type: VirtualFieldType) => {
-        setFieldConfig(current =>
-            current.map(field => {
-                if (field.id === id) {
-                    return {
-                        ...field,
-                        type,
-                    } as SheetCollectionFieldInput
-                }
-                return field
-            })
-        )
+    const handleFieldTypeChange = (id: string, type: FieldType) => {
+        setFieldConfig(current => {
+            const nextFields: EditableField[] = []
+
+            for (const field of current) {
+                nextFields.push(field.id === id ? { ...field, type } : field)
+            }
+
+            return nextFields
+        })
     }
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -218,28 +240,59 @@ export function MapSheetFieldsPage({
 
         if (isPending) return
 
-        const allFields = fieldConfig
-            .filter(field => !disabledColumns.has(field.id))
-            .map(field => {
-                const maybeOverride = fieldNameOverrides[field.id]
-                if (maybeOverride) {
-                    field.name = maybeOverride
-                }
+        const allFields: EditableField[] = []
+        for (const field of fieldConfig) {
+            if (disabledColumns.has(field.id)) continue
 
-                return field
-            })
+            const result: EditableField = { ...field }
+            const maybeOverride = fieldNameOverrides[result.id]
+            if (maybeOverride) {
+                result.name = maybeOverride
+            }
+
+            if (result.type === "enum") {
+                const colIndex = uniqueColumnNames.indexOf(result.id)
+                if (colIndex !== -1) {
+                    const uniqueValues: string[] = []
+                    const seenValues = new Set<string>()
+                    for (const row of rows) {
+                        const rawValue = row[colIndex]
+                        if (!isDefined(rawValue)) continue
+
+                        const normalizedValue = String(rawValue).trim()
+                        if (!normalizedValue || seenValues.has(normalizedValue)) continue
+
+                        seenValues.add(normalizedValue)
+                        uniqueValues.push(normalizedValue)
+                    }
+                    result.cases = uniqueValues.map(value => ({
+                        id: generateHashId(value),
+                        name: value,
+                    }))
+                }
+            }
+
+            allFields.push(result)
+        }
+
+        const colFieldTypes: FieldType[] = []
+        for (const field of fieldConfig) {
+            colFieldTypes.push(field.type)
+        }
 
         await framer.setCloseWarning("Synchronization in progress. Closing will cancel the sync.")
 
-        onSubmit({
-            fields: allFields,
+        const submitOptions: SyncMutationOptions = {
+            fields: allFields as SyncMutationOptions["fields"],
             spreadsheetId,
             sheetTitle,
-            colFieldTypes: fieldConfig.map(field => field.type),
+            colFieldTypes: colFieldTypes as SyncMutationOptions["colFieldTypes"],
             ignoredColumns: Array.from(disabledColumns),
             slugColumn,
             lastSyncedTime: getLastSyncedTime(pluginContext, slugColumn),
-        })
+        }
+
+        onSubmit(submitOptions)
     }
 
     const isAllowedToManage = useIsAllowedTo("ManagedCollection.setFields", ...syncMethods)
@@ -293,7 +346,7 @@ export function MapSheetFieldsPage({
                                     disabled={isDisabled || !isAllowedToManage}
                                     value={field.type}
                                     onChange={e => {
-                                        handleFieldTypeChange(field.id, e.target.value as VirtualFieldType)
+                                        handleFieldTypeChange(field.id, e.target.value as FieldType)
                                     }}
                                     title={isAllowedToManage ? undefined : "Insufficient permissions"}
                                 >

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -33,6 +33,60 @@ function isFieldType(value: string): value is FieldType {
     return fieldTypeOptions.some(option => option.type === value)
 }
 
+function getConfiguredField(
+    context: PluginContext,
+    columnId: string
+): PluginContextUpdate["collectionFields"][number] | undefined {
+    if (!isUpdateContext(context)) return undefined
+
+    return context.collectionFields.find(field => field.id === columnId)
+}
+
+function getEnumCasesForColumn(rows: Row[], colIndex: number): NonNullable<EditableField["cases"]> {
+    const cases: NonNullable<EditableField["cases"]> = []
+    const seenValues = new Set<string>()
+
+    for (const row of rows) {
+        const rawValue = row[colIndex]
+        if (!isDefined(rawValue)) continue
+
+        const normalizedValue = String(rawValue).trim()
+        if (!normalizedValue || seenValues.has(normalizedValue)) continue
+
+        seenValues.add(normalizedValue)
+        cases.push({
+            id: generateHashId(normalizedValue),
+            name: normalizedValue,
+        })
+    }
+
+    return cases
+}
+
+function mergeEnumCases(
+    existingCases: EditableField["cases"],
+    derivedCases: NonNullable<EditableField["cases"]>
+): NonNullable<EditableField["cases"]> {
+    const mergedCases: NonNullable<EditableField["cases"]> = []
+    const seenCaseNames = new Set<string>()
+
+    for (const existingCase of existingCases ?? []) {
+        if (seenCaseNames.has(existingCase.name)) continue
+
+        seenCaseNames.add(existingCase.name)
+        mergedCases.push(existingCase)
+    }
+
+    for (const derivedCase of derivedCases) {
+        if (seenCaseNames.has(derivedCase.name)) continue
+
+        seenCaseNames.add(derivedCase.name)
+        mergedCases.push(derivedCase)
+    }
+
+    return mergedCases
+}
+
 function isUpdateContext(context: PluginContext): context is PluginContextUpdate {
     return context.type === "update"
 }
@@ -110,10 +164,8 @@ const inferFieldType = (cellValue: CellValue): FieldType => {
 
 const getFieldType = (context: PluginContext, columnId: string, cellValue?: CellValue): FieldType => {
     // Determine if the field type is already configured
-    if (isUpdateContext(context)) {
-        const field = context.collectionFields.find(field => field.id === columnId)
-        return field?.type ?? "string"
-    }
+    const configuredField = getConfiguredField(context, columnId)
+    if (configuredField) return configuredField.type
 
     // Otherwise, infer the field type from the cell value
     return cellValue ? inferFieldType(cellValue) : "string"
@@ -130,12 +182,14 @@ const createFieldConfig = (
     for (const [columnIndex] of headerRow.entries()) {
         const sanitizedName = uniqueColumnNames[columnIndex]
         if (!sanitizedName) continue
+        const configuredField = getConfiguredField(context, sanitizedName)
         const initialType: FieldType = getFieldType(context, sanitizedName, row?.[columnIndex])
 
         fields.push({
             id: sanitizedName,
             name: sanitizedName,
             type: initialType,
+            cases: configuredField?.cases,
         })
     }
 
@@ -238,22 +292,18 @@ export function MapSheetFieldsPage({
             if (result.type === "enum") {
                 const colIndex = uniqueColumnNames.indexOf(result.id)
                 if (colIndex !== -1) {
-                    const uniqueValues: string[] = []
-                    const seenValues = new Set<string>()
-                    for (const row of rows) {
-                        const rawValue = row[colIndex]
-                        if (!isDefined(rawValue)) continue
+                    result.cases = mergeEnumCases(result.cases, getEnumCasesForColumn(rows, colIndex))
+                }
 
-                        const normalizedValue = String(rawValue).trim()
-                        if (!normalizedValue || seenValues.has(normalizedValue)) continue
-
-                        seenValues.add(normalizedValue)
-                        uniqueValues.push(normalizedValue)
-                    }
-                    result.cases = uniqueValues.map(value => ({
-                        id: generateHashId(value),
-                        name: value,
-                    }))
+                if (!result.cases || result.cases.length === 0) {
+                    framer.notify(
+                        `"${result.name}" needs at least one non-empty value before it can be imported as an Option field.`,
+                        {
+                            variant: "error",
+                            durationMs: 5000,
+                        }
+                    )
+                    return
                 }
             }
 

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -6,33 +6,14 @@ import { IconChevron } from "../components/Icons"
 import type { CellValue, HeaderRow, PluginContext, PluginContextUpdate, Row, SyncMutationOptions } from "../sheets"
 import { generateHashId, generateUniqueNames, isDefined, syncMethods } from "../utils"
 
-type FieldType =
-    | "string"
-    | "number"
-    | "boolean"
-    | "formattedText"
-    | "enum"
-    | "date"
-    | "dateTime"
-    | "link"
-    | "image"
-    | "color"
-    | "file"
-    | "collectionReference"
-    | "multiCollectionReference"
-    | "array"
+type FieldType = SyncMutationOptions["colFieldTypes"][number]
 
 interface FieldTypeOption {
     type: FieldType
     label: string
 }
 
-interface EditableField {
-    id: string
-    name: string
-    type: FieldType
-    cases?: { id: string; name: string }[]
-}
+type EditableField = SyncMutationOptions["fields"][number]
 
 const fieldTypeOptions: FieldTypeOption[] = [
     { type: "string", label: "Plain Text" },
@@ -47,6 +28,10 @@ const fieldTypeOptions: FieldTypeOption[] = [
     { type: "number", label: "Number" },
     { type: "file", label: "File" },
 ]
+
+function isFieldType(value: string): value is FieldType {
+    return fieldTypeOptions.some(option => option.type === value)
+}
 
 function isUpdateContext(context: PluginContext): context is PluginContextUpdate {
     return context.type === "update"
@@ -240,7 +225,7 @@ export function MapSheetFieldsPage({
 
         if (isPending) return
 
-        const allFields: EditableField[] = []
+        const allFields: SyncMutationOptions["fields"] = []
         for (const field of fieldConfig) {
             if (disabledColumns.has(field.id)) continue
 
@@ -275,7 +260,7 @@ export function MapSheetFieldsPage({
             allFields.push(result)
         }
 
-        const colFieldTypes: FieldType[] = []
+        const colFieldTypes: SyncMutationOptions["colFieldTypes"] = []
         for (const field of fieldConfig) {
             colFieldTypes.push(field.type)
         }
@@ -283,10 +268,10 @@ export function MapSheetFieldsPage({
         await framer.setCloseWarning("Synchronization in progress. Closing will cancel the sync.")
 
         const submitOptions: SyncMutationOptions = {
-            fields: allFields as SyncMutationOptions["fields"],
+            fields: allFields,
             spreadsheetId,
             sheetTitle,
-            colFieldTypes: colFieldTypes as SyncMutationOptions["colFieldTypes"],
+            colFieldTypes,
             ignoredColumns: Array.from(disabledColumns),
             slugColumn,
             lastSyncedTime: getLastSyncedTime(pluginContext, slugColumn),
@@ -346,7 +331,9 @@ export function MapSheetFieldsPage({
                                     disabled={isDisabled || !isAllowedToManage}
                                     value={field.type}
                                     onChange={e => {
-                                        handleFieldTypeChange(field.id, e.target.value as FieldType)
+                                        if (isFieldType(e.target.value)) {
+                                            handleFieldTypeChange(field.id, e.target.value)
+                                        }
                                     }}
                                     title={isAllowedToManage ? undefined : "Insufficient permissions"}
                                 >

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -2,7 +2,7 @@ import cx from "classnames"
 import { framer, useIsAllowedTo } from "framer-plugin"
 import { Fragment, useMemo, useState } from "react"
 import { CheckboxTextfield } from "../components/CheckboxTextField"
-import { getEnumCasesForColumn, mergeEnumCases } from "../enumCases"
+import { getEnumCasesForColumn } from "../enumCases"
 import { IconChevron } from "../components/Icons"
 import type { CellValue, HeaderRow, PluginContext, PluginContextUpdate, Row, SyncMutationOptions } from "../sheets"
 import { generateUniqueNames, syncMethods } from "../utils"
@@ -19,7 +19,6 @@ type EditableField = SyncMutationOptions["fields"][number]
 const fieldTypeOptions: FieldTypeOption[] = [
     { type: "string", label: "Plain Text" },
     { type: "formattedText", label: "Formatted Text" },
-    { type: "enum", label: "Option" },
     { type: "date", label: "Date" },
     { type: "dateTime", label: "Date & Time" },
     { type: "link", label: "Link" },
@@ -27,6 +26,7 @@ const fieldTypeOptions: FieldTypeOption[] = [
     { type: "color", label: "Color" },
     { type: "boolean", label: "Toggle" },
     { type: "number", label: "Number" },
+    { type: "enum", label: "Option" },
     { type: "file", label: "File" },
 ]
 
@@ -248,7 +248,7 @@ export function MapSheetFieldsPage({
             if (result.type === "enum") {
                 const colIndex = uniqueColumnNames.indexOf(result.id)
                 if (colIndex !== -1) {
-                    result.cases = mergeEnumCases(result.cases, getEnumCasesForColumn(rows, colIndex))
+                    result.cases = getEnumCasesForColumn(rows, colIndex)
                 }
 
                 if (!result.cases || result.cases.length === 0) {

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -2,9 +2,10 @@ import cx from "classnames"
 import { framer, useIsAllowedTo } from "framer-plugin"
 import { Fragment, useMemo, useState } from "react"
 import { CheckboxTextfield } from "../components/CheckboxTextField"
+import { getEnumCasesForColumn, mergeEnumCases } from "../enumCases"
 import { IconChevron } from "../components/Icons"
 import type { CellValue, HeaderRow, PluginContext, PluginContextUpdate, Row, SyncMutationOptions } from "../sheets"
-import { generateHashId, generateUniqueNames, isDefined, syncMethods } from "../utils"
+import { generateUniqueNames, syncMethods } from "../utils"
 
 type FieldType = SyncMutationOptions["colFieldTypes"][number]
 
@@ -40,51 +41,6 @@ function getConfiguredField(
     if (!isUpdateContext(context)) return undefined
 
     return context.collectionFields.find(field => field.id === columnId)
-}
-
-function getEnumCasesForColumn(rows: Row[], colIndex: number): NonNullable<EditableField["cases"]> {
-    const cases: NonNullable<EditableField["cases"]> = []
-    const seenValues = new Set<string>()
-
-    for (const row of rows) {
-        const rawValue = row[colIndex]
-        if (!isDefined(rawValue)) continue
-
-        const normalizedValue = String(rawValue).trim()
-        if (!normalizedValue || seenValues.has(normalizedValue)) continue
-
-        seenValues.add(normalizedValue)
-        cases.push({
-            id: generateHashId(normalizedValue),
-            name: normalizedValue,
-        })
-    }
-
-    return cases
-}
-
-function mergeEnumCases(
-    existingCases: EditableField["cases"],
-    derivedCases: NonNullable<EditableField["cases"]>
-): NonNullable<EditableField["cases"]> {
-    const mergedCases: NonNullable<EditableField["cases"]> = []
-    const seenCaseNames = new Set<string>()
-
-    for (const existingCase of existingCases ?? []) {
-        if (seenCaseNames.has(existingCase.name)) continue
-
-        seenCaseNames.add(existingCase.name)
-        mergedCases.push(existingCase)
-    }
-
-    for (const derivedCase of derivedCases) {
-        if (seenCaseNames.has(derivedCase.name)) continue
-
-        seenCaseNames.add(derivedCase.name)
-        mergedCases.push(derivedCase)
-    }
-
-    return mergedCases
 }
 
 function isUpdateContext(context: PluginContext): context is PluginContextUpdate {

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -631,14 +631,14 @@ export async function syncSheet({
             const cases = mergeEnumCases(field.cases, getEnumCasesForColumn(rows, colIndex))
             if (cases.length === 0) {
                 throw new Error(
-                    `Enum field "${field.name}" requires at least one non-empty value before it can be synced.`
+                    `Option field "${field.name}" requires at least one non-empty value before it can be synced.`
                 )
             }
 
             if (!areEnumCasesEqual(field.cases, cases)) {
                 if (!canSetFields) {
                     throw new Error(
-                        "This sheet has enum columns with values that are not configured on the collection, " +
+                        "This sheet has option columns with values that are not configured on the collection, " +
                             "but the plugin does not have permission to update collection fields."
                     )
                 }
@@ -917,7 +917,7 @@ function mapFieldToFramer(field: SheetCollectionFieldInput): ManagedCollectionFi
     }
 
     if (field.type === "enum") {
-        assert(field.cases && field.cases.length > 0, `Enum field "${field.name}" requires at least one case`)
+        assert(field.cases && field.cases.length > 0, `Option field "${field.name}" requires at least one case`)
 
         const enumField: Extract<ManagedCollectionFieldInput, { type: "enum" }> = {
             id: field.id,

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -314,6 +314,48 @@ export interface SyncMutationOptions {
     lastSyncedTime: string | null
 }
 
+function getEnumCasesForColumn(rows: Row[], colIndex: number): EnumCase[] {
+    const cases: EnumCase[] = []
+    const seenValues = new Set<string>()
+
+    for (const row of rows) {
+        const rawValue = row[colIndex]
+        if (!isDefined(rawValue)) continue
+
+        const normalizedValue = String(rawValue).trim()
+        if (!normalizedValue || seenValues.has(normalizedValue)) continue
+
+        seenValues.add(normalizedValue)
+        cases.push({
+            id: generateHashId(normalizedValue),
+            name: normalizedValue,
+        })
+    }
+
+    return cases
+}
+
+function mergeEnumCases(existingCases: EnumCase[] | undefined, derivedCases: EnumCase[]): EnumCase[] {
+    const mergedCases: EnumCase[] = []
+    const seenCaseNames = new Set<string>()
+
+    for (const existingCase of existingCases ?? []) {
+        if (seenCaseNames.has(existingCase.name)) continue
+
+        seenCaseNames.add(existingCase.name)
+        mergedCases.push(existingCase)
+    }
+
+    for (const derivedCase of derivedCases) {
+        if (seenCaseNames.has(derivedCase.name)) continue
+
+        seenCaseNames.add(derivedCase.name)
+        mergedCases.push(derivedCase)
+    }
+
+    return mergedCases
+}
+
 const BASE_DATE_1900 = new Date(Date.UTC(1899, 11, 30))
 const BASE_DATE_1904 = new Date(Date.UTC(1904, 0, 1))
 const MS_PER_DAY = 24 * 60 * 60 * 1000 // hours * minutes * seconds * milliseconds
@@ -625,23 +667,12 @@ export async function syncSheet({
             const colIndex = uniqueHeaderRowNames.indexOf(field.id)
             if (colIndex === -1) return mapFieldToFramer(field)
 
-            const uniqueValues: string[] = []
-            const seenValues = new Set<string>()
-            for (const row of rows) {
-                const rawValue = row[colIndex]
-                if (!isDefined(rawValue)) continue
-
-                const normalizedValue = String(rawValue).trim()
-                if (!normalizedValue || seenValues.has(normalizedValue)) continue
-
-                seenValues.add(normalizedValue)
-                uniqueValues.push(normalizedValue)
+            const cases = mergeEnumCases(field.cases, getEnumCasesForColumn(rows, colIndex))
+            if (cases.length === 0) {
+                throw new Error(
+                    `Enum field "${field.name}" requires at least one non-empty value before it can be synced.`
+                )
             }
-
-            const cases: Extract<ManagedCollectionFieldInput, { type: "enum" }>["cases"] = uniqueValues.map(value => ({
-                id: generateHashId(value),
-                name: value,
-            }))
 
             const enumField: Extract<ManagedCollectionFieldInput, { type: "enum" }> = {
                 id: field.id,
@@ -912,12 +943,16 @@ function mapFieldToFramer(field: SheetCollectionFieldInput): ManagedCollectionFi
     }
 
     if (field.type === "enum") {
-        return {
+        assert(field.cases && field.cases.length > 0, `Enum field "${field.name}" requires at least one case`)
+
+        const enumField: Extract<ManagedCollectionFieldInput, { type: "enum" }> = {
             id: field.id,
             name: field.name,
             type: "enum",
-            cases: field.cases ?? [],
-        } as ManagedCollectionFieldInput
+            cases: field.cases,
+        }
+
+        return enumField
     }
 
     return field as ManagedCollectionFieldInput

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -9,6 +9,7 @@ import {
 import * as v from "valibot"
 import auth from "./auth"
 import { logSyncResult } from "./debug.ts"
+import { areEnumCasesEqual, getEnumCasesForColumn, mergeEnumCases } from "./enumCases"
 import { queryClient } from "./main.tsx"
 import { assert, columnToLetter, generateHashId, generateUniqueNames, isDefined, listFormatter, slugify } from "./utils"
 
@@ -312,48 +313,6 @@ export interface SyncMutationOptions {
     ignoredColumns: string[]
     colFieldTypes: VirtualFieldType[]
     lastSyncedTime: string | null
-}
-
-function getEnumCasesForColumn(rows: Row[], colIndex: number): EnumCase[] {
-    const cases: EnumCase[] = []
-    const seenValues = new Set<string>()
-
-    for (const row of rows) {
-        const rawValue = row[colIndex]
-        if (!isDefined(rawValue)) continue
-
-        const normalizedValue = String(rawValue).trim()
-        if (!normalizedValue || seenValues.has(normalizedValue)) continue
-
-        seenValues.add(normalizedValue)
-        cases.push({
-            id: generateHashId(normalizedValue),
-            name: normalizedValue,
-        })
-    }
-
-    return cases
-}
-
-function mergeEnumCases(existingCases: EnumCase[] | undefined, derivedCases: EnumCase[]): EnumCase[] {
-    const mergedCases: EnumCase[] = []
-    const seenCaseNames = new Set<string>()
-
-    for (const existingCase of existingCases ?? []) {
-        if (seenCaseNames.has(existingCase.name)) continue
-
-        seenCaseNames.add(existingCase.name)
-        mergedCases.push(existingCase)
-    }
-
-    for (const derivedCase of derivedCases) {
-        if (seenCaseNames.has(derivedCase.name)) continue
-
-        seenCaseNames.add(derivedCase.name)
-        mergedCases.push(derivedCase)
-    }
-
-    return mergedCases
 }
 
 const BASE_DATE_1900 = new Date(Date.UTC(1899, 11, 30))
@@ -660,7 +619,9 @@ export async function syncSheet({
     // Update enum field definitions with cases derived from column data so new
     // values that appeared since the last sync are recognised.
     const hasEnumFields = colFieldTypes.includes("enum")
-    if (hasEnumFields && framer.isAllowedTo("ManagedCollection.setFields")) {
+    if (hasEnumFields) {
+        const canSetFields = framer.isAllowedTo("ManagedCollection.setFields")
+        let shouldUpdateFields = false
         const updatedFields = fields.map(field => {
             if (field.type !== "enum") return mapFieldToFramer(field)
 
@@ -674,6 +635,17 @@ export async function syncSheet({
                 )
             }
 
+            if (!areEnumCasesEqual(field.cases, cases)) {
+                if (!canSetFields) {
+                    throw new Error(
+                        "This sheet has enum columns with values that are not configured on the collection, " +
+                            "but the plugin does not have permission to update collection fields."
+                    )
+                }
+
+                shouldUpdateFields = true
+            }
+
             const enumField: Extract<ManagedCollectionFieldInput, { type: "enum" }> = {
                 id: field.id,
                 name: field.name,
@@ -684,7 +656,9 @@ export async function syncSheet({
             return enumField
         })
 
-        await collection.setFields(updatedFields)
+        if (canSetFields && shouldUpdateFields) {
+            await collection.setFields(updatedFields)
+        }
     }
 
     const { collectionItems, status } = processSheet(rows, {

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -616,48 +616,80 @@ export async function syncSheet({
         )
     }
 
-    // Update enum field definitions with cases derived from column data so new
-    // values that appeared since the last sync are recognised.
+    // Enum fields: (1) merge sheet values into field cases before updating items so
+    // new options exist in the schema and existing rows stay valid; (2) after items
+    // match the sheet, set cases to sheet-derived only so unused options are removed.
     const hasEnumFields = colFieldTypes.includes("enum")
+    let canSetFieldsForEnums = false
+    let enumFieldsNeedPruneAfterSync = false
+    let expandedEnumFields: ManagedCollectionFieldInput[] | undefined
+
     if (hasEnumFields) {
-        const canSetFields = framer.isAllowedTo("ManagedCollection.setFields")
-        let shouldUpdateFields = false
-        const updatedFields = fields.map(field => {
+        canSetFieldsForEnums = framer.isAllowedTo("ManagedCollection.setFields")
+
+        expandedEnumFields = fields.map(field => {
             if (field.type !== "enum") return mapFieldToFramer(field)
 
             const colIndex = uniqueHeaderRowNames.indexOf(field.id)
             if (colIndex === -1) return mapFieldToFramer(field)
 
-            const cases = mergeEnumCases(field.cases, getEnumCasesForColumn(rows, colIndex))
-            if (cases.length === 0) {
+            const derivedCases = getEnumCasesForColumn(rows, colIndex)
+            const expandedCases =
+                derivedCases.length > 0
+                    ? mergeEnumCases(field.cases, derivedCases)
+                    : (field.cases ?? [])
+            if (expandedCases.length === 0) {
                 throw new Error(
                     `Option field "${field.name}" requires at least one non-empty value before it can be synced.`
                 )
-            }
-
-            if (!areEnumCasesEqual(field.cases, cases)) {
-                if (!canSetFields) {
-                    throw new Error(
-                        "This sheet has option columns with values that are not configured on the collection, " +
-                            "but the plugin does not have permission to update collection fields."
-                    )
-                }
-
-                shouldUpdateFields = true
             }
 
             const enumField: Extract<ManagedCollectionFieldInput, { type: "enum" }> = {
                 id: field.id,
                 name: field.name,
                 type: "enum",
-                cases,
+                cases: expandedCases,
             }
 
             return enumField
         })
 
-        if (canSetFields && shouldUpdateFields) {
-            await collection.setFields(updatedFields)
+        let shouldExpandEnumFields = false
+        for (let i = 0; i < fields.length; i++) {
+            const field = fields[i]
+            const mapped = expandedEnumFields[i]
+            if (field === undefined || mapped === undefined) continue
+            if (field.type === "enum" && mapped.type === "enum" && !areEnumCasesEqual(field.cases, mapped.cases)) {
+                shouldExpandEnumFields = true
+                break
+            }
+        }
+
+        for (let i = 0; i < fields.length; i++) {
+            const field = fields[i]
+            const mapped = expandedEnumFields[i]
+            if (field === undefined || mapped === undefined) continue
+            if (field.type !== "enum" || mapped.type !== "enum") continue
+
+            const colIndex = uniqueHeaderRowNames.indexOf(field.id)
+            if (colIndex === -1) continue
+
+            const derivedCases = getEnumCasesForColumn(rows, colIndex)
+            if (derivedCases.length === 0) continue
+            if (!areEnumCasesEqual(mapped.cases, derivedCases)) {
+                enumFieldsNeedPruneAfterSync = true
+            }
+        }
+
+        if (shouldExpandEnumFields && !canSetFieldsForEnums) {
+            throw new Error(
+                "This sheet has option columns with values that are not configured on the collection, " +
+                    "but the plugin does not have permission to update collection fields."
+            )
+        }
+
+        if (canSetFieldsForEnums && shouldExpandEnumFields) {
+            await collection.setFields(expandedEnumFields)
         }
     }
 
@@ -681,6 +713,42 @@ export async function syncSheet({
     if (collectionItems.length > 0) {
         await collection.addItems(collectionItems)
         await collection.setItemOrder(collectionItems.map(collectionItem => collectionItem.id))
+    }
+
+    if (hasEnumFields && enumFieldsNeedPruneAfterSync) {
+        if (!canSetFieldsForEnums) {
+            throw new Error(
+                "This sheet no longer uses some option values that are still on the collection, " +
+                    "but the plugin does not have permission to update collection fields."
+            )
+        }
+
+        assert(expandedEnumFields !== undefined, "Expected expanded enum field list when pruning option fields")
+
+        const prunedFields = fields.map((field, fieldIndex) => {
+            if (field.type !== "enum") return mapFieldToFramer(field)
+
+            const colIndex = uniqueHeaderRowNames.indexOf(field.id)
+            if (colIndex === -1) return mapFieldToFramer(field)
+
+            const derivedCases = getEnumCasesForColumn(rows, colIndex)
+            const expandedForField = expandedEnumFields[fieldIndex]
+            if (expandedForField === undefined) return mapFieldToFramer(field)
+            if (derivedCases.length === 0) {
+                return expandedForField.type === "enum" ? expandedForField : mapFieldToFramer(field)
+            }
+
+            const enumField: Extract<ManagedCollectionFieldInput, { type: "enum" }> = {
+                id: field.id,
+                name: field.name,
+                type: "enum",
+                cases: derivedCases,
+            }
+
+            return enumField
+        })
+
+        await collection.setFields(prunedFields)
     }
 
     const spreadsheetInfo = await fetchSpreadsheetInfo(spreadsheetId)

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -227,8 +227,14 @@ function fetchSheetWithClient(spreadsheetId: string, sheetTitle: string, range?:
 
 export type CollectionFieldType = ManagedCollectionFieldInput["type"]
 export type VirtualFieldType = CollectionFieldType | "dateTime"
+export interface EnumCase {
+    id: string
+    name: string
+}
+
 export type SheetCollectionFieldInput = Omit<ManagedCollectionFieldInput, "type"> & {
     type: VirtualFieldType
+    cases?: EnumCase[]
 }
 
 export interface PluginContextNew {
@@ -380,6 +386,12 @@ function getFieldDataEntryInput(type: VirtualFieldType, cellValue: CellValue): F
 
             return null
         }
+        case "enum": {
+            if (!isDefined(cellValue)) return null
+            const enumValue = String(cellValue).trim()
+            if (!enumValue) return null
+            return { type: "enum", value: generateHashId(enumValue) }
+        }
         case "image":
         case "link":
         case "file":
@@ -460,6 +472,9 @@ function processSheetRow({
                         type: "date",
                     }
                     break
+                case "enum":
+                    // Empty enum cells are valid (no selection) — skip silently
+                    continue
             }
         }
 
@@ -598,6 +613,40 @@ export async function syncSheet({
         throw new Error(
             `Empty header cell${pluralSuffix} found in column${pluralSuffix} ${columnList}. All header row cells must contain values.`
         )
+    }
+
+    // Update enum field definitions with cases derived from column data so new
+    // values that appeared since the last sync are recognised.
+    const hasEnumFields = colFieldTypes.includes("enum")
+    if (hasEnumFields && framer.isAllowedTo("ManagedCollection.setFields")) {
+        const updatedFields = fields.map(field => {
+            if (field.type !== "enum") return mapFieldToFramer(field)
+
+            const colIndex = uniqueHeaderRowNames.indexOf(field.id)
+            if (colIndex === -1) return mapFieldToFramer(field)
+
+            const uniqueValues = [
+                ...new Set(
+                    rows
+                        .map(row => row[colIndex])
+                        .filter(isDefined)
+                        .map(v => String(v).trim())
+                        .filter(Boolean)
+                ),
+            ]
+
+            return {
+                id: field.id,
+                name: field.name,
+                type: "enum" as const,
+                cases: uniqueValues.map(value => ({
+                    id: generateHashId(value),
+                    name: value,
+                })),
+            } as ManagedCollectionFieldInput
+        })
+
+        await collection.setFields(updatedFields)
     }
 
     const { collectionItems, status } = processSheet(rows, {
@@ -853,6 +902,15 @@ function mapFieldToFramer(field: SheetCollectionFieldInput): ManagedCollectionFi
             type: "file",
             allowedFileTypes: [],
         }
+    }
+
+    if (field.type === "enum") {
+        return {
+            id: field.id,
+            name: field.name,
+            type: "enum",
+            cases: field.cases ?? [],
+        } as ManagedCollectionFieldInput
     }
 
     return field as ManagedCollectionFieldInput

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -625,25 +625,32 @@ export async function syncSheet({
             const colIndex = uniqueHeaderRowNames.indexOf(field.id)
             if (colIndex === -1) return mapFieldToFramer(field)
 
-            const uniqueValues = [
-                ...new Set(
-                    rows
-                        .map(row => row[colIndex])
-                        .filter(isDefined)
-                        .map(v => String(v).trim())
-                        .filter(Boolean)
-                ),
-            ]
+            const uniqueValues: string[] = []
+            const seenValues = new Set<string>()
+            for (const row of rows) {
+                const rawValue = row[colIndex]
+                if (!isDefined(rawValue)) continue
 
-            return {
+                const normalizedValue = String(rawValue).trim()
+                if (!normalizedValue || seenValues.has(normalizedValue)) continue
+
+                seenValues.add(normalizedValue)
+                uniqueValues.push(normalizedValue)
+            }
+
+            const cases: Extract<ManagedCollectionFieldInput, { type: "enum" }>["cases"] = uniqueValues.map(value => ({
+                id: generateHashId(value),
+                name: value,
+            }))
+
+            const enumField: Extract<ManagedCollectionFieldInput, { type: "enum" }> = {
                 id: field.id,
                 name: field.name,
-                type: "enum" as const,
-                cases: uniqueValues.map(value => ({
-                    id: generateHashId(value),
-                    name: value,
-                })),
-            } as ManagedCollectionFieldInput
+                type: "enum",
+                cases,
+            }
+
+            return enumField
         })
 
         await collection.setFields(updatedFields)


### PR DESCRIPTION
## Summary
- add enum as a supported Google Sheets field type and derive enum cases from sheet values during field mapping
- refresh enum field definitions during sync so newly introduced values are recognized by the collection
- tighten the field-mapping page types to avoid unsafe field mutations and fix local type errors

## QA
- [ ] Import a sheet column as an enum field and confirm the generated cases match the unique non-empty cell values
- [ ] Re-sync after adding a new enum value in Google Sheets and confirm the collection field cases are updated before item sync
- [ ] Verify existing non-enum field imports still behave the same