### PR TITLE
Code Link: Ensure the server stops reliably with --once

### DIFF
--- a/packages/code-link-cli/package.json
+++ b/packages/code-link-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-code-link",
-    "version": "0.21.0",
+    "version": "0.21.1",
     "description": "CLI tool for syncing Framer code components - controller-centric architecture",
     "main": "dist/index.mjs",
     "type": "module",

--- a/packages/code-link-cli/src/controller.ts
+++ b/packages/code-link-cli/src/controller.ts
@@ -1468,12 +1468,21 @@ export async function start(config: Config): Promise<void> {
         isShuttingDown = true
         runtime.cleanupUserActions()
 
+        if (pendingDependencyVersions) {
+            clearTimeout(pendingDependencyVersions.timeout)
+            pendingDependencyVersions = null
+        }
+
         if (watcher) {
             await watcher.close()
             watcher = null
         }
 
         connection.close()
+
+        // Closing the server does not always release the event loop, so a one-shot run has
+        // to exit explicitly.
+        if (config.once) process.exit(0)
     }
 
     const startWatcher = () => {

--- a/packages/code-link-cli/src/index.ts
+++ b/packages/code-link-cli/src/index.ts
@@ -118,7 +118,3 @@ program
     )
 
 program.parse()
-
-// Export for programmatic usage
-export { start } from "./controller.ts"
-export type { Config } from "./types.ts"


### PR DESCRIPTION
I ran into `npx framer-code-link --once` hanging after printing

```
$ npx framer-code-link --once --dir .

  ⚡ Code Link v0.21.0

  Waiting for Plugin connection...
✓ Connected to 💙 Shaders 2026
✓ Synced into . (0 files updated, 29 unchanged)
  Sync complete, exiting...
```

This usually happens because we forgot to clean up something (timeouts or sockets). But it’s easy to forget to clean things up, so `process.exit()` should fix it for good.