### PR TITLE
Fix Code Link delete button in dark mode

### DIFF
--- a/plugins/code-link/src/App.css
+++ b/plugins/code-link/src/App.css
@@ -113,6 +113,20 @@ html,
 .destructive-button:active {
     background: #cf2e55;
 }
+
+[data-framer-theme="dark"] .framer-button-primary.destructive-button {
+    background: #ff3366;
+}
+
+[data-framer-theme="dark"] .framer-button-primary.destructive-button:hover,
+[data-framer-theme="dark"] .framer-button-primary.destructive-button:focus {
+    background: #e7315e;
+}
+
+[data-framer-theme="dark"] .framer-button-primary.destructive-button:active {
+    background: #cf2e55;
+}
+
 /* Copy Button */
 .copy-button {
     display: flex;

--- a/plugins/code-link/src/App.tsx
+++ b/plugins/code-link/src/App.tsx
@@ -355,7 +355,7 @@ function DeletePanel({ files, onConfirm, onKeep }: DeletePanelProps) {
           }
         : {
               title: "Confirm Deletion",
-              description: "Code file was deleted locally and will be permanently removed from this Project.",
+              description: "File was deleted locally and will be permanently removed from this Project.",
           }
 
     const lines = files.map(file => file.content?.split("\n").length ?? 0)


### PR DESCRIPTION
### Description

Fix the Code Link deletion confirmation button so its destructive red styling is not overridden by Framer's dark-mode primary button styles. This also simplifies copy so it fits on two lines.

<img width="332" height="310" alt="Screenshot 2026-08-05 at 11 42 54" src="https://github.com/user-attachments/assets/76203788-858f-45c2-94f3-1926561fa047" />

### Changelog

- Keep the Code Link deletion confirmation button red and legible in dark mode.

### Testing

- [ ] Verify the deletion confirmation modal in dark mode
  - [x] Open Code Link and trigger a local file deletion confirmation
  - [x] Verify the modal looks correct
  - [x] Verify the Delete button text is legible

<!-- Thank you for contributing! -->
