### PR TITLE
Fix image mode permissions

### DIFF
--- a/plugins/ascii/src/App.tsx
+++ b/plugins/ascii/src/App.tsx
@@ -55,7 +55,10 @@ function ASCIIPlugin({ framerCanvasImage }: { framerCanvasImage: ImageAsset | nu
     const asciiRef = useRef<ASCIIRef | null>(null)
     const { gl, toBytes, program, setProgram, setResolution } = useOGLPipeline()
 
-    const isAllowedToUpsertImage = useIsAllowedTo("addImage", "setImage")
+    const isAllowedToAddImage = useIsAllowedTo("addImage")
+    const isAllowedToSetImage = useIsAllowedTo("setImage")
+    const isAllowedToUpsertImage =
+        framer.mode === "canvas" ? isAllowedToAddImage && isAllowedToSetImage : isAllowedToSetImage
 
     useEffect(() => {
         asciiRef.current?.setPixelSize(exportSize * 0.02)

--- a/plugins/dither/src/App.tsx
+++ b/plugins/dither/src/App.tsx
@@ -42,7 +42,10 @@ export interface DroppedAsset {
 }
 
 function DitherImage({ image }: { image: ImageAsset | null }) {
-    const isAllowedToUpsertImage = useIsAllowedTo("addImage", "setImage")
+    const isAllowedToAddImage = useIsAllowedTo("addImage")
+    const isAllowedToSetImage = useIsAllowedTo("setImage")
+    const isAllowedToUpsertImage =
+        framer.mode === "canvas" ? isAllowedToAddImage && isAllowedToSetImage : isAllowedToSetImage
 
     const canvasContainerRef = useRef<HTMLDivElement>(null)
     const [droppedAsset, setDroppedAsset] = useState<DroppedAsset | null>()

--- a/plugins/unsplash/src/App.tsx
+++ b/plugins/unsplash/src/App.tsx
@@ -22,7 +22,7 @@ const minWindowWidth = mode === "canvas" ? 260 : 600
 const minColumnWidth = 100
 const columnGap = 5
 const sidePadding = 15 * 2
-const resizable = framer.mode === "canvas"
+const resizable = mode === "canvas"
 
 void framer.showUI({
     position: "top right",
@@ -34,7 +34,7 @@ void framer.showUI({
 })
 
 export function App() {
-    const isAllowedToUpsertImage = useIsAllowedTo("addImage", "setImage")
+    const isAllowedToUpsertImage = useIsAllowedTo(mode === "canvas" ? "addImage" : "setImage")
 
     const [query, setQuery] = useState("")
 
@@ -42,7 +42,6 @@ export function App() {
 
     const addRandomMutation = useMutation({
         mutationFn: async (query: string) => {
-            const mode = framer.mode
             const randomPhoto = await getRandomPhoto(query)
 
             if (mode === "canvas") {
@@ -83,7 +82,7 @@ export function App() {
                 </div>
             </div>
             <AppErrorBoundary>
-                <PhotosList query={debouncedQuery} />
+                <PhotosList query={debouncedQuery} isAllowedToUpsertImage={isAllowedToUpsertImage} />
             </AppErrorBoundary>
             <div className="mt-[15px] px-[15px]">
                 <button
@@ -104,9 +103,13 @@ export function App() {
 
 type PhotoId = string
 
-const PhotosList = memo(function PhotosList({ query }: { query: string }) {
-    const isAllowedToUpsertImage = useIsAllowedTo("addImage", "setImage")
-
+const PhotosList = memo(function PhotosList({
+    query,
+    isAllowedToUpsertImage,
+}: {
+    query: string
+    isAllowedToUpsertImage: boolean
+}) {
     const { data, fetchNextPage, isFetchingNextPage, isLoading, hasNextPage } = useListPhotosInfinite(query)
     const scrollRef = useRef<HTMLDivElement>(null)
     const [windowWidth, setWindowWidth] = useState(window.innerWidth)
@@ -147,8 +150,6 @@ const PhotosList = memo(function PhotosList({ query }: { query: string }) {
 
     const addPhotoMutation = useMutation({
         mutationFn: async (photo: UnsplashPhoto) => {
-            const mode = framer.mode
-
             if (mode === "canvas") {
                 await framer.addImage({
                     image: photo.urls.full,


### PR DESCRIPTION
### Description

This pull request makes Unsplash, Dither and ASCII only check "setImage" permissions in image mode, in order to allow editors without canvas editing access to use these plugins in the CMS.

Requires https://github.com/framer/FramerStudio/pull/33829 to work.

### Changelog

- Project editors who only have content editing permissions can now insert images in the CMS.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [ ] Test adding an image in the CMS with full permissions
- [ ] Test adding an image in the CMS with content editing permissions only

<!-- Thank you for contributing! -->