### PR TITLE
Truncate button text in Notion and Airtable

### DIFF
--- a/plugins/airtable/src/App.css
+++ b/plugins/airtable/src/App.css
@@ -130,6 +130,11 @@ select:not(:disabled) {
     gap: 8px;
 }
 
+.mapping .source-field span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .mapping .source-field[aria-disabled="true"] {
     opacity: 0.5;
 }

--- a/plugins/airtable/src/FieldMapping.tsx
+++ b/plugins/airtable/src/FieldMapping.tsx
@@ -8,7 +8,7 @@ import { isCollectionReference } from "./utils"
 
 function ChevronIcon() {
     return (
-        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="16" aria-label="Chevron">
+        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="16" aria-hidden="true">
             <path
                 d="M 3 11 L 6 8 L 3 5"
                 fill="transparent"

--- a/plugins/airtable/src/FieldMapping.tsx
+++ b/plugins/airtable/src/FieldMapping.tsx
@@ -8,8 +8,7 @@ import { isCollectionReference } from "./utils"
 
 function ChevronIcon() {
     return (
-        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="16">
-            <title>Chevron</title>
+        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="16" aria-label="Chevron">
             <path
                 d="M 3 11 L 6 8 L 3 5"
                 fill="transparent"
@@ -75,6 +74,7 @@ const FieldMappingRow = memo(
                     onClick={disabled ? undefined : () => onToggleIgnored?.(field.id)}
                     tabIndex={0}
                     disabled={disabled || unsupported || missingCollection}
+                    title={originalFieldName ?? field.id}
                 >
                     <input type="checkbox" checked={!isIgnored} tabIndex={-1} readOnly disabled={disabled} />
                     <span>{originalFieldName ?? field.id}</span>

--- a/plugins/notion/src/App.css
+++ b/plugins/notion/src/App.css
@@ -166,6 +166,11 @@ p a {
     gap: 8px;
 }
 
+.mapping .source-field span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .mapping .source-field.unsupported {
     pointer-events: none;
 }

--- a/plugins/notion/src/FieldMapping.tsx
+++ b/plugins/notion/src/FieldMapping.tsx
@@ -89,6 +89,7 @@ function FieldMappingRow({
                 width="8"
                 height="8"
                 fill="none"
+                aria-hidden="true"
                 style={{ opacity: disabled ? 0.5 : 1 }}
             >
                 <path

--- a/plugins/notion/src/FieldMapping.tsx
+++ b/plugins/notion/src/FieldMapping.tsx
@@ -79,6 +79,7 @@ function FieldMappingRow({
                     onToggleIgnored(id)
                 }}
                 tabIndex={0}
+                title={originalName}
             >
                 <input type="checkbox" checked={!disabled} tabIndex={-1} readOnly />
                 <span>{originalName}</span>


### PR DESCRIPTION
### Description

This pull request adds text truncation to field name buttons in Notion and Airtable plugins, and adds titles to the buttons for tooltips. https://github.com/framer/plugins/pull/605 did this for Google Sheets.

| Before | After |
| --- | --- |
| <img width="452" height="497" alt="image" src="https://github.com/user-attachments/assets/5bb0c5e8-b3a3-4ce5-b350-59cf1bec58e6" /> | <img width="451" height="503" alt="image" src="https://github.com/user-attachments/assets/04bb4ef3-21e5-4de3-8b19-e725ccfc90a2" /> |

### Changelog

- Improved text truncation on field name buttons.

### Testing

- [ ] Long column names are truncated with ellipsis