### PR TITLE
Update marketplace URL and fix CLI version

### DIFF
--- a/packages/plugin-tools/Readme.md
+++ b/packages/plugin-tools/Readme.md
@@ -39,4 +39,4 @@ framer-plugin-tools pack --help
 ## Submitting Your Plugin
 
 After running `pack`, submit your plugin at:
-https://www.framer.com/marketplace/dashboard/plugins/
+https://www.framer.com/community/marketplace/plugins/

--- a/packages/plugin-tools/Readme.md
+++ b/packages/plugin-tools/Readme.md
@@ -38,5 +38,5 @@ framer-plugin-tools pack --help
 
 ## Submitting Your Plugin
 
-After running `pack`, submit your plugin at:
+After running `pack`, publish your plugin at:
 https://www.framer.com/community/marketplace/plugins/

--- a/packages/plugin-tools/package.json
+++ b/packages/plugin-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-plugin-tools",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "CLI Tools for Framer Plugins",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/plugin-tools/src/cli.ts
+++ b/packages/plugin-tools/src/cli.ts
@@ -36,7 +36,7 @@ program
         const dirName = path.dirname(zipFilePath)
 
         console.log(
-            `\n⚡️ ${fileName} file has been created in ${dirName} \n Submit your Plugin on the Framer Marketplace: https://www.framer.com/marketplace/dashboard/plugins/`
+            `\n⚡️ ${fileName} file has been created in ${dirName} \n Submit your Plugin on the Framer Marketplace: https://www.framer.com/community/marketplace/plugins/`
         )
     })
 

--- a/packages/plugin-tools/src/cli.ts
+++ b/packages/plugin-tools/src/cli.ts
@@ -1,12 +1,13 @@
 import path from "node:path"
 import { program } from "@commander-js/extra-typings"
+import { version } from "../package.json"
 import { runPluginBuildScript, zipPluginDistribution } from "./lib"
 
 const defaultDistDir = "dist"
 const defaultOutputFilename = "plugin.zip"
 const defaultCWD = process.cwd()
 
-program.name("framer-plugin-tools").description("CLI tools for Framer Plugins").version("1.1.0")
+program.name("framer-plugin-tools").description("CLI tools for Framer Plugins").version(version)
 
 program
     .command("pack")

--- a/packages/plugin-tools/src/cli.ts
+++ b/packages/plugin-tools/src/cli.ts
@@ -37,7 +37,7 @@ program
         const dirName = path.dirname(zipFilePath)
 
         console.log(
-            `\n⚡️ ${fileName} file has been created in ${dirName} \n Submit your Plugin on the Framer Marketplace: https://www.framer.com/community/marketplace/plugins/`
+            `\n⚡️ ${fileName} file has been created in ${dirName} \n Publish your Plugin on the Framer Marketplace: https://www.framer.com/community/marketplace/plugins/`
         )
     })
 


### PR DESCRIPTION
## Description

- Update the Framer Marketplace submission URL to `https://www.framer.com/community/marketplace/plugins/` in both the CLI `pack` output and the README.
- Read the CLI `--version` from `package.json` instead of hardcoding it, so it can't drift out of sync again (it was reporting `1.1.0` while the package was at `1.2.1`).

## QA

- [x] QA
  - `yarn build` succeeds.
  - `node dist/cli.js --version` prints `1.2.2` (matches `package.json`).
  - CLI `pack` output and README both point to the new marketplace URL.

<!-- Thank you for contributing! -->