### PR TITLE
Fix spinner alignment in Airtable

### DIFF
--- a/plugins/airtable/package.json
+++ b/plugins/airtable/package.json
@@ -14,6 +14,7 @@
         "check-vitest": "vitest run"
     },
     "dependencies": {
+        "classnames": "^2.5.1",
         "framer-plugin": "^3.10.3",
         "marked": "^17.0.1",
         "react": "^18.3.1",

--- a/plugins/airtable/src/App.css
+++ b/plugins/airtable/src/App.css
@@ -193,6 +193,10 @@ select:not(:disabled) {
     display: inline-block;
 }
 
+.import-button.syncing {
+    display: flex;
+}
+
 /* Login */
 
 .login-steps {

--- a/plugins/airtable/src/FieldMapping.tsx
+++ b/plugins/airtable/src/FieldMapping.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames"
 import type { ManagedCollection, ManagedCollectionField, ManagedCollectionFieldInput } from "framer-plugin"
 import { FramerPluginClosedError, framer, useIsAllowedTo } from "framer-plugin"
 import { memo, useEffect, useMemo, useState } from "react"
@@ -401,7 +402,7 @@ export function FieldMapping({ collection, dataSource, initialSlugFieldId }: Fie
             <footer>
                 <hr className="sticky-top" />
                 <button
-                    className="import-button"
+                    className={cx("import-button", isSyncing && "syncing")}
                     type="submit"
                     disabled={isSyncing || !isAllowedToManage}
                     tabIndex={0}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3834,6 +3834,7 @@ __metadata:
   dependencies:
     "@types/react": "npm:^18.3.24"
     "@types/react-dom": "npm:^18.3.7"
+    classnames: "npm:^2.5.1"
     framer-plugin: "npm:^3.10.3"
     happy-dom: "npm:^20.8.9"
     marked: "npm:^17.0.1"


### PR DESCRIPTION
### Description

https://github.com/framer/plugins/pull/582 introduced a bug where the loading spinner is left aligned instead of centered in the import button. I already fixed it in the Google Sheets plugin and this PR fixes it in the Airtable plugin.

### Changelog

- Fixed loading spinner alignment.

### Testing

- [ ] Sync an Airtable base and observe the loading spinner position