### PR TITLE
CSV Import: move CMS icon into dropdown

### DIFF
--- a/plugins/csv-import/src/App.css
+++ b/plugins/csv-import/src/App.css
@@ -164,8 +164,12 @@ body {
     box-shadow: inset 0 0 0 1px currentColor;
 }
 
+select.collection-select {
+    padding-bottom: 0;
+}
+
 input.collection-select {
-    padding: 0px 16px 1px 33px;
+    padding-left: 33px;
 }
 
 .error-message {

--- a/plugins/csv-import/src/App.css
+++ b/plugins/csv-import/src/App.css
@@ -126,6 +126,8 @@ body {
     align-items: center;
     gap: 10px;
     width: 100%;
+    position: relative;
+    color: var(--framer-color-text);
 }
 
 .collection-icon-container {
@@ -134,7 +136,9 @@ body {
     justify-content: center;
     width: 20px;
     height: 20px;
-    opacity: 0.5;
+    position: absolute;
+    left: 8px;
+    top: 5px;
 }
 
 .collection-creation-container {
@@ -147,22 +151,25 @@ body {
 .collection-select {
     flex: 1;
     min-width: 0;
-    height: 28px;
+    padding-left: 33px;
 }
 
-.collection-select.error {
+.collection-selector.error {
     color: #f36;
-    background-color: color-mix(in srgb, #f36 10%, transparent);
-    box-shadow: inset 0 0 0 1px #f36;
+}
+
+.collection-selector.error .collection-select {
+    color: inherit;
+    background-color: color-mix(in srgb, currentColor 10%, transparent);
+    box-shadow: inset 0 0 0 1px currentColor;
 }
 
 input.collection-select {
-    padding: 0px 16px 1px 8px;
+    padding: 0px 16px 1px 33px;
 }
 
 .error-message {
     color: #f36;
-    padding-left: 30px;
 }
 
 /* Manage conflicts screen */

--- a/plugins/csv-import/src/components/CollectionIcon.tsx
+++ b/plugins/csv-import/src/components/CollectionIcon.tsx
@@ -1,6 +1,4 @@
-import type { SVGProps } from "react"
-
-export function CollectionIcon(props: SVGProps<SVGSVGElement>) {
+export function CollectionIcon() {
     return (
         <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -10,7 +8,6 @@ export function CollectionIcon(props: SVGProps<SVGSVGElement>) {
             fill="none"
             role="presentation"
             aria-hidden="true"
-            {...props}
         >
             <path
                 d="M 6 0.5 C 8.761 0.5 11 1.619 11 3 C 11 4.381 8.761 5.5 6 5.5 C 3.239 5.5 1 4.381 1 3 C 1 1.619 3.239 0.5 6 0.5 Z"

--- a/plugins/csv-import/src/components/CollectionSelector.tsx
+++ b/plugins/csv-import/src/components/CollectionSelector.tsx
@@ -124,7 +124,7 @@ export function CollectionSelector({ forceCreate, collection, onCollectionChange
     if (isCreatingNew) {
         return (
             <div className="collection-creation-container">
-                <div className="collection-selector">
+                <div className={creationError ? "collection-selector error" : "collection-selector"}>
                     <div className="collection-icon-container">
                         <CollectionIcon />
                     </div>
@@ -132,7 +132,7 @@ export function CollectionSelector({ forceCreate, collection, onCollectionChange
                     <input
                         ref={inputRef}
                         type="text"
-                        className={creationError ? "collection-select error" : "collection-select"}
+                        className="collection-select"
                         value={newCollectionName}
                         onChange={handleCollectionNameChange}
                         onKeyDown={handleKeyDown}


### PR DESCRIPTION
### Description

This pull request moves the collection icon into the dropdown in the CSV Import plugin.

| Before | After |
| --- | --- |
| <img width="284" height="143" alt="CSV Import (Development)" src="https://github.com/user-attachments/assets/e15b9522-f6e2-40ef-9cd6-5264ae09a767" /> | <img width="284" height="143" alt="CSV Import (Development)" src="https://github.com/user-attachments/assets/c4604e92-6bfe-4490-a16a-2eb5c237ad5a" /> |
| <img width="284" height="143" alt="CSV Import (Development)" src="https://github.com/user-attachments/assets/2457f154-c318-47fb-b98a-7b4a5d99ea94" /> | <img width="284" height="143" alt="CSV Import (Development)" src="https://github.com/user-attachments/assets/91e49e0b-70b3-4d3f-9019-22edbc934b31" /> |

The idea is to make it consistent with other dropdowns and inputs that have an icon to the left of them in Framer, such as:

CMS fields tab:
<img width="243" height="45" alt="image" src="https://github.com/user-attachments/assets/2397db76-ceed-48b1-8b75-d6e845b3b30b" />

Pages dropdown in layers tab:
<img width="239" height="45" alt="image" src="https://github.com/user-attachments/assets/7b317e38-6a38-4709-a0b0-12bf9fa114c8" />

### Changelog

- Updated collection dropdown design.

### Testing

- [x] Open CSV Import plugin
- [x] Click the button to create a new collection, and enter the name of an existing collection to see the error state.