### PR TITLE
Notion: import up to 100 relation values

### DIFF
--- a/plugins/notion/src/api.ts
+++ b/plugins/notion/src/api.ts
@@ -2,7 +2,6 @@ import { Client, collectPaginatedAPI, isFullBlock, isFullDatabase, isFullPage } 
 import type {
     BlockObjectResponse,
     GetDatabaseResponse,
-    GetPagePropertyResponse,
     PageObjectResponse,
     RichTextItemResponse,
 } from "@notionhq/client/build/src/api-endpoints"
@@ -421,7 +420,7 @@ export async function fetchRelationIdsForPageProperty(pageId: string, propertyId
     })
 
     if (response.object === "list") {
-        return response.results.flatMap(item => (item.type === "relation" ? [item.relation.id] : []))
+        return response.results.map(item => (item.type === "relation" ? item.relation.id : "")).filter(id => id !== "")
     }
     if (response.type === "relation") {
         return [response.relation.id]

--- a/plugins/notion/src/api.ts
+++ b/plugins/notion/src/api.ts
@@ -2,6 +2,7 @@ import { Client, collectPaginatedAPI, isFullBlock, isFullDatabase, isFullPage } 
 import type {
     BlockObjectResponse,
     GetDatabaseResponse,
+    GetPagePropertyResponse,
     PageObjectResponse,
     RichTextItemResponse,
 } from "@notionhq/client/build/src/api-endpoints"
@@ -403,6 +404,29 @@ export async function getPageBlocksAsRichText(pageId: string) {
     assert(blocks.every(isFullBlock), "Response is not a full block")
 
     return blocksToHtml(blocks)
+}
+
+const RELATION_PROPERTY_PAGE_SIZE = 100
+
+/**
+ * Loads up to {@link RELATION_PROPERTY_PAGE_SIZE} related page ids when the relation is truncated on
+ * retrieve-page / query (has_more). Does not paginate past the first page.
+ */
+export async function fetchRelationIdsForPageProperty(pageId: string, propertyId: string): Promise<string[]> {
+    const notion = getNotionClient()
+    const response = await notion.pages.properties.retrieve({
+        page_id: pageId,
+        property_id: propertyId,
+        page_size: RELATION_PROPERTY_PAGE_SIZE,
+    })
+
+    if (response.object === "list") {
+        return response.results.flatMap(item => (item.type === "relation" ? [item.relation.id] : []))
+    }
+    if (response.type === "relation") {
+        return [response.relation.id]
+    }
+    return []
 }
 
 export async function getDatabaseItems(

--- a/plugins/notion/src/data.ts
+++ b/plugins/notion/src/data.ts
@@ -13,6 +13,7 @@ import {
     alwaysSyncedPropertyTypes,
     assertFieldTypeMatchesPropertyType,
     type FieldInfo,
+    fetchRelationIdsForPageProperty,
     getDatabase,
     getDatabaseFieldsInfo,
     getDatabaseItems,
@@ -241,7 +242,7 @@ export async function syncCollection(
                     continue
                 }
 
-                const fieldEntry = getFieldDataEntryForProperty(property, field)
+                const fieldEntry = await getFieldDataEntryForProperty(property, field, item.id)
                 if (fieldEntry) {
                     fieldData[field.id] = fieldEntry
                 } else {
@@ -624,10 +625,11 @@ export function fieldsInfoToCollectionFields(
     return fields
 }
 
-export function getFieldDataEntryForProperty(
+async function getFieldDataEntryForProperty(
     property: PageObjectResponse["properties"][string],
-    field: ManagedCollectionFieldInput
-): FieldDataEntryInput | null {
+    field: ManagedCollectionFieldInput,
+    itemId: string
+): Promise<FieldDataEntryInput | null> {
     switch (property.type) {
         case "checkbox": {
             return { type: "boolean", value: property.checkbox }
@@ -691,7 +693,14 @@ export function getFieldDataEntryForProperty(
         }
         case "relation": {
             if (field.type === "multiCollectionReference") {
-                return { type: "multiCollectionReference", value: property.relation.map(({ id }) => id) }
+                let relationItemIds: string[] = []
+                if ("has_more" in property && property.has_more) {
+                    relationItemIds = await fetchRelationIdsForPageProperty(itemId, property.id)
+                } else {
+                    relationItemIds = property.relation.map(({ id }) => id)
+                }
+
+                return { type: "multiCollectionReference", value: relationItemIds }
             } else if (field.type === "collectionReference") {
                 return { type: "collectionReference", value: property.relation[0]?.id ?? null }
             }


### PR DESCRIPTION
### Description

This PR makes the Notion plugin fetch up to 100 multi-reference values for relation properties instead of 25 items.

Slack thread: https://framer-team.slack.com/archives/C06FEPVRM52/p1775751610941059?thread_ts=1775558816.166349&cid=C06FEPVRM52

### Changelog

- Relation field multi-reference limit has been increased from 25 items to 100 items.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Import a relation field with more than 25 values.

Testing databases: "Formula and Rollup Test" and "Images" databases at https://www.notion.so/framer/Notion-Plugin-Test-Database-1efadf6e8c9680b38910d2d0575513a0?source=copy_link