### PR TITLE
Fix HubSpot blog author name

### DIFF
--- a/plugins/hubspot/src/api.ts
+++ b/plugins/hubspot/src/api.ts
@@ -1,3 +1,4 @@
+import type { BlogAuthor } from "@hubspot/api-client/lib/codegen/cms/blogs/authors/models/BlogAuthor"
 import { BlogPost } from "@hubspot/api-client/lib/codegen/cms/blogs/blog_posts/models/BlogPost"
 import { HubDbTableRowV3 } from "@hubspot/api-client/lib/codegen/cms/hubdb/models/HubDbTableRowV3"
 import { HubDbTableV3 } from "@hubspot/api-client/lib/codegen/cms/hubdb/models/HubDbTableV3"
@@ -100,6 +101,7 @@ const API_URL = "https://api.hubapi.com"
 
 const queryKeys = {
     blogPosts: (limit: number, properties: string[]) => ["blog-posts", limit, properties] as const,
+    blogAuthor: (id: string) => ["blog-author", id] as const,
     publishedTables: (limit: number) => ["hubdb-tables", limit] as const,
     publishedTable: (tableId: string) => ["hubdb-table", tableId] as const,
     tableRows: (tableId: string, properties: string[], limit: number) =>
@@ -174,6 +176,13 @@ export const fetchAllBlogPosts = (limit: number, properties: string[]): Promise<
     return cachedFetch(
         queryKeys.blogPosts(limit, properties),
         () => request({ path: "/cms/v3/blogs/posts", query: { limit, properties } }) as Promise<CMSPaging<BlogPost>>
+    )
+}
+
+export const fetchBlogAuthor = (authorId: string): Promise<BlogAuthor> => {
+    return cachedFetch(
+        queryKeys.blogAuthor(authorId),
+        () => request({ path: `/cms/v3/blogs/authors/${authorId}` }) as Promise<BlogAuthor>
     )
 }
 

--- a/plugins/hubspot/src/blog.ts
+++ b/plugins/hubspot/src/blog.ts
@@ -242,15 +242,22 @@ export async function syncBlogs({ fields, includedFieldIds }: SyncBlogMutation) 
 
     const fieldsById = new Map(fields.map(field => [field.id, field]))
     const unsyncedItemIds = new Set(await collection.getItemIds())
+    const hasAuthorNameField = fieldsById.has(AUTHOR_NAME_FIELD_ID)
     const requestedProperties = new Set([...includedFieldIds, "id", "slug"])
 
-    if (fieldsById.has(AUTHOR_NAME_FIELD_ID)) requestedProperties.add(BLOG_AUTHOR_ID_FIELD_ID)
+    if (hasAuthorNameField) requestedProperties.add(BLOG_AUTHOR_ID_FIELD_ID)
 
     const { results: posts } = await fetchAllBlogPosts(MAX_CMS_ITEMS, Array.from(requestedProperties))
 
