### PR TITLE
Text Search prerelease styles

### DIFF
--- a/plugins/global-search/src/components/GroupHeader.tsx
+++ b/plugins/global-search/src/components/GroupHeader.tsx
@@ -5,7 +5,7 @@ import type { PreparedGroup } from "../utils/filter/group-results"
 import type { RootNodeType } from "../utils/indexer/types"
 import { headerId } from "../utils/selection/constants"
 import { useSelection } from "../utils/selection/useSelection"
-import { IconArrowRight } from "./ui/IconArrowRight"
+import { IconArrowDown } from "./ui/IconArrowDown"
 import { IconCode } from "./ui/IconCode"
 import { IconCollection } from "./ui/IconCollection"
 import { IconComponent } from "./ui/IconComponent"
@@ -52,11 +52,11 @@ export const GroupHeader = memo(
                         aria-hidden={index === 0}
                     />
                     <div className="h-[calc(100%-10px)] flex flex-row gap-2 rounded-lg justify-start items-center select-none overflow-hidden ps-2 group-focus-visible:bg-option-light dark:group-focus-visible:bg-option-dark group-focus-visible:text-primary-light dark:group-focus-visible:text-primary-dark">
-                        <div className="flex-shrink-0 flex gap-2 justify-start items-center">
-                            <IconArrowRight
+                        <div className="shrink-0 flex gap-2 justify-start items-center">
+                            <IconArrowDown
                                 className={cn(
-                                    "text-tertiary-light dark:text-secondary-dark transition-transform duration-200 ease-in-out",
-                                    isExpanded && "rotate-90"
+                                    "text-tertiary-light dark:text-secondary-dark",
+                                    !isExpanded && "-rotate-90"
                                 )}
                                 aria-hidden="true"
                             />

--- a/plugins/global-search/src/components/ui/IconArrowDown.tsx
+++ b/plugins/global-search/src/components/ui/IconArrowDown.tsx
@@ -1,12 +1,12 @@
-import type { HTMLAttributes } from "react"
+import type { SVGProps } from "react"
 
-export function IconCode(props: HTMLAttributes<SVGSVGElement>) {
+export function IconArrowDown(props: SVGProps<SVGSVGElement>) {
     return (
         <svg
             xmlns="http://www.w3.org/2000/svg"
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
+            width="6"
+            height="6"
+            viewBox="0 0 6 6"
             fill="none"
             role="presentation"
             aria-hidden="true"
@@ -17,8 +17,8 @@ export function IconCode(props: HTMLAttributes<SVGSVGElement>) {
                 stroke="currentColor"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                stroke-width="1.5"
-                d="M3.5 2.75 1.311 4.939a1.5 1.5 0 0 0 0 2.122L3.5 9.25M8.5 2.75l2.189 2.189a1.5 1.5 0 0 1 0 2.122L8.5 9.25"
+                strokeWidth="1.25"
+                d="M 0.86 2.1 L 2.647 3.891 C 2.842 4.087 3.158 4.087 3.354 3.892 L 5.15 2.1"
             />
         </svg>
     )

--- a/plugins/global-search/src/components/ui/IconArrowRight.tsx
+++ b/plugins/global-search/src/components/ui/IconArrowRight.tsx
@@ -1,9 +1,0 @@
-import type { SVGProps } from "react"
-
-export function IconArrowRight(props: SVGProps<SVGSVGElement>) {
-    return (
-        <svg xmlns="http://www.w3.org/2000/svg" width={5} height={6} {...props}>
-            <path fill="currentColor" d="M1.5 1A.3.3 0 001 1v4c0 .2.3.4.5.2l2.2-1.9c.2 0 .2-.3 0-.4z" />
-        </svg>
-    )
-}

--- a/plugins/global-search/src/components/ui/IconCollection.tsx
+++ b/plugins/global-search/src/components/ui/IconCollection.tsx
@@ -1,7 +1,33 @@
-import type { SVGProps } from "react"
+import { type SVGProps, useMemo } from "react"
 
 export function IconCollection(props: SVGProps<SVGSVGElement>) {
-    return (
+    const isPrerelease = useMemo(() => document.body.getAttribute("data-framer-styles") === "prerelease", [])
+
+    return isPrerelease ? (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            role="presentation"
+            aria-hidden="true"
+            {...props}
+        >
+            <path
+                fill="currentColor"
+                fillOpacity="0.2"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                d="M1.5 8.75v-5.5C1.5 1.869 3.515.75 6 .75s4.5 1.119 4.5 2.5v5.5m0 0c0 1.381-2.015 2.5-4.5 2.5s-4.5-1.119-4.5-2.5"
+            />
+            <path
+                fill="none"
+                stroke="currentColor"
+                d="M10.25 3.25c0 1.105-1.903 2-4.25 2s-4.25-.895-4.25-2M10.25 6c0 1.105-1.903 2-4.25 2s-4.25-.895-4.25-2"
+            />
+        </svg>
+    ) : (
         <svg
             xmlns="http://www.w3.org/2000/svg"
             width={12}

--- a/plugins/global-search/src/components/ui/IconComponent.tsx
+++ b/plugins/global-search/src/components/ui/IconComponent.tsx
@@ -1,7 +1,29 @@
-import type { SVGProps } from "react"
+import { type SVGProps, useMemo } from "react"
 
 export function IconComponent(props: SVGProps<SVGSVGElement>) {
-    return (
+    const isPrerelease = useMemo(() => document.body.getAttribute("data-framer-styles") === "prerelease", [])
+
+    return isPrerelease ? (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            aria-hidden="true"
+            role="presentation"
+            {...props}
+        >
+            <path
+                fill="currentColor"
+                fillOpacity="0.2"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                d="M4.586 1.354a2 2 0 0 1 2.828 0l3.232 3.232a2 2 0 0 1 0 2.828l-3.232 3.232a2 2 0 0 1-2.828 0L1.354 7.414a2 2 0 0 1 0-2.828Z"
+            />
+            <path fill="none" stroke="currentColor" d="m3 3 6 6M9 3 3 9" />
+        </svg>
+    ) : (
         <svg xmlns="http://www.w3.org/2000/svg" width={11} height={11} fill="none" {...props}>
             <path
                 fill="currentColor"

--- a/plugins/global-search/src/components/ui/IconSearch.tsx
+++ b/plugins/global-search/src/components/ui/IconSearch.tsx
@@ -2,10 +2,10 @@ import type { SVGProps } from "react"
 
 export function IconSearch(props: SVGProps<SVGSVGElement>) {
     return (
-        <svg xmlns="http://www.w3.org/2000/svg" width={11.4} height={11.1} fill="none" overflow="visible" {...props}>
+        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12" {...props}>
             <path
+                d="M5.299.5a5 5 0 0 1 4.416 7.345.75.75 0 0 0 .127.887l1.621 1.622a.749.749 0 1 1-1.06 1.06L8.851 9.862a.75.75 0 0 0-.925-.107A5.001 5.001 0 1 1 5.299.5m-3.5 5a3.5 3.5 0 1 0 7 0 3.5 3.5 0 0 0-7 0"
                 fill="currentColor"
-                d="M5 0a5 5 0 014.1 7.8l2 2a.8.8 0 01-1 1.1l-2-2A5 5 0 115 0zM1.5 5a3.5 3.5 0 107 0 3.5 3.5 0 00-7 0z"
             />
         </svg>
     )

--- a/plugins/global-search/src/components/ui/IconWebPage.tsx
+++ b/plugins/global-search/src/components/ui/IconWebPage.tsx
@@ -1,7 +1,34 @@
-import type { SVGProps } from "react"
+import { type SVGProps, useMemo } from "react"
 
 export function IconWebPage(props: SVGProps<SVGSVGElement>) {
-    return (
+    const isPrerelease = useMemo(() => document.body.getAttribute("data-framer-styles") === "prerelease", [])
+
+    return isPrerelease ? (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            role="presentation"
+            aria-hidden="true"
+            {...props}
+        >
+            <path
+                d="M1.75 2.75a2 2 0 0 1 2-2h1a1 1 0 0 1 1 1v2.5a1 1 0 0 0 1 1h2.5a1 1 0 0 1 1 1v3a2 2 0 0 1-2 2h-4.5a2 2 0 0 1-2-2Z"
+                fill="currentColor"
+                fillOpacity="0.2"
+                stroke="currentColor"
+                strokeWidth="1.5"
+            />
+            <path
+                d="M4.5.75h1.172a2 2 0 0 1 1.414.586l2.578 2.578a2 2 0 0 1 .586 1.414V6.5"
+                fill="transparent"
+                stroke="currentColor"
+                strokeWidth="1.5"
+            />
+        </svg>
+    ) : (
         <svg xmlns="http://www.w3.org/2000/svg" width={10} height={12} fill="none" overflow="visible" {...props}>
             <path
                 fill="currentColor"

--- a/plugins/global-search/src/components/ui/Menu.tsx
+++ b/plugins/global-search/src/components/ui/Menu.tsx
@@ -42,10 +42,10 @@ export const Menu = memo(function Menu({ items, children, className }: MenuProps
                 ref={buttonRef}
                 onMouseDown={toggleMenu}
                 onKeyDown={toggleMenu}
-                className="group h-full -mx-2 px-2 -my-3 py-3 text-white rounded-md flex-shrink-0 flex items-center justify-center bg-transparent outline-offset-0 outline-focus-ring-light dark:outline-focus-ring-dark focus-visible:outline-2 focus-visible:outline-solid hover:text-primary-light dark:hover:text-primary-dark focus:text-primary-light dark:focus:text-primary-dark disabled:opacity-50 disabled:pointer-events-none disabled:cursor-default visible"
+                className="group h-full -mx-2 px-2 -my-3 py-3 text-white rounded-md shrink-0 flex items-center justify-center bg-transparent outline-offset-0 outline-focus-ring-light dark:outline-focus-ring-dark focus-visible:outline-2 focus-visible:outline-solid hover:text-primary-light dark:hover:text-primary-dark focus:text-primary-light dark:focus:text-primary-dark cursor-pointer disabled:opacity-50 disabled:pointer-events-none disabled:cursor-default visible"
                 aria-haspopup="true"
             >
-                <div className="flex items-center justify-center w-fit h-fit flex-shrink-0 bg-transparent text-tertiary-light dark:text-tertiary-dark group-hover:text-primary-light dark:group-hover:text-primary-dark group-focus:text-primary-light dark:group-focus:text-primary-dark">
+                <div className="flex items-center justify-center w-fit h-fit shrink-0 bg-transparent text-tertiary-light dark:text-tertiary-dark group-hover:text-primary-light dark:group-hover:text-primary-dark group-focus:text-primary-light dark:group-focus:text-primary-dark">
                     {children}
                 </div>
             </button>


### PR DESCRIPTION
### Description

This pull request adds prerelease styles to the Text Search plugin.

Screenshots: https://www.notion.so/framer/365adf6e8c9680f4be1cef9bd9a126bc

The search and code file icons are not behind the prerelease styles flag because they appear to be the same in the assets panel regardless of whether the experiment is on or off.

The arrow icon was renamed from arrow right to arrow down because the arrow SVG used in all of the panels in Framer (pages, layers, assets) points down instead of right.

### Changelog

- Updated icons.
- Added pointer cursor style to menu button.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Verify that the icons looks correct with the experiment on and off.