### PR TITLE
Notion: always sync formula and relation properties

### DIFF
--- a/plugins/notion/src/api.ts
+++ b/plugins/notion/src/api.ts
@@ -85,6 +85,12 @@ export const supportedCMSTypeByNotionPropertyType = {
     formula: ["string", "number", "boolean", "date", "dateTime", "link", "color"],
 } satisfies Partial<Record<NotionProperty["type"], readonly VirtualFieldType[]>>
 
+/**
+ * These Notion property types are always re-synced even when the page's `last_edited_time` is unchanged.
+ * Formula results and relation values can change without the last edited time being updated in Notion.
+ */
+export const alwaysSyncedPropertyTypes = ["formula", "relation"]
+
 // Naive implementation to be authenticated, a token could be expired.
 // For simplicity we just close the plugin and clear storage in that case.
 export function isAuthenticated() {

--- a/plugins/notion/src/data.ts
+++ b/plugins/notion/src/data.ts
@@ -233,8 +233,13 @@ export async function syncCollection(
 
                 // Skip field value if the item has not changed and the field type has not changed.
                 // Always synced property types are never skipped.
-                if (isUnchanged && !updatedFieldIds.has(field.id) && !alwaysSyncedPropertyTypes.includes(property.type))
+                if (
+                    isUnchanged &&
+                    !updatedFieldIds.has(field.id) &&
+                    !alwaysSyncedPropertyTypes.includes(property.type)
+                ) {
                     continue
+                }
 
                 const fieldEntry = getFieldDataEntryForProperty(property, field)
                 if (fieldEntry) {

--- a/plugins/notion/src/data.ts
+++ b/plugins/notion/src/data.ts
@@ -4,12 +4,13 @@ import {
     type FieldDataEntryInput,
     type FieldDataInput,
     framer,
-    ManagedCollection,
+    type ManagedCollection,
     type ManagedCollectionFieldInput,
 } from "framer-plugin"
 import pLimit from "p-limit"
 import * as v from "valibot"
 import {
+    alwaysSyncedPropertyTypes,
     assertFieldTypeMatchesPropertyType,
     type FieldInfo,
     getDatabase,
@@ -230,8 +231,10 @@ export async function syncCollection(
                 const field = fieldsById.get(property.id)
                 if (!field) continue
 
-                // Skip field value if the item has not changed and the field type has not changed
-                if (isUnchanged && !updatedFieldIds.has(field.id)) continue
+                // Skip field value if the item has not changed and the field type has not changed.
+                // Always synced property types are never skipped.
+                if (isUnchanged && !updatedFieldIds.has(field.id) && !alwaysSyncedPropertyTypes.includes(property.type))
+                    continue
 
                 const fieldEntry = getFieldDataEntryForProperty(property, field)
                 if (fieldEntry) {


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request makes the Notion plugin always sync formula and relation properties.

Fixes # 2 here: https://framer-team.slack.com/archives/C06FEPVRM52/p1775558816166349

### Changelog

- Fixed formula and relation values not always being updated when syncing.

### Testing

- [x] Sync a Notion database with a formula and relation field

Test database: https://www.notion.so/framer/224adf6e8c9680eca17fda0e00267005?v=224adf6e8c9680899fb5000c4fa462a1