-    const authorIds = Array.from(new Set(posts.map(post => post.blogAuthorId)))
-    const authors = authorIds.length ? await Promise.all(authorIds.map(fetchBlogAuthor)) : []
-    const authorNamesById = new Map(authors.map(author => [author.id, author.displayName]))
+    const authorNamesById = new Map<string, string>()
+    if (hasAuthorNameField) {
+        const authorIds = Array.from(new Set(posts.map(post => post.blogAuthorId)))
+        const authors = authorIds.length ? await Promise.all(authorIds.map(fetchBlogAuthor)) : []
+
+        for (const author of authors) {
+            authorNamesById.set(author.id, author.displayName)
+        }
+    }
 
     const { collectionItems, status } = processBlog(posts, {
         fields,

--- a/plugins/hubspot/src/blog.ts
+++ b/plugins/hubspot/src/blog.ts
@@ -7,7 +7,7 @@ import {
     type ManagedCollection,
     type ManagedCollectionFieldInput,
 } from "framer-plugin"
-import { fetchAllBlogPosts } from "./api"
+import { fetchAllBlogPosts, fetchBlogAuthor } from "./api"
 import {
     computeFieldSets,
     createFieldSetHash,
@@ -22,6 +22,10 @@ import { assert, isDefined } from "./utils"
 
 export const PLUGIN_INCLUDED_FIELDS_HASH = "hubspotPluginBlogIncludedFieldsHash"
 
+// Keep this ID stable for existing managed collections and their Framer bindings.
+const AUTHOR_NAME_FIELD_ID = "authorName"
+const BLOG_AUTHOR_ID_FIELD_ID = "blogAuthorId"
+
 export interface SyncBlogMutation {
     fields: ManagedCollectionFieldInput[]
     includedFieldIds: string[]
@@ -30,6 +34,7 @@ export interface SyncBlogMutation {
 export interface ProcessBlogParams {
     fields: ManagedCollectionFieldInput[]
     fieldsById: FieldsById
+    authorNamesById: Map<string, string>
     unsyncedItemIds: Set<string>
 }
 
@@ -166,7 +171,7 @@ function getFieldDataEntryInput(
     }
 }
 
-function processPost({ post, fieldsById, unsyncedItemIds, status }: ProcessPostParams) {
+function processPost({ post, fieldsById, authorNamesById, unsyncedItemIds, status }: ProcessPostParams) {
     let slugValue: string | null = null
     const fieldData: FieldDataInput = {}
 
@@ -184,7 +189,12 @@ function processPost({ post, fieldsById, unsyncedItemIds, status }: ProcessPostP
         // Not included in field mapping, skip
         if (!field) continue
 
-        const fieldDataEntryInput = getFieldDataEntryInput(field, propertyValue, post)
+        // HubSpot uses authorName for the user who updated the post, not its blog author.
+        // Retain that value when the associated Blog Author cannot be resolved.
+        const resolvedAuthorName =
+            propertyName === AUTHOR_NAME_FIELD_ID ? authorNamesById.get(post.blogAuthorId) : undefined
+        const value = resolvedAuthorName ?? propertyValue
+        const fieldDataEntryInput = getFieldDataEntryInput(field, value, post)
         if (fieldDataEntryInput) {
             fieldData[propertyName] = fieldDataEntryInput
         } else {
@@ -232,15 +242,20 @@ export async function syncBlogs({ fields, includedFieldIds }: SyncBlogMutation) 
 
     const fieldsById = new Map(fields.map(field => [field.id, field]))
     const unsyncedItemIds = new Set(await collection.getItemIds())
+    const requestedProperties = new Set([...includedFieldIds, "id", "slug"])
 
-    // Always include the blog Id and slug
-    const { results: posts } = await fetchAllBlogPosts(
-        MAX_CMS_ITEMS,
-        Array.from(new Set([...includedFieldIds, "id", "slug"]))
-    )
+    if (fieldsById.has(AUTHOR_NAME_FIELD_ID)) requestedProperties.add(BLOG_AUTHOR_ID_FIELD_ID)
+
+    const { results: posts } = await fetchAllBlogPosts(MAX_CMS_ITEMS, Array.from(requestedProperties))
+
+    const authorIds = Array.from(new Set(posts.map(post => post.blogAuthorId)))
+    const authors = authorIds.length ? await Promise.all(authorIds.map(fetchBlogAuthor)) : []
+    const authorNamesById = new Map(authors.map(author => [author.id, author.displayName]))
+
     const { collectionItems, status } = processBlog(posts, {
         fields,
         fieldsById,
+        authorNamesById,
         unsyncedItemIds,
     })
 


### PR DESCRIPTION
### Description

<!-- What is this PR doing? Please write a clear description or reference the issues it solves (e.g. `fixes #123`). Are there any parts you think require specific attention from reviewers? -->

This pull request fixes an issue where hubspot blog author name was synced with last editor name instead of the actual linked author name. The field `authorName` is a bit confusing, but according to their docs indeed something else than what you would expect (https://developers.hubspot.com/docs/api-reference/latest/cms/blogs/posts/create-post#body-author-name)

To keep this change backwards compatible, we keep using the original `authorName` field id, but populate it with the fetched blog author name.

### Changelog

<!-- Required when using the "Auto submit to Marketplace on merge" label. Describe user-facing changes in bullet points. -->

- Fixed synced blog posts showing the last editor name instead of the linked author name.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Sync a hubspot blog post and verify the author name is now populated with actual blog author that you linked to the post and not the last updated name