### PR TITLE
Google sheets plugin - image alt text support

### DIFF
--- a/plugins/google-sheets/src/App.tsx
+++ b/plugins/google-sheets/src/App.tsx
@@ -15,7 +15,7 @@ import {
     useSyncSheetMutation,
 } from "./sheets"
 import { showFieldMappingUI, showLoginUI } from "./ui"
-import { assert, syncMethods } from "./utils"
+import { assert, generateUniqueNames, syncMethods } from "./utils"
 
 interface AppProps {
     pluginContext: PluginContext
@@ -209,8 +209,10 @@ export function App({ pluginContext }: AppProps) {
             slugColumn,
             lastSyncedTime,
             sheet,
+            altTextAssignments,
         } = context
         const [headerRow] = sheet.values
+        const uniqueHeaderRowNames = generateUniqueNames(headerRow)
 
         const task = async () => {
             try {
@@ -224,10 +226,14 @@ export function App({ pluginContext }: AppProps) {
                     spreadsheetId,
                     sheetTitle,
                     fields,
-                    // Determine if the field type is already configured, otherwise default to "string"
-                    colFieldTypes: headerRow.map(colName => {
-                        const field = fields.find(field => field.name === colName)
-                        return field?.type ?? "string"
+                    // Determine if the field type is already configured, otherwise default to "string".
+                    // Alt text columns never become real CMS fields, so `fields` won't have them.
+                    columnConfigs: uniqueHeaderRowNames.map(columnId => {
+                        if (columnId in altTextAssignments) {
+                            return { type: "altText" as const, imageFieldId: altTextAssignments[columnId] }
+                        }
+                        const field = fields.find(field => field.id === columnId)
+                        return { type: field?.type ?? "string" }
                     }),
                     configureFields: false,
                 })

--- a/plugins/google-sheets/src/App.tsx
+++ b/plugins/google-sheets/src/App.tsx
@@ -229,7 +229,7 @@ export function App({ pluginContext }: AppProps) {
                     // Alt text columns never become real CMS fields, so `fields` won't have them.
                     columnConfigs: headerRow.map(columnId => {
                         if (Object.hasOwn(altTextAssignments, columnId)) {
-                            return { type: "altText" as const, imageFieldId: altTextAssignments[columnId] }
+                            return { type: "altText" as const, imageColumnId: altTextAssignments[columnId] }
                         }
                         const field = fields.find(field => field.id === columnId)
                         return { type: field?.type ?? "string" }

--- a/plugins/google-sheets/src/App.tsx
+++ b/plugins/google-sheets/src/App.tsx
@@ -15,7 +15,7 @@ import {
     useSyncSheetMutation,
 } from "./sheets"
 import { showFieldMappingUI, showLoginUI } from "./ui"
-import { assert, generateUniqueNames, syncMethods } from "./utils"
+import { assert, syncMethods } from "./utils"
 
 interface AppProps {
     pluginContext: PluginContext
@@ -212,7 +212,6 @@ export function App({ pluginContext }: AppProps) {
             altTextAssignments,
         } = context
         const [headerRow] = sheet.values
-        const uniqueHeaderRowNames = generateUniqueNames(headerRow)
 
         const task = async () => {
             try {
@@ -228,7 +227,7 @@ export function App({ pluginContext }: AppProps) {
                     fields,
                     // Determine if the field type is already configured, otherwise default to "string".
                     // Alt text columns never become real CMS fields, so `fields` won't have them.
-                    columnConfigs: uniqueHeaderRowNames.map(columnId => {
+                    columnConfigs: headerRow.map(columnId => {
                         if (Object.hasOwn(altTextAssignments, columnId)) {
                             return { type: "altText" as const, imageFieldId: altTextAssignments[columnId] }
                         }

--- a/plugins/google-sheets/src/App.tsx
+++ b/plugins/google-sheets/src/App.tsx
@@ -229,7 +229,7 @@ export function App({ pluginContext }: AppProps) {
                     // Determine if the field type is already configured, otherwise default to "string".
                     // Alt text columns never become real CMS fields, so `fields` won't have them.
                     columnConfigs: uniqueHeaderRowNames.map(columnId => {
-                        if (columnId in altTextAssignments) {
+                        if (Object.hasOwn(altTextAssignments, columnId)) {
                             return { type: "altText" as const, imageFieldId: altTextAssignments[columnId] }
                         }
                         const field = fields.find(field => field.id === columnId)

--- a/plugins/google-sheets/src/components/FieldTypeMenuButton.tsx
+++ b/plugins/google-sheets/src/components/FieldTypeMenuButton.tsx
@@ -1,0 +1,112 @@
+import cx from "classnames"
+import { framer, type MenuItem, useIsAllowedTo } from "framer-plugin"
+import type { SheetCollectionFieldInput, VirtualFieldType } from "../sheets"
+import { syncMethods } from "../utils"
+import { IconChevron, IconChevronDown } from "./Icons"
+
+interface FieldTypeOption {
+    type: VirtualFieldType
+    label: string
+}
+
+const fieldTypeOptions: FieldTypeOption[] = [
+    { type: "string", label: "Plain Text" },
+    { type: "formattedText", label: "Formatted Text" },
+    { type: "date", label: "Date" },
+    { type: "dateTime", label: "Date & Time" },
+    { type: "link", label: "Link" },
+    { type: "image", label: "Image" },
+    { type: "color", label: "Color" },
+    { type: "boolean", label: "Toggle" },
+    { type: "number", label: "Number" },
+    { type: "enum", label: "Option" },
+    { type: "file", label: "File" },
+]
+
+const contextMenuOffset = 4
+
+const getFieldTypeLabel = (field: SheetCollectionFieldInput, allFields: SheetCollectionFieldInput[]): string => {
+    if (field.type === "altText") {
+        const imageField = allFields.find(candidate => candidate.id === field.imageFieldId)
+        return imageField ? `Alt Text → ${imageField.name}` : "Alt Text"
+    }
+
+    return fieldTypeOptions.find(option => option.type === field.type)?.label ?? field.type
+}
+
+interface Props {
+    field: SheetCollectionFieldInput
+    fields: SheetCollectionFieldInput[]
+    disabled: boolean
+    disabledFieldIds: Set<string>
+    onFieldTypeChange: (id: string, type: VirtualFieldType, imageFieldId?: string) => void
+}
+
+export function FieldTypeMenuButton({ field, fields, disabled, disabledFieldIds, onFieldTypeChange }: Props) {
+    const isAllowedToManage = useIsAllowedTo("ManagedCollection.setFields", ...syncMethods)
+    const isDisabled = disabled || !isAllowedToManage
+    const imageField = fields.find(candidate => candidate.id === field.imageFieldId)
+
+    const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
+        const availableImageFields = fields.filter(
+            candidate => candidate.type === "image" && candidate.id !== field.id && !disabledFieldIds.has(candidate.id)
+        )
+        const { left, bottom, width } = event.currentTarget.getBoundingClientRect()
+
+        const items: MenuItem[] = [
+            ...fieldTypeOptions.map(({ type, label }) => ({
+                label,
+                checked: field.type === type,
+                onAction: () => {
+                    onFieldTypeChange(field.id, type)
+                },
+            })),
+            {
+                label: "Alt Text",
+                checked: field.type === "altText",
+                enabled: availableImageFields.length > 0,
+                submenu: availableImageFields.map(candidate => ({
+                    label: candidate.name,
+                    checked: field.type === "altText" && field.imageFieldId === candidate.id,
+                    onAction: () => {
+                        onFieldTypeChange(field.id, "altText", candidate.id)
+                    },
+                })),
+            },
+        ]
+
+        void framer.showContextMenu(items, {
+            location: {
+                x: left + width - contextMenuOffset,
+                y: bottom + contextMenuOffset,
+            },
+            placement: "bottom-left",
+            width,
+        })
+    }
+
+    return (
+        <button
+            type="button"
+            className={cx("flex w-full min-w-0 items-center gap-1 text-left", isDisabled && "opacity-50")}
+            disabled={isDisabled}
+            title={isAllowedToManage ? getFieldTypeLabel(field, fields) : "Insufficient permissions"}
+            onClick={handleMenuOpen}
+        >
+            {field.type === "altText" ? (
+                <span className="flex min-w-0 flex-1 items-center gap-1">
+                    <span className="flex shrink-0 items-center gap-1">
+                        Alt Text
+                        <IconChevron />
+                    </span>
+                    <span className="truncate">{imageField?.name ?? "Image"}</span>
+                </span>
+            ) : (
+                <span className="min-w-0 flex-1 truncate">{getFieldTypeLabel(field, fields)}</span>
+            )}
+            <span className="shrink-0 text-content">
+                <IconChevronDown />
+            </span>
+        </button>
+    )
+}

--- a/plugins/google-sheets/src/components/FieldTypeSelectField.tsx
+++ b/plugins/google-sheets/src/components/FieldTypeSelectField.tsx
@@ -45,8 +45,14 @@ export function FieldTypeSelectField({ field, fields, isDisabled, disabledFieldI
     }, [field, imageColumn])
 
     const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
+        const assignedImageColumnIds = new Set(fields.filter(isAltTextColumn).map(candidate => candidate.imageColumnId))
+
         const availableImageFields = fields.filter(
-            candidate => candidate.type === "image" && candidate.id !== field.id && !disabledFieldIds.has(candidate.id)
+            candidate =>
+                candidate.type === "image" &&
+                candidate.id !== field.id &&
+                !disabledFieldIds.has(candidate.id) &&
+                (!assignedImageColumnIds.has(candidate.id) || candidate.id === field.imageColumnId)
         )
 
         const items: MenuItem[] = [

--- a/plugins/google-sheets/src/components/FieldTypeSelectField.tsx
+++ b/plugins/google-sheets/src/components/FieldTypeSelectField.tsx
@@ -1,7 +1,6 @@
 import cx from "classnames"
-import { framer, type MenuItem, useIsAllowedTo } from "framer-plugin"
-import type { SheetCollectionFieldInput, VirtualFieldType } from "../sheets"
-import { syncMethods } from "../utils"
+import { framer, type MenuItem } from "framer-plugin"
+import { isAltTextColumn, type SheetCollectionFieldInput, type VirtualFieldType } from "../sheets"
 import { IconChevron, IconChevronDown } from "./Icons"
 
 interface FieldTypeOption {
@@ -26,7 +25,7 @@ const fieldTypeOptions: FieldTypeOption[] = [
 const contextMenuOffset = 4
 
 const getFieldTypeLabel = (field: SheetCollectionFieldInput, allFields: SheetCollectionFieldInput[]): string => {
-    if (field.type === "altText") {
+    if (isAltTextColumn(field)) {
         const imageField = allFields.find(candidate => candidate.id === field.imageFieldId)
         return imageField ? `Alt Text → ${imageField.name}` : "Alt Text"
     }
@@ -37,14 +36,12 @@ const getFieldTypeLabel = (field: SheetCollectionFieldInput, allFields: SheetCol
 interface Props {
     field: SheetCollectionFieldInput
     fields: SheetCollectionFieldInput[]
-    disabled: boolean
+    isDisabled: boolean
     disabledFieldIds: Set<string>
     onFieldTypeChange: (id: string, type: VirtualFieldType, imageFieldId?: string) => void
 }
 
-export function FieldTypeMenuButton({ field, fields, disabled, disabledFieldIds, onFieldTypeChange }: Props) {
-    const isAllowedToManage = useIsAllowedTo("ManagedCollection.setFields", ...syncMethods)
-    const isDisabled = disabled || !isAllowedToManage
+export function FieldTypeSelectField({ field, fields, isDisabled, disabledFieldIds, onFieldTypeChange }: Props) {
     const imageField = fields.find(candidate => candidate.id === field.imageFieldId)
 
     const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -63,11 +60,11 @@ export function FieldTypeMenuButton({ field, fields, disabled, disabledFieldIds,
             })),
             {
                 label: "Alt Text",
-                checked: field.type === "altText",
+                checked: isAltTextColumn(field),
                 enabled: availableImageFields.length > 0,
                 submenu: availableImageFields.map(candidate => ({
                     label: candidate.name,
-                    checked: field.type === "altText" && field.imageFieldId === candidate.id,
+                    checked: isAltTextColumn(field) && field.imageFieldId === candidate.id,
                     onAction: () => {
                         onFieldTypeChange(field.id, "altText", candidate.id)
                     },
@@ -90,10 +87,10 @@ export function FieldTypeMenuButton({ field, fields, disabled, disabledFieldIds,
             type="button"
             className={cx("flex w-full min-w-0 items-center gap-1 text-left", isDisabled && "opacity-50")}
             disabled={isDisabled}
-            title={isAllowedToManage ? getFieldTypeLabel(field, fields) : "Insufficient permissions"}
+            title={getFieldTypeLabel(field, fields)}
             onClick={handleMenuOpen}
         >
-            {field.type === "altText" ? (
+            {isAltTextColumn(field) ? (
                 <span className="flex min-w-0 flex-1 items-center gap-1">
                     <span className="flex shrink-0 items-center gap-1">
                         Alt Text

--- a/plugins/google-sheets/src/components/FieldTypeSelectField.tsx
+++ b/plugins/google-sheets/src/components/FieldTypeSelectField.tsx
@@ -1,6 +1,6 @@
 import cx from "classnames"
 import { framer, type MenuItem } from "framer-plugin"
-import { useMemo } from "react"
+import React, { useMemo } from "react"
 import { isAltTextColumn, type SheetCollectionFieldInput, type VirtualFieldType } from "../sheets"
 import { IconChevron, IconChevronDown } from "./Icons"
 
@@ -47,13 +47,11 @@ export function FieldTypeSelectField({ field, fields, isDisabled, disabledFieldI
     const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
         const assignedImageColumnIds = new Set(fields.filter(isAltTextColumn).map(candidate => candidate.imageColumnId))
 
-        const availableImageFields = fields.filter(
-            candidate =>
-                candidate.type === "image" &&
-                candidate.id !== field.id &&
-                !disabledFieldIds.has(candidate.id) &&
-                (!assignedImageColumnIds.has(candidate.id) || candidate.id === field.imageColumnId)
+        const imageFields = fields.filter(
+            candidate => candidate.type === "image" && candidate.id !== field.id && !disabledFieldIds.has(candidate.id)
         )
+        const canAssignImageField = (candidate: SheetCollectionFieldInput) =>
+            !assignedImageColumnIds.has(candidate.id) || candidate.id === field.imageColumnId
 
         const items: MenuItem[] = [
             ...fieldTypeOptions.map(({ type, label }) => ({
@@ -66,10 +64,11 @@ export function FieldTypeSelectField({ field, fields, isDisabled, disabledFieldI
             {
                 label: "Alt Text",
                 checked: isAltTextColumn(field),
-                enabled: availableImageFields.length > 0,
-                submenu: availableImageFields.map(candidate => ({
+                enabled: imageFields.some(canAssignImageField),
+                submenu: imageFields.map(candidate => ({
                     label: candidate.name,
                     checked: isAltTextColumn(field) && field.imageColumnId === candidate.id,
+                    enabled: canAssignImageField(candidate),
                     onAction: () => {
                         onFieldTypeChange(field.id, "altText", candidate.id)
                     },

--- a/plugins/google-sheets/src/components/FieldTypeSelectField.tsx
+++ b/plugins/google-sheets/src/components/FieldTypeSelectField.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames"
 import { framer, type MenuItem } from "framer-plugin"
+import { useMemo } from "react"
 import { isAltTextColumn, type SheetCollectionFieldInput, type VirtualFieldType } from "../sheets"
 import { IconChevron, IconChevronDown } from "./Icons"
 
@@ -24,15 +25,6 @@ const fieldTypeOptions: FieldTypeOption[] = [
 
 const contextMenuOffset = 4
 
-const getFieldTypeLabel = (field: SheetCollectionFieldInput, allFields: SheetCollectionFieldInput[]): string => {
-    if (isAltTextColumn(field)) {
-        const imageField = allFields.find(candidate => candidate.id === field.imageFieldId)
-        return imageField ? `Alt Text → ${imageField.name}` : "Alt Text"
-    }
-
-    return fieldTypeOptions.find(option => option.type === field.type)?.label ?? field.type
-}
-
 interface Props {
     field: SheetCollectionFieldInput
     fields: SheetCollectionFieldInput[]
@@ -44,11 +36,18 @@ interface Props {
 export function FieldTypeSelectField({ field, fields, isDisabled, disabledFieldIds, onFieldTypeChange }: Props) {
     const imageField = fields.find(candidate => candidate.id === field.imageFieldId)
 
+    const fieldTypeLabel = useMemo(() => {
+        if (isAltTextColumn(field)) {
+            return imageField ? `Alt Text → ${imageField.name}` : "Alt Text"
+        }
+
+        return fieldTypeOptions.find(option => option.type === field.type)?.label ?? field.type
+    }, [field, imageField])
+
     const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
         const availableImageFields = fields.filter(
             candidate => candidate.type === "image" && candidate.id !== field.id && !disabledFieldIds.has(candidate.id)
         )
-        const { left, bottom, width } = event.currentTarget.getBoundingClientRect()
 
         const items: MenuItem[] = [
             ...fieldTypeOptions.map(({ type, label }) => ({
@@ -72,6 +71,7 @@ export function FieldTypeSelectField({ field, fields, isDisabled, disabledFieldI
             },
         ]
 
+        const { left, bottom, width } = event.currentTarget.getBoundingClientRect()
         void framer.showContextMenu(items, {
             location: {
                 x: left + width - contextMenuOffset,
@@ -87,7 +87,7 @@ export function FieldTypeSelectField({ field, fields, isDisabled, disabledFieldI
             type="button"
             className={cx("flex w-full min-w-0 items-center gap-1 text-left", isDisabled && "opacity-50")}
             disabled={isDisabled}
-            title={getFieldTypeLabel(field, fields)}
+            title={fieldTypeLabel}
             onClick={handleMenuOpen}
         >
             {isAltTextColumn(field) ? (
@@ -99,7 +99,7 @@ export function FieldTypeSelectField({ field, fields, isDisabled, disabledFieldI
                     <span className="truncate">{imageField?.name ?? "Image"}</span>
                 </span>
             ) : (
-                <span className="min-w-0 flex-1 truncate">{getFieldTypeLabel(field, fields)}</span>
+                <span className="min-w-0 flex-1 truncate">{fieldTypeLabel}</span>
             )}
             <span className="shrink-0 text-content">
                 <IconChevronDown />

--- a/plugins/google-sheets/src/components/FieldTypeSelectField.tsx
+++ b/plugins/google-sheets/src/components/FieldTypeSelectField.tsx
@@ -30,19 +30,19 @@ interface Props {
     fields: SheetCollectionFieldInput[]
     isDisabled: boolean
     disabledFieldIds: Set<string>
-    onFieldTypeChange: (id: string, type: VirtualFieldType, imageFieldId?: string) => void
+    onFieldTypeChange: (id: string, type: VirtualFieldType, imageColumnId?: string) => void
 }
 
 export function FieldTypeSelectField({ field, fields, isDisabled, disabledFieldIds, onFieldTypeChange }: Props) {
-    const imageField = fields.find(candidate => candidate.id === field.imageFieldId)
+    const imageColumn = fields.find(candidate => candidate.id === field.imageColumnId)
 
     const fieldTypeLabel = useMemo(() => {
         if (isAltTextColumn(field)) {
-            return imageField ? `Alt Text → ${imageField.name}` : "Alt Text"
+            return imageColumn ? `Alt Text → ${imageColumn.name}` : "Alt Text"
         }
 
         return fieldTypeOptions.find(option => option.type === field.type)?.label ?? field.type
-    }, [field, imageField])
+    }, [field, imageColumn])
 
     const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
         const availableImageFields = fields.filter(
@@ -63,7 +63,7 @@ export function FieldTypeSelectField({ field, fields, isDisabled, disabledFieldI
                 enabled: availableImageFields.length > 0,
                 submenu: availableImageFields.map(candidate => ({
                     label: candidate.name,
-                    checked: isAltTextColumn(field) && field.imageFieldId === candidate.id,
+                    checked: isAltTextColumn(field) && field.imageColumnId === candidate.id,
                     onAction: () => {
                         onFieldTypeChange(field.id, "altText", candidate.id)
                     },
@@ -96,7 +96,7 @@ export function FieldTypeSelectField({ field, fields, isDisabled, disabledFieldI
                         Alt Text
                         <IconChevron />
                     </span>
-                    <span className="truncate">{imageField?.name ?? "Image"}</span>
+                    <span className="truncate">{imageColumn?.name ?? "Image"}</span>
                 </span>
             ) : (
                 <span className="min-w-0 flex-1 truncate">{fieldTypeLabel}</span>

--- a/plugins/google-sheets/src/components/Icons.tsx
+++ b/plugins/google-sheets/src/components/Icons.tsx
@@ -10,3 +10,16 @@ export const IconChevron = () => (
         ></path>
     </svg>
 )
+
+export const IconChevronDown = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="8" height="8">
+        <path
+            fill="transparent"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="m1 2.75 2.293 2.293a1 1 0 0 0 1.414 0L7 2.75"
+        />
+    </svg>
+)

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -87,7 +87,7 @@ const inferFieldType = (cellValue: CellValue): VirtualFieldType => {
 }
 
 const getColumnConfig = (context: PluginContext, columnId: string, cellValue?: CellValue): SheetColumnConfig => {
-    if (context.type === "update" && columnId in context.altTextAssignments) {
+    if (context.type === "update" && Object.hasOwn(context.altTextAssignments, columnId)) {
         return { type: "altText", imageFieldId: context.altTextAssignments[columnId] }
     }
 
@@ -191,18 +191,23 @@ export function MapSheetFieldsPage({
     }
 
     const handleFieldTypeChange = (id: string, type: VirtualFieldType, imageFieldId?: string) => {
-        setFieldConfig(current =>
-            current.map(field => {
-                if (field.id === id) {
-                    return {
-                        ...field,
-                        type,
-                        imageFieldId: type === "altText" ? imageFieldId : undefined,
-                    } as SheetCollectionFieldInput
-                }
-                return field
-            })
-        )
+        const nextFieldConfig = fieldConfig.map(field => {
+            if (field.id === id) {
+                return {
+                    ...field,
+                    type,
+                    imageFieldId: type === "altText" ? imageFieldId : undefined,
+                } as SheetCollectionFieldInput
+            }
+            return field
+        })
+
+        setFieldConfig(nextFieldConfig)
+
+        const nextSlugFields = getPossibleSlugFields(nextFieldConfig)
+        if (!nextSlugFields.some(field => field.id === slugColumn)) {
+            setSlugColumn(nextSlugFields[0]?.id ?? "")
+        }
     }
 
     const handleSubmit = async (e: React.FormEvent) => {

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -1,8 +1,9 @@
 import cx from "classnames"
-import { framer, type MenuItem, useIsAllowedTo } from "framer-plugin"
+import { framer, useIsAllowedTo } from "framer-plugin"
 import { Fragment, useMemo, useState } from "react"
 import { CheckboxTextfield } from "../components/CheckboxTextField"
-import { IconChevron, IconChevronDown } from "../components/Icons"
+import { FieldTypeMenuButton } from "../components/FieldTypeMenuButton"
+import { IconChevron } from "../components/Icons"
 import type {
     CellValue,
     HeaderRow,
@@ -14,25 +15,6 @@ import type {
     VirtualFieldType,
 } from "../sheets"
 import { generateUniqueNames, isDefined, syncMethods } from "../utils"
-
-interface FieldTypeOption {
-    type: VirtualFieldType
-    label: string
-}
-
-const fieldTypeOptions: FieldTypeOption[] = [
-    { type: "string", label: "Plain Text" },
-    { type: "formattedText", label: "Formatted Text" },
-    { type: "date", label: "Date" },
-    { type: "dateTime", label: "Date & Time" },
-    { type: "link", label: "Link" },
-    { type: "image", label: "Image" },
-    { type: "color", label: "Color" },
-    { type: "boolean", label: "Toggle" },
-    { type: "number", label: "Number" },
-    { type: "enum", label: "Option" },
-    { type: "file", label: "File" },
-]
 
 const getInitialSlugColumn = (context: PluginContext, slugFields: SheetCollectionFieldInput[]): string => {
     if (context.type === "update" && context.slugColumn) {
@@ -157,19 +139,6 @@ const getPossibleSlugFields = (fieldConfig: SheetCollectionFieldInput[]): SheetC
     return fieldConfig.filter(field => field.type === "string")
 }
 
-const getFieldTypeLabel = (field: SheetCollectionFieldInput, allFields: SheetCollectionFieldInput[]): string => {
-    if (field.type === "altText") {
-        const imageField = allFields.find(f => f.id === field.imageFieldId)
-        return imageField ? `Alt Text → ${imageField.name}` : "Alt Text"
-    }
-
-    return fieldTypeOptions.find(option => option.type === field.type)?.label ?? field.type
-}
-
-const getAltTextImageField = (field: SheetCollectionFieldInput, allFields: SheetCollectionFieldInput[]) => {
-    return allFields.find(candidate => candidate.id === field.imageFieldId)
-}
-
 interface Props {
     spreadsheetId: string
     sheetTitle: string
@@ -234,44 +203,6 @@ export function MapSheetFieldsPage({
                 return field
             })
         )
-    }
-
-    const handleFieldTypeMenuOpen = (field: SheetCollectionFieldInput, e: React.MouseEvent<HTMLButtonElement>) => {
-        const imageFields = fieldConfig.filter(
-            f => f.type === "image" && f.id !== field.id && !disabledColumns.has(f.id)
-        )
-        const { left, bottom, width } = e.currentTarget.getBoundingClientRect()
-
-        const items: MenuItem[] = [
-            ...fieldTypeOptions.map(({ type, label }) => ({
-                label,
-                checked: field.type === type,
-                onAction: () => {
-                    handleFieldTypeChange(field.id, type)
-                },
-            })),
-            {
-                label: "Alt Text",
-                checked: field.type === "altText",
-                enabled: imageFields.length > 0,
-                submenu: imageFields.map(imgField => ({
-                    label: imgField.name,
-                    checked: field.type === "altText" && field.imageFieldId === imgField.id,
-                    onAction: () => {
-                        handleFieldTypeChange(field.id, "altText", imgField.id)
-                    },
-                })),
-            },
-        ]
-
-        const locationX = left + width - 4;
-        const locationY = bottom + 4;
-
-        void framer.showContextMenu(items, {
-            location: { x: locationX, y: locationY },
-            placement: "bottom-left",
-            width,
-        })
     }
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -351,41 +282,13 @@ export function MapSheetFieldsPage({
                                 <div className="flex items-center justify-center">
                                     <IconChevron />
                                 </div>
-                                <button
-                                    type="button"
-                                    className={cx(
-                                        "flex w-full min-w-0 items-center gap-1 text-left",
-                                        (isDisabled || !isAllowedToManage) && "opacity-50"
-                                    )}
-                                    disabled={isDisabled || !isAllowedToManage}
-                                    title={
-                                        isAllowedToManage
-                                            ? getFieldTypeLabel(field, fieldConfig)
-                                            : "Insufficient permissions"
-                                    }
-                                    onClick={e => {
-                                        handleFieldTypeMenuOpen(field, e)
-                                    }}
-                                >
-                                    {field.type === "altText" ? (
-                                        <span className="flex min-w-0 flex-1 items-center gap-1">
-                                            <span className="flex shrink-0 items-center gap-1">
-                                                Alt Text
-                                                <IconChevron />
-                                            </span>
-                                            <span className="truncate">
-                                                {getAltTextImageField(field, fieldConfig)?.name ?? "Image"}
-                                            </span>
-                                        </span>
-                                    ) : (
-                                        <span className="min-w-0 flex-1 truncate">
-                                            {getFieldTypeLabel(field, fieldConfig)}
-                                        </span>
-                                    )}
-                                    <span className="shrink-0 text-content">
-                                        <IconChevronDown />
-                                    </span>
-                                </button>
+                                <FieldTypeMenuButton
+                                    field={field}
+                                    fields={fieldConfig}
+                                    disabled={isDisabled}
+                                    disabledFieldIds={disabledColumns}
+                                    onFieldTypeChange={handleFieldTypeChange}
+                                />
                                 {field.type !== "altText" ? (
                                     <input
                                         type="text"

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -2,7 +2,7 @@ import cx from "classnames"
 import { framer, useIsAllowedTo } from "framer-plugin"
 import { Fragment, useMemo, useState } from "react"
 import { CheckboxTextfield } from "../components/CheckboxTextField"
-import { FieldTypeMenuButton } from "../components/FieldTypeMenuButton"
+import { FieldTypeSelectField } from "../components/FieldTypeSelectField"
 import { IconChevron } from "../components/Icons"
 import type {
     CellValue,
@@ -14,6 +14,7 @@ import type {
     SyncMutationOptions,
     VirtualFieldType,
 } from "../sheets"
+import { isAltTextColumn } from "../sheets"
 import { generateUniqueNames, isDefined, syncMethods } from "../utils"
 
 const getInitialSlugColumn = (context: PluginContext, slugFields: SheetCollectionFieldInput[]): string => {
@@ -191,23 +192,18 @@ export function MapSheetFieldsPage({
     }
 
     const handleFieldTypeChange = (id: string, type: VirtualFieldType, imageFieldId?: string) => {
-        const nextFieldConfig = fieldConfig.map(field => {
-            if (field.id === id) {
-                return {
-                    ...field,
-                    type,
-                    imageFieldId: type === "altText" ? imageFieldId : undefined,
-                } as SheetCollectionFieldInput
-            }
-            return field
-        })
-
-        setFieldConfig(nextFieldConfig)
-
-        const nextSlugFields = getPossibleSlugFields(nextFieldConfig)
-        if (!nextSlugFields.some(field => field.id === slugColumn)) {
-            setSlugColumn(nextSlugFields[0]?.id ?? "")
-        }
+        setFieldConfig(current =>
+            current.map(field => {
+                if (field.id === id) {
+                    return {
+                        ...field,
+                        type,
+                        imageFieldId: type === "altText" ? imageFieldId : undefined,
+                    } as SheetCollectionFieldInput
+                }
+                return field
+            })
+        )
     }
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -217,7 +213,7 @@ export function MapSheetFieldsPage({
 
         const allFields = fieldConfig
             // Alt text columns are virtual: they never become their own CMS field.
-            .filter(field => !disabledColumns.has(field.id) && field.type !== "altText")
+            .filter(field => !disabledColumns.has(field.id) && !isAltTextColumn(field))
             .map(field => {
                 const maybeOverride = fieldNameOverrides[field.id]
                 if (maybeOverride) {
@@ -287,14 +283,14 @@ export function MapSheetFieldsPage({
                                 <div className="flex items-center justify-center">
                                     <IconChevron />
                                 </div>
-                                <FieldTypeMenuButton
+                                <FieldTypeSelectField
                                     field={field}
                                     fields={fieldConfig}
-                                    disabled={isDisabled}
+                                    isDisabled={isDisabled || !isAllowedToManage}
                                     disabledFieldIds={disabledColumns}
                                     onFieldTypeChange={handleFieldTypeChange}
                                 />
-                                {field.type !== "altText" ? (
+                                {!isAltTextColumn(field) ? (
                                     <input
                                         type="text"
                                         className={cx("w-full", (isDisabled || !isAllowedToManage) && "opacity-50")}

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -1,14 +1,15 @@
 import cx from "classnames"
-import { framer, useIsAllowedTo } from "framer-plugin"
+import { framer, type MenuItem, useIsAllowedTo } from "framer-plugin"
 import { Fragment, useMemo, useState } from "react"
 import { CheckboxTextfield } from "../components/CheckboxTextField"
-import { IconChevron } from "../components/Icons"
+import { IconChevron, IconChevronDown } from "../components/Icons"
 import type {
     CellValue,
     HeaderRow,
     PluginContext,
     Row,
     SheetCollectionFieldInput,
+    SheetColumnConfig,
     SyncMutationOptions,
     VirtualFieldType,
 } from "../sheets"
@@ -103,15 +104,19 @@ const inferFieldType = (cellValue: CellValue): VirtualFieldType => {
     return "string"
 }
 
-const getFieldType = (context: PluginContext, columnId: string, cellValue?: CellValue): VirtualFieldType => {
+const getColumnConfig = (context: PluginContext, columnId: string, cellValue?: CellValue): SheetColumnConfig => {
+    if (context.type === "update" && columnId in context.altTextAssignments) {
+        return { type: "altText", imageFieldId: context.altTextAssignments[columnId] }
+    }
+
     // Determine if the field type is already configured
     if ("collectionFields" in context) {
         const field = context.collectionFields.find(field => field.id === columnId)
-        return field?.type ?? "string"
+        return { type: field?.type ?? "string" }
     }
 
     // Otherwise, infer the field type from the cell value
-    return cellValue ? inferFieldType(cellValue) : "string"
+    return { type: cellValue ? inferFieldType(cellValue) : "string" }
 }
 
 const createFieldConfig = (
@@ -125,10 +130,13 @@ const createFieldConfig = (
             const sanitizedName = uniqueColumnNames[columnIndex]
             if (!sanitizedName) return null
 
+            const { type, imageFieldId } = getColumnConfig(context, sanitizedName, row?.[columnIndex])
+
             return {
                 id: sanitizedName,
                 name: sanitizedName,
-                type: getFieldType(context, sanitizedName, row?.[columnIndex]),
+                type,
+                imageFieldId,
             } as SheetCollectionFieldInput
         })
         .filter(isDefined)
@@ -147,6 +155,19 @@ const getFieldNameOverrides = (context: PluginContext): Record<string, string> =
 
 const getPossibleSlugFields = (fieldConfig: SheetCollectionFieldInput[]): SheetCollectionFieldInput[] => {
     return fieldConfig.filter(field => field.type === "string")
+}
+
+const getFieldTypeLabel = (field: SheetCollectionFieldInput, allFields: SheetCollectionFieldInput[]): string => {
+    if (field.type === "altText") {
+        const imageField = allFields.find(f => f.id === field.imageFieldId)
+        return imageField ? `Alt Text → ${imageField.name}` : "Alt Text"
+    }
+
+    return fieldTypeOptions.find(option => option.type === field.type)?.label ?? field.type
+}
+
+const getAltTextImageField = (field: SheetCollectionFieldInput, allFields: SheetCollectionFieldInput[]) => {
+    return allFields.find(candidate => candidate.id === field.imageFieldId)
 }
 
 interface Props {
@@ -200,18 +221,57 @@ export function MapSheetFieldsPage({
         }))
     }
 
-    const handleFieldTypeChange = (id: string, type: VirtualFieldType) => {
+    const handleFieldTypeChange = (id: string, type: VirtualFieldType, imageFieldId?: string) => {
         setFieldConfig(current =>
             current.map(field => {
                 if (field.id === id) {
                     return {
                         ...field,
                         type,
+                        imageFieldId: type === "altText" ? imageFieldId : undefined,
                     } as SheetCollectionFieldInput
                 }
                 return field
             })
         )
+    }
+
+    const handleFieldTypeMenuOpen = (field: SheetCollectionFieldInput, e: React.MouseEvent<HTMLButtonElement>) => {
+        const imageFields = fieldConfig.filter(
+            f => f.type === "image" && f.id !== field.id && !disabledColumns.has(f.id)
+        )
+        const { left, bottom, width } = e.currentTarget.getBoundingClientRect()
+
+        const items: MenuItem[] = [
+            ...fieldTypeOptions.map(({ type, label }) => ({
+                label,
+                checked: field.type === type,
+                onAction: () => {
+                    handleFieldTypeChange(field.id, type)
+                },
+            })),
+            {
+                label: "Alt Text",
+                checked: field.type === "altText",
+                enabled: imageFields.length > 0,
+                submenu: imageFields.map(imgField => ({
+                    label: imgField.name,
+                    checked: field.type === "altText" && field.imageFieldId === imgField.id,
+                    onAction: () => {
+                        handleFieldTypeChange(field.id, "altText", imgField.id)
+                    },
+                })),
+            },
+        ]
+
+        const locationX = left + width - 4;
+        const locationY = bottom + 4;
+
+        void framer.showContextMenu(items, {
+            location: { x: locationX, y: locationY },
+            placement: "bottom-left",
+            width,
+        })
     }
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -220,7 +280,8 @@ export function MapSheetFieldsPage({
         if (isPending) return
 
         const allFields = fieldConfig
-            .filter(field => !disabledColumns.has(field.id))
+            // Alt text columns are virtual: they never become their own CMS field.
+            .filter(field => !disabledColumns.has(field.id) && field.type !== "altText")
             .map(field => {
                 const maybeOverride = fieldNameOverrides[field.id]
                 if (maybeOverride) {
@@ -236,7 +297,7 @@ export function MapSheetFieldsPage({
             fields: allFields,
             spreadsheetId,
             sheetTitle,
-            colFieldTypes: fieldConfig.map(field => field.type),
+            columnConfigs: fieldConfig.map(field => ({ type: field.type, imageFieldId: field.imageFieldId })),
             ignoredColumns: Array.from(disabledColumns),
             slugColumn,
             lastSyncedTime: getLastSyncedTime(pluginContext, slugColumn),
@@ -290,31 +351,55 @@ export function MapSheetFieldsPage({
                                 <div className="flex items-center justify-center">
                                     <IconChevron />
                                 </div>
-                                <select
-                                    className={cx("w-full", (isDisabled || !isAllowedToManage) && "opacity-50")}
+                                <button
+                                    type="button"
+                                    className={cx(
+                                        "flex w-full min-w-0 items-center gap-1 text-left",
+                                        (isDisabled || !isAllowedToManage) && "opacity-50"
+                                    )}
                                     disabled={isDisabled || !isAllowedToManage}
-                                    value={field.type}
-                                    onChange={e => {
-                                        handleFieldTypeChange(field.id, e.target.value as VirtualFieldType)
+                                    title={
+                                        isAllowedToManage
+                                            ? getFieldTypeLabel(field, fieldConfig)
+                                            : "Insufficient permissions"
+                                    }
+                                    onClick={e => {
+                                        handleFieldTypeMenuOpen(field, e)
                                     }}
-                                    title={isAllowedToManage ? undefined : "Insufficient permissions"}
                                 >
-                                    {fieldTypeOptions.map(({ type, label }) => (
-                                        <option key={type} value={type}>
-                                            {label}
-                                        </option>
-                                    ))}
-                                </select>
-                                <input
-                                    type="text"
-                                    className={cx("w-full", (isDisabled || !isAllowedToManage) && "opacity-50")}
-                                    disabled={isDisabled || !isAllowedToManage}
-                                    placeholder={field.name}
-                                    value={fieldNameOverrides[field.id] ?? ""}
-                                    onChange={e => {
-                                        handleFieldNameChange(field.id, e.target.value)
-                                    }}
-                                />
+                                    {field.type === "altText" ? (
+                                        <span className="flex min-w-0 flex-1 items-center gap-1">
+                                            <span className="flex shrink-0 items-center gap-1">
+                                                Alt Text
+                                                <IconChevron />
+                                            </span>
+                                            <span className="truncate">
+                                                {getAltTextImageField(field, fieldConfig)?.name ?? "Image"}
+                                            </span>
+                                        </span>
+                                    ) : (
+                                        <span className="min-w-0 flex-1 truncate">
+                                            {getFieldTypeLabel(field, fieldConfig)}
+                                        </span>
+                                    )}
+                                    <span className="shrink-0 text-content">
+                                        <IconChevronDown />
+                                    </span>
+                                </button>
+                                {field.type !== "altText" ? (
+                                    <input
+                                        type="text"
+                                        className={cx("w-full", (isDisabled || !isAllowedToManage) && "opacity-50")}
+                                        disabled={isDisabled || !isAllowedToManage}
+                                        placeholder={field.name}
+                                        value={fieldNameOverrides[field.id] ?? ""}
+                                        onChange={e => {
+                                            handleFieldNameChange(field.id, e.target.value)
+                                        }}
+                                    />
+                                ) : (
+                                    <div />
+                                )}
                             </Fragment>
                         )
                     })}

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -199,8 +199,17 @@ export function MapSheetFieldsPage({
                         ...field,
                         type,
                         imageFieldId: type === "altText" ? imageFieldId : undefined,
-                    } as SheetCollectionFieldInput
+                    }
                 }
+
+                if (type !== "image" && isAltTextColumn(field) && field.imageFieldId === id) {
+                    return {
+                        ...field,
+                        type: "string",
+                        imageFieldId: undefined,
+                    }
+                }
+
                 return field
             })
         )

--- a/plugins/google-sheets/src/pages/MapSheetFields.tsx
+++ b/plugins/google-sheets/src/pages/MapSheetFields.tsx
@@ -89,7 +89,7 @@ const inferFieldType = (cellValue: CellValue): VirtualFieldType => {
 
 const getColumnConfig = (context: PluginContext, columnId: string, cellValue?: CellValue): SheetColumnConfig => {
     if (context.type === "update" && Object.hasOwn(context.altTextAssignments, columnId)) {
-        return { type: "altText", imageFieldId: context.altTextAssignments[columnId] }
+        return { type: "altText", imageColumnId: context.altTextAssignments[columnId] }
     }
 
     // Determine if the field type is already configured
@@ -113,13 +113,13 @@ const createFieldConfig = (
             const sanitizedName = uniqueColumnNames[columnIndex]
             if (!sanitizedName) return null
 
-            const { type, imageFieldId } = getColumnConfig(context, sanitizedName, row?.[columnIndex])
+            const { type, imageColumnId } = getColumnConfig(context, sanitizedName, row?.[columnIndex])
 
             return {
                 id: sanitizedName,
                 name: sanitizedName,
                 type,
-                imageFieldId,
+                imageColumnId,
             } as SheetCollectionFieldInput
         })
         .filter(isDefined)
@@ -191,22 +191,22 @@ export function MapSheetFieldsPage({
         }))
     }
 
-    const handleFieldTypeChange = (id: string, type: VirtualFieldType, imageFieldId?: string) => {
+    const handleFieldTypeChange = (id: string, type: VirtualFieldType, imageColumnId?: string) => {
         setFieldConfig(current =>
             current.map(field => {
                 if (field.id === id) {
                     return {
                         ...field,
                         type,
-                        imageFieldId: type === "altText" ? imageFieldId : undefined,
+                        imageColumnId: type === "altText" ? imageColumnId : undefined,
                     }
                 }
 
-                if (type !== "image" && isAltTextColumn(field) && field.imageFieldId === id) {
+                if (type !== "image" && isAltTextColumn(field) && field.imageColumnId === id) {
                     return {
                         ...field,
                         type: "string",
-                        imageFieldId: undefined,
+                        imageColumnId: undefined,
                     }
                 }
 
@@ -238,7 +238,7 @@ export function MapSheetFieldsPage({
             fields: allFields,
             spreadsheetId,
             sheetTitle,
-            columnConfigs: fieldConfig.map(field => ({ type: field.type, imageFieldId: field.imageFieldId })),
+            columnConfigs: fieldConfig.map(field => ({ type: field.type, imageColumnId: field.imageColumnId })),
             ignoredColumns: Array.from(disabledColumns),
             slugColumn,
             lastSyncedTime: getLastSyncedTime(pluginContext, slugColumn),

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -31,6 +31,7 @@ const PLUGIN_LAST_SYNCED_KEY = "sheetsPluginLastSynced"
 const PLUGIN_IGNORED_COLUMNS_KEY = "sheetsPluginIgnoredColumns"
 const PLUGIN_SHEET_HEADER_ROW_HASH_KEY = "sheetsPluginSheetHeaderRowHash"
 const PLUGIN_SLUG_COLUMN_KEY = "sheetsPluginSlugColumn"
+const PLUGIN_ALT_TEXT_ASSIGNMENTS_KEY = "sheetsPluginAltTextAssignments"
 
 const CELL_BOOLEAN_VALUES = ["Y", "yes", "true", "TRUE", "Yes", 1, true]
 const HEADER_ROW_DELIMITER = "OIhpKTpp"
@@ -235,9 +236,15 @@ function fetchSheetWithClient(spreadsheetId: string, sheetTitle: string, range?:
 }
 
 export type CollectionFieldType = ManagedCollectionFieldInput["type"]
-export type VirtualFieldType = CollectionFieldType | "dateTime"
+export type VirtualFieldType = CollectionFieldType | "dateTime" | "altText"
 export type SheetCollectionFieldInput = Omit<ManagedCollectionFieldInput, "type"> & {
     type: VirtualFieldType
+    imageFieldId?: string
+}
+
+export interface SheetColumnConfig {
+    type: VirtualFieldType
+    imageFieldId?: string
 }
 
 export interface PluginContextNew {
@@ -259,6 +266,7 @@ export interface PluginContextUpdate {
     sheet: Sheet
     lastSyncedTime: string
     sheetHeaderRow: string[]
+    altTextAssignments: Record<string, string>
 }
 
 export interface PluginContextNoSheetAccess {
@@ -296,13 +304,14 @@ export interface SyncResult extends SyncStatus {
 }
 
 interface ProcessSheetRowParams {
-    fieldTypes: VirtualFieldType[]
+    columnConfigs: SheetColumnConfig[]
     row: Row
     rowIndex: number
     columnCount: number
     uniqueHeaderRowNames: string[]
     slugFieldColumnIndex: number
     ignoredFieldColumnIndexes: number[]
+    imageAltColumnIndexes: Map<number, number>
     status: SyncStatus
 }
 
@@ -313,7 +322,7 @@ export interface SyncMutationOptions {
     fields: SheetCollectionFieldInput[]
     slugColumn: string | null
     ignoredColumns: string[]
-    colFieldTypes: VirtualFieldType[]
+    columnConfigs: SheetColumnConfig[]
     lastSyncedTime: string | null
     /**
      * When false (sync-only mode), schema is only applied when enum fields need refreshed cases.
@@ -410,7 +419,23 @@ function enrichFieldsWithEnumCases(
     })
 }
 
-function getFieldDataEntryInput(type: VirtualFieldType, cellValue: CellValue): FieldDataEntryInput | null {
+function getAltTextAssignments(columnConfigs: SheetColumnConfig[], uniqueHeaderRowNames: string[]) {
+    return columnConfigs.reduce<Record<string, string>>((assignments, column, i) => {
+        if (column.type !== "altText") return assignments
+
+        const imageFieldId = column.imageFieldId
+        const altColumnId = uniqueHeaderRowNames[i]
+        if (!imageFieldId || !altColumnId) return assignments
+
+        return { ...assignments, [altColumnId]: imageFieldId }
+    }, {})
+}
+
+function getFieldDataEntryInput(
+    type: VirtualFieldType,
+    cellValue: CellValue,
+    altCellValue?: CellValue
+): FieldDataEntryInput | null {
     switch (type) {
         case "number": {
             const num = Number(cellValue)
@@ -442,7 +467,14 @@ function getFieldDataEntryInput(type: VirtualFieldType, cellValue: CellValue): F
 
             return null
         }
-        case "image":
+        case "image": {
+            if (!isDefined(cellValue)) return null
+            return {
+                type: "image",
+                value: String(cellValue),
+                alt: isDefined(altCellValue) ? String(altCellValue) : undefined,
+            }
+        }
         case "link":
         case "file":
         case "formattedText":
@@ -467,8 +499,9 @@ function processSheetRow({
     uniqueHeaderRowNames,
     ignoredFieldColumnIndexes,
     slugFieldColumnIndex,
+    imageAltColumnIndexes,
     status,
-    fieldTypes,
+    columnConfigs,
 }: ProcessSheetRowParams) {
     const fieldData: FieldDataInput = {}
     let slugValue: string | null = null
@@ -477,8 +510,11 @@ function processSheetRow({
     for (let i = 0; i < columnCount; i++) {
         const cell = row[i] ?? null
 
-        const fieldType = fieldTypes[i]
+        const fieldType = columnConfigs[i]?.type
         if (!fieldType) continue
+
+        // Alt text columns are virtual and never become their own field
+        if (fieldType === "altText") continue
 
         // Skip processing ignored columns unless they are the slug field
         const isIgnored = ignoredFieldColumnIndexes.includes(i)
@@ -486,7 +522,10 @@ function processSheetRow({
 
         if (isIgnored && !isSlugField) continue
 
-        let fieldDataEntryInput = getFieldDataEntryInput(fieldType, cell)
+        const altColumnIndex = imageAltColumnIndexes.get(i)
+        const altCell = isDefined(altColumnIndex) ? (row[altColumnIndex] ?? null) : undefined
+
+        let fieldDataEntryInput = getFieldDataEntryInput(fieldType, cell, altCell)
 
         // Set to default value for type if no value is provided
         if (!fieldDataEntryInput) {
@@ -636,7 +675,7 @@ export async function syncSheet({
     fields,
     ignoredColumns,
     slugColumn,
-    colFieldTypes,
+    columnConfigs,
     configureFields,
 }: SyncMutationOptions) {
     if (fields.length === 0) {
@@ -649,6 +688,9 @@ export async function syncSheet({
     const [headerRow, ...rows] = sheet.values
 
     const uniqueHeaderRowNames = generateUniqueNames(headerRow)
+
+    const altTextAssignments = getAltTextAssignments(columnConfigs, uniqueHeaderRowNames)
+
     const enrichedFields = enrichFieldsWithEnumCases(fields, uniqueHeaderRowNames, rows)
     const needsFieldSchemaUpdate = configureFields || enrichedFields.some(field => field.type === "enum")
 
@@ -680,11 +722,26 @@ export async function syncSheet({
         )
     }
 
+    const imageAltColumnIndexes = new Map<number, number>()
+    for (let i = 0; i < columnConfigs.length; i++) {
+        if (columnConfigs[i]?.type !== "altText") continue
+        if (ignoredColumns.includes(uniqueHeaderRowNames[i] ?? "")) continue
+
+        const imageFieldId = columnConfigs[i]?.imageFieldId
+        if (!imageFieldId || ignoredColumns.includes(imageFieldId)) continue
+
+        const imageColIndex = uniqueHeaderRowNames.indexOf(imageFieldId)
+        if (imageColIndex === -1 || columnConfigs[imageColIndex]?.type !== "image") continue
+
+        imageAltColumnIndexes.set(imageColIndex, i)
+    }
+
     const { collectionItems, status } = processSheet(rows, {
         uniqueHeaderRowNames,
-        fieldTypes: colFieldTypes,
+        columnConfigs,
         ignoredFieldColumnIndexes: ignoredColumns.map(col => uniqueHeaderRowNames.indexOf(col)),
         slugFieldColumnIndex: slugColumn ? uniqueHeaderRowNames.indexOf(slugColumn) : -1,
+        imageAltColumnIndexes,
         columnCount: headerRow.length,
     })
 
@@ -712,6 +769,7 @@ export async function syncSheet({
         collection.setPluginData(PLUGIN_IGNORED_COLUMNS_KEY, JSON.stringify(ignoredColumns)),
         collection.setPluginData(PLUGIN_SHEET_HEADER_ROW_HASH_KEY, headerRowHash),
         collection.setPluginData(PLUGIN_SLUG_COLUMN_KEY, slugColumn),
+        collection.setPluginData(PLUGIN_ALT_TEXT_ASSIGNMENTS_KEY, JSON.stringify(altTextAssignments)),
         collection.setPluginData(PLUGIN_LAST_SYNCED_KEY, new Date().toISOString()),
     ])
 
@@ -747,12 +805,20 @@ export async function getPluginContext(): Promise<PluginContext> {
     }
 
     // Fetch both new and legacy data
-    const [rawIgnoredColumns, rawSheetHeaderRowHash, storedSlugColumn, lastSyncedTime] = await Promise.all([
-        collection.getPluginData(PLUGIN_IGNORED_COLUMNS_KEY),
-        collection.getPluginData(PLUGIN_SHEET_HEADER_ROW_HASH_KEY),
-        collection.getPluginData(PLUGIN_SLUG_COLUMN_KEY),
-        collection.getPluginData(PLUGIN_LAST_SYNCED_KEY),
-    ])
+    const [rawIgnoredColumns, rawSheetHeaderRowHash, storedSlugColumn, lastSyncedTime, rawAltTextAssignments] =
+        await Promise.all([
+            collection.getPluginData(PLUGIN_IGNORED_COLUMNS_KEY),
+            collection.getPluginData(PLUGIN_SHEET_HEADER_ROW_HASH_KEY),
+            collection.getPluginData(PLUGIN_SLUG_COLUMN_KEY),
+            collection.getPluginData(PLUGIN_LAST_SYNCED_KEY),
+            collection.getPluginData(PLUGIN_ALT_TEXT_ASSIGNMENTS_KEY),
+        ])
+
+    const altTextAssignmentsResult = v.safeParse(
+        v.pipe(v.string(), v.parseJson(), v.record(v.string(), v.string())),
+        rawAltTextAssignments
+    )
+    const altTextAssignments = altTextAssignmentsResult.success ? altTextAssignmentsResult.output : {}
 
     let spreadsheetInfo
 
@@ -865,6 +931,7 @@ export async function getPluginContext(): Promise<PluginContext> {
         collectionFields,
         sheetHeaderRow,
         ignoredColumns,
+        altTextAssignments,
         hasChangedFields: storedSheetHeaderRowHash !== currentSheetHeaderRowHash,
     }
 }

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -1009,7 +1009,7 @@ function mapFieldFromFramer(field: ManagedCollectionFieldInput): SheetCollection
     return field
 }
 
-function mapFieldToFramer(field: SheetCollectionFieldInput): ManagedCollectionFieldInput {
+function mapFieldToFramer({ imageColumnId: _, ...field }: SheetCollectionFieldInput): ManagedCollectionFieldInput {
     if (field.type === "dateTime") {
         return {
             ...field,

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -240,7 +240,7 @@ export type VirtualFieldType = CollectionFieldType | "dateTime" | "altText"
 
 export interface SheetColumnConfig {
     type: VirtualFieldType
-    imageFieldId?: string
+    imageColumnId?: string
 }
 
 export type SheetCollectionFieldInput = Omit<ManagedCollectionFieldInput, "type"> & SheetColumnConfig
@@ -419,20 +419,23 @@ function enrichFieldsWithEnumCases(
     })
 }
 
-function buildAltTextAssignments(columnConfigs: SheetColumnConfig[], uniqueHeaderRowNames: string[]): Record<string, string> {
+function buildAltTextAssignments(
+    columnConfigs: SheetColumnConfig[],
+    uniqueHeaderRowNames: string[]
+): Record<string, string> {
     const assignments: Record<string, string> = {}
 
     for (const [altColumnIndex, columnConfig] of columnConfigs.entries()) {
         if (!isAltTextColumn(columnConfig)) continue
 
         const altColumnId = uniqueHeaderRowNames[altColumnIndex]
-        const imageFieldId = columnConfig.imageFieldId
-        if (!altColumnId || !imageFieldId) continue
+        const imageColumnId = columnConfig.imageColumnId
+        if (!altColumnId || !imageColumnId) continue
 
-        const imageColumnIndex = uniqueHeaderRowNames.indexOf(imageFieldId)
+        const imageColumnIndex = uniqueHeaderRowNames.indexOf(imageColumnId)
         if (imageColumnIndex === -1 || columnConfigs[imageColumnIndex]?.type !== "image") continue
 
-        assignments[altColumnId] = imageFieldId
+        assignments[altColumnId] = imageColumnId
     }
 
     return assignments
@@ -449,10 +452,10 @@ function buildAltColumnIndexByImageColumnIndex(
         const altColumnId = uniqueHeaderRowNames[altColumnIndex]
         if (!altColumnId || ignoredColumns.includes(altColumnId) || !isAltTextColumn(columnConfig)) continue
 
-        const imageFieldId = columnConfig.imageFieldId
-        if (!imageFieldId || ignoredColumns.includes(imageFieldId)) continue
+        const imageColumnId = columnConfig.imageColumnId
+        if (!imageColumnId || ignoredColumns.includes(imageColumnId)) continue
 
-        const imageColumnIndex = uniqueHeaderRowNames.indexOf(imageFieldId)
+        const imageColumnIndex = uniqueHeaderRowNames.indexOf(imageColumnId)
         if (imageColumnIndex === -1 || columnConfigs[imageColumnIndex]?.type !== "image") continue
 
         altColumnIndexByImageColumnIndex.set(imageColumnIndex, altColumnIndex)

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -419,6 +419,24 @@ function enrichFieldsWithEnumCases(
     })
 }
 
+function resolveAltTextPair(
+    altColumnIndex: number,
+    columnConfig: SheetColumnConfig,
+    columnConfigs: SheetColumnConfig[],
+    uniqueHeaderRowNames: string[]
+) {
+    if (!isAltTextColumn(columnConfig)) return null
+
+    const altColumnId = uniqueHeaderRowNames[altColumnIndex]
+    const imageColumnId = columnConfig.imageColumnId
+    if (!altColumnId || !imageColumnId) return null
+
+    const imageColumnIndex = uniqueHeaderRowNames.indexOf(imageColumnId)
+    if (imageColumnIndex === -1 || columnConfigs[imageColumnIndex]?.type !== "image") return null
+
+    return { altColumnId, imageColumnId, imageColumnIndex }
+}
+
 function buildAltTextAssignments(
     columnConfigs: SheetColumnConfig[],
     uniqueHeaderRowNames: string[]
@@ -426,16 +444,10 @@ function buildAltTextAssignments(
     const assignments: Record<string, string> = {}
 
     for (const [altColumnIndex, columnConfig] of columnConfigs.entries()) {
-        if (!isAltTextColumn(columnConfig)) continue
+        const pair = resolveAltTextPair(altColumnIndex, columnConfig, columnConfigs, uniqueHeaderRowNames)
+        if (!pair) continue
 
-        const altColumnId = uniqueHeaderRowNames[altColumnIndex]
-        const imageColumnId = columnConfig.imageColumnId
-        if (!altColumnId || !imageColumnId) continue
-
-        const imageColumnIndex = uniqueHeaderRowNames.indexOf(imageColumnId)
-        if (imageColumnIndex === -1 || columnConfigs[imageColumnIndex]?.type !== "image") continue
-
-        assignments[altColumnId] = imageColumnId
+        assignments[pair.altColumnId] = pair.imageColumnId
     }
 
     return assignments
@@ -449,16 +461,10 @@ function buildAltColumnIndexByImageColumnIndex(
     const altColumnIndexByImageColumnIndex = new Map<number, number>()
 
     for (const [altColumnIndex, columnConfig] of columnConfigs.entries()) {
-        const altColumnId = uniqueHeaderRowNames[altColumnIndex]
-        if (!altColumnId || ignoredColumns.includes(altColumnId) || !isAltTextColumn(columnConfig)) continue
+        const pair = resolveAltTextPair(altColumnIndex, columnConfig, columnConfigs, uniqueHeaderRowNames)
+        if (!pair || ignoredColumns.includes(pair.altColumnId)) continue
 
-        const imageColumnId = columnConfig.imageColumnId
-        if (!imageColumnId || ignoredColumns.includes(imageColumnId)) continue
-
-        const imageColumnIndex = uniqueHeaderRowNames.indexOf(imageColumnId)
-        if (imageColumnIndex === -1 || columnConfigs[imageColumnIndex]?.type !== "image") continue
-
-        altColumnIndexByImageColumnIndex.set(imageColumnIndex, altColumnIndex)
+        altColumnIndexByImageColumnIndex.set(pair.imageColumnIndex, altColumnIndex)
     }
 
     return altColumnIndexByImageColumnIndex

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -247,6 +247,8 @@ export interface SheetColumnConfig {
     imageFieldId?: string
 }
 
+export const isAltTextColumn = (column: Pick<SheetColumnConfig, "type">): boolean => column.type === "altText"
+
 export interface PluginContextNew {
     type: "new"
     collection: ManagedCollection
@@ -421,7 +423,7 @@ function enrichFieldsWithEnumCases(
 
 function buildAltTextAssignments(columnConfigs: SheetColumnConfig[], uniqueHeaderRowNames: string[]) {
     return columnConfigs.reduce<Record<string, string>>((assignments, column, i) => {
-        if (column.type !== "altText") return assignments
+        if (!isAltTextColumn(column)) return assignments
 
         const imageFieldId = column.imageFieldId
         const altColumnId = uniqueHeaderRowNames[i]
@@ -439,10 +441,11 @@ function buildAltColumnIndexByImageColumnIndex(
     const altColumnIndexByImageColumnIndex = new Map<number, number>()
 
     for (let i = 0; i < columnConfigs.length; i++) {
-        if (columnConfigs[i]?.type !== "altText") continue
+        const columnConfig = columnConfigs[i]
+        if (!columnConfig || !isAltTextColumn(columnConfig)) continue
         if (ignoredColumns.includes(uniqueHeaderRowNames[i] ?? "")) continue
 
-        const imageFieldId = columnConfigs[i]?.imageFieldId
+        const imageFieldId = columnConfig.imageFieldId
         if (!imageFieldId || ignoredColumns.includes(imageFieldId)) continue
 
         const imageColumnIndex = uniqueHeaderRowNames.indexOf(imageFieldId)
@@ -533,11 +536,10 @@ function processSheetRow({
     for (let i = 0; i < columnCount; i++) {
         const cell = row[i] ?? null
 
-        const fieldType = columnConfigs[i]?.type
-        if (!fieldType) continue
-
-        // Alt text columns are virtual and never become their own field
-        if (fieldType === "altText") continue
+        const columnConfig = columnConfigs[i]
+        // Alt text columns are virtual and never become their own field.
+        if (!columnConfig || isAltTextColumn(columnConfig)) continue
+        const fieldType = columnConfig.type
 
         // Skip processing ignored columns unless they are the slug field
         const isIgnored = ignoredFieldColumnIndexes.includes(i)

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -429,6 +429,9 @@ function buildAltTextAssignments(columnConfigs: SheetColumnConfig[], uniqueHeade
         const altColumnId = uniqueHeaderRowNames[i]
         if (!imageFieldId || !altColumnId) return assignments
 
+        const imageColumnIndex = uniqueHeaderRowNames.indexOf(imageFieldId)
+        if (imageColumnIndex === -1 || columnConfigs[imageColumnIndex]?.type !== "image") return assignments
+
         return { ...assignments, [altColumnId]: imageFieldId }
     }, {})
 }

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -237,15 +237,13 @@ function fetchSheetWithClient(spreadsheetId: string, sheetTitle: string, range?:
 
 export type CollectionFieldType = ManagedCollectionFieldInput["type"]
 export type VirtualFieldType = CollectionFieldType | "dateTime" | "altText"
-export type SheetCollectionFieldInput = Omit<ManagedCollectionFieldInput, "type"> & {
-    type: VirtualFieldType
-    imageFieldId?: string
-}
 
 export interface SheetColumnConfig {
     type: VirtualFieldType
     imageFieldId?: string
 }
+
+export type SheetCollectionFieldInput = Omit<ManagedCollectionFieldInput, "type"> & SheetColumnConfig
 
 export const isAltTextColumn = (column: Pick<SheetColumnConfig, "type">): boolean => column.type === "altText"
 
@@ -421,19 +419,23 @@ function enrichFieldsWithEnumCases(
     })
 }
 
-function buildAltTextAssignments(columnConfigs: SheetColumnConfig[], uniqueHeaderRowNames: string[]) {
-    return columnConfigs.reduce<Record<string, string>>((assignments, column, i) => {
-        if (!isAltTextColumn(column)) return assignments
+function buildAltTextAssignments(columnConfigs: SheetColumnConfig[], uniqueHeaderRowNames: string[]): Record<string, string> {
+    const assignments: Record<string, string> = {}
 
-        const imageFieldId = column.imageFieldId
-        const altColumnId = uniqueHeaderRowNames[i]
-        if (!imageFieldId || !altColumnId) return assignments
+    for (const [altColumnIndex, columnConfig] of columnConfigs.entries()) {
+        if (!isAltTextColumn(columnConfig)) continue
+
+        const altColumnId = uniqueHeaderRowNames[altColumnIndex]
+        const imageFieldId = columnConfig.imageFieldId
+        if (!altColumnId || !imageFieldId) continue
 
         const imageColumnIndex = uniqueHeaderRowNames.indexOf(imageFieldId)
-        if (imageColumnIndex === -1 || columnConfigs[imageColumnIndex]?.type !== "image") return assignments
+        if (imageColumnIndex === -1 || columnConfigs[imageColumnIndex]?.type !== "image") continue
 
-        return { ...assignments, [altColumnId]: imageFieldId }
-    }, {})
+        assignments[altColumnId] = imageFieldId
+    }
+
+    return assignments
 }
 
 function buildAltColumnIndexByImageColumnIndex(
@@ -443,10 +445,9 @@ function buildAltColumnIndexByImageColumnIndex(
 ): Map<number, number> {
     const altColumnIndexByImageColumnIndex = new Map<number, number>()
 
-    for (let i = 0; i < columnConfigs.length; i++) {
-        const columnConfig = columnConfigs[i]
-        if (!columnConfig || !isAltTextColumn(columnConfig)) continue
-        if (ignoredColumns.includes(uniqueHeaderRowNames[i] ?? "")) continue
+    for (const [altColumnIndex, columnConfig] of columnConfigs.entries()) {
+        const altColumnId = uniqueHeaderRowNames[altColumnIndex]
+        if (!altColumnId || ignoredColumns.includes(altColumnId) || !isAltTextColumn(columnConfig)) continue
 
         const imageFieldId = columnConfig.imageFieldId
         if (!imageFieldId || ignoredColumns.includes(imageFieldId)) continue
@@ -454,7 +455,7 @@ function buildAltColumnIndexByImageColumnIndex(
         const imageColumnIndex = uniqueHeaderRowNames.indexOf(imageFieldId)
         if (imageColumnIndex === -1 || columnConfigs[imageColumnIndex]?.type !== "image") continue
 
-        altColumnIndexByImageColumnIndex.set(imageColumnIndex, i)
+        altColumnIndexByImageColumnIndex.set(imageColumnIndex, altColumnIndex)
     }
 
     return altColumnIndexByImageColumnIndex

--- a/plugins/google-sheets/src/sheets.ts
+++ b/plugins/google-sheets/src/sheets.ts
@@ -311,7 +311,7 @@ interface ProcessSheetRowParams {
     uniqueHeaderRowNames: string[]
     slugFieldColumnIndex: number
     ignoredFieldColumnIndexes: number[]
-    imageAltColumnIndexes: Map<number, number>
+    altColumnIndexByImageColumnIndex: Map<number, number>
     status: SyncStatus
 }
 
@@ -419,7 +419,7 @@ function enrichFieldsWithEnumCases(
     })
 }
 
-function getAltTextAssignments(columnConfigs: SheetColumnConfig[], uniqueHeaderRowNames: string[]) {
+function buildAltTextAssignments(columnConfigs: SheetColumnConfig[], uniqueHeaderRowNames: string[]) {
     return columnConfigs.reduce<Record<string, string>>((assignments, column, i) => {
         if (column.type !== "altText") return assignments
 
@@ -429,6 +429,29 @@ function getAltTextAssignments(columnConfigs: SheetColumnConfig[], uniqueHeaderR
 
         return { ...assignments, [altColumnId]: imageFieldId }
     }, {})
+}
+
+function buildAltColumnIndexByImageColumnIndex(
+    columnConfigs: SheetColumnConfig[],
+    uniqueHeaderRowNames: string[],
+    ignoredColumns: string[]
+): Map<number, number> {
+    const altColumnIndexByImageColumnIndex = new Map<number, number>()
+
+    for (let i = 0; i < columnConfigs.length; i++) {
+        if (columnConfigs[i]?.type !== "altText") continue
+        if (ignoredColumns.includes(uniqueHeaderRowNames[i] ?? "")) continue
+
+        const imageFieldId = columnConfigs[i]?.imageFieldId
+        if (!imageFieldId || ignoredColumns.includes(imageFieldId)) continue
+
+        const imageColumnIndex = uniqueHeaderRowNames.indexOf(imageFieldId)
+        if (imageColumnIndex === -1 || columnConfigs[imageColumnIndex]?.type !== "image") continue
+
+        altColumnIndexByImageColumnIndex.set(imageColumnIndex, i)
+    }
+
+    return altColumnIndexByImageColumnIndex
 }
 
 function getFieldDataEntryInput(
@@ -499,7 +522,7 @@ function processSheetRow({
     uniqueHeaderRowNames,
     ignoredFieldColumnIndexes,
     slugFieldColumnIndex,
-    imageAltColumnIndexes,
+    altColumnIndexByImageColumnIndex,
     status,
     columnConfigs,
 }: ProcessSheetRowParams) {
@@ -522,7 +545,7 @@ function processSheetRow({
 
         if (isIgnored && !isSlugField) continue
 
-        const altColumnIndex = imageAltColumnIndexes.get(i)
+        const altColumnIndex = altColumnIndexByImageColumnIndex.get(i)
         const altCell = isDefined(altColumnIndex) ? (row[altColumnIndex] ?? null) : undefined
 
         let fieldDataEntryInput = getFieldDataEntryInput(fieldType, cell, altCell)
@@ -689,7 +712,7 @@ export async function syncSheet({
 
     const uniqueHeaderRowNames = generateUniqueNames(headerRow)
 
-    const altTextAssignments = getAltTextAssignments(columnConfigs, uniqueHeaderRowNames)
+    const altTextAssignments = buildAltTextAssignments(columnConfigs, uniqueHeaderRowNames)
 
     const enrichedFields = enrichFieldsWithEnumCases(fields, uniqueHeaderRowNames, rows)
     const needsFieldSchemaUpdate = configureFields || enrichedFields.some(field => field.type === "enum")
@@ -722,26 +745,18 @@ export async function syncSheet({
         )
     }
 
-    const imageAltColumnIndexes = new Map<number, number>()
-    for (let i = 0; i < columnConfigs.length; i++) {
-        if (columnConfigs[i]?.type !== "altText") continue
-        if (ignoredColumns.includes(uniqueHeaderRowNames[i] ?? "")) continue
-
-        const imageFieldId = columnConfigs[i]?.imageFieldId
-        if (!imageFieldId || ignoredColumns.includes(imageFieldId)) continue
-
-        const imageColIndex = uniqueHeaderRowNames.indexOf(imageFieldId)
-        if (imageColIndex === -1 || columnConfigs[imageColIndex]?.type !== "image") continue
-
-        imageAltColumnIndexes.set(imageColIndex, i)
-    }
+    const altColumnIndexByImageColumnIndex = buildAltColumnIndexByImageColumnIndex(
+        columnConfigs,
+        uniqueHeaderRowNames,
+        ignoredColumns
+    )
 
     const { collectionItems, status } = processSheet(rows, {
         uniqueHeaderRowNames,
         columnConfigs,
         ignoredFieldColumnIndexes: ignoredColumns.map(col => uniqueHeaderRowNames.indexOf(col)),
         slugFieldColumnIndex: slugColumn ? uniqueHeaderRowNames.indexOf(slugColumn) : -1,
-        imageAltColumnIndexes,
+        altColumnIndexByImageColumnIndex,
         columnCount: headerRow.length,
     })
 


### PR DESCRIPTION
### Description

Adds image alt-text support to the Google Sheets plugin, including field mapping, synchronization, persisted assignments, and automatic cleanup when image field types change.

https://github.com/user-attachments/assets/d14f2cee-6ca8-46fd-af47-e2224e91c3ba

Fixes: https://github.com/framer/plugins/issues/423
<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

### Changelog

<!-- Required when using the "Auto submit to Marketplace on merge" label. Describe user-facing changes in bullet points. -->

- Added support for mapping Google Sheets columns as alt text for CMS image fields.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Image alt text imports correctly
    - [ ] Map a text column to an image field as Alt Text
    - [ ] Confirm no CMS field is created for the alt-text column
    - [ ] Confirm the rendered image has the expected `alt` value
- [x] Alt-text mappings persist and update
    - [ ] Reopen the plugin and confirm the mapping is restored
    - [ ] Change the alt text and run automatic sync
    - [ ] Confirm the rendered alt text updates
- [x] Alt text can be cleared
    - [ ] Sync an image with populated alt text
    - [ ] Clear the corresponding sheet cell and sync again
    - [ ] Confirm the previous alt text is removed
- [x] Existing collections remain compatible after upgrading
    - [ ] Sync without changing field mappings
    - [ ] Confirm existing fields, items, images, and ignored columns remain unchanged
- [x] Mapping changes are handled safely
    - [ ] Remap the alt-text column to another image
    - [ ] Change the target image to another field type
    - [ ] Confirm no stale or incorrect mapping remains
- [x] Sheet structure changes are handled safely
    - [ ] Reorder the mapped columns
    - [ ] Rename or remove a mapped column
    - [ ] Confirm existing CMS fields are not corrupted

<!-- Thank you for contributing! -->