### PR TITLE
Close silently in text search

### DIFF
--- a/plugins/global-search/src/App.tsx
+++ b/plugins/global-search/src/App.tsx
@@ -13,9 +13,7 @@ document.addEventListener("keydown", event => {
 
     if (!isEscape && !isOwnOpenCombination) return
 
-    // This will close the plugin, but also show a message that the plugin was closed.
-    // We might add a "silent" option later.
-    framer.closePlugin()
+    framer.closePlugin(undefined, { silent: true })
 })
 
 void framer.showUI(getPluginUiOptions({ query: undefined, hasResults: false }))


### PR DESCRIPTION
### Description

This pull request makes the Text Search plugin use the "silent" option when closing the plugin with Cmd+Shift+F to hide the notification when it closes. There's a comment about adding a silent option, and it was added to the API but the plugin wasn't updated to use it yet.

### Changelog

- Closing the plugin with Cmd+Shift+F no longer shows a notification.

### Testing

- [x] Close the plugin with Cmd+Shift+F and verify that no notification is displayed.