### PR TITLE
HubSpot plugin - handle invalid blog author references

### DIFF
--- a/plugins/hubspot/src/PluginError.ts
+++ b/plugins/hubspot/src/PluginError.ts
@@ -1,7 +1,8 @@
 export class PluginError extends Error {
     constructor(
         public title: string,
-        message: string
+        message: string,
+        public status?: number
     ) {
         super(message)
         Object.setPrototypeOf(this, PluginError.prototype)

--- a/plugins/hubspot/src/api.ts
+++ b/plugins/hubspot/src/api.ts
@@ -149,7 +149,7 @@ const request = async ({ path, method, query, body }: RequestOptions): Promise<u
         }
 
         if (!res.ok) {
-            throw new PluginError("Fetch Failed", `Failed to fetch HubSpot API: ${res.status}`)
+            throw new PluginError("Fetch Failed", `Failed to fetch HubSpot API: ${res.status}`, res.status)
         }
 
         return await res.json()
@@ -179,11 +179,20 @@ export const fetchAllBlogPosts = (limit: number, properties: string[]): Promise<
     )
 }
 
-export const fetchBlogAuthor = (authorId: string): Promise<BlogAuthor> => {
-    return cachedFetch(
-        queryKeys.blogAuthor(authorId),
-        () => request({ path: `/cms/v3/blogs/authors/${authorId}` }) as Promise<BlogAuthor>
-    )
+export async function fetchBlogAuthor(authorId: string): Promise<BlogAuthor | undefined> {
+    try {
+        return await cachedFetch(
+            queryKeys.blogAuthor(authorId),
+            () =>
+                request({
+                    path: `/cms/v3/blogs/authors/${authorId}`,
+                    query: { archived: "true" },
+                }) as Promise<BlogAuthor>
+        )
+    } catch (e) {
+        if (e instanceof PluginError && e.status === 404) return undefined
+        throw e
+    }
 }
 
 export const fetchPublishedTables = (limit: number): Promise<CMSPaging<HubDbTableV3>> => {

--- a/plugins/hubspot/src/blog.ts
+++ b/plugins/hubspot/src/blog.ts
@@ -251,8 +251,14 @@ export async function syncBlogs({ fields, includedFieldIds }: SyncBlogMutation) 
 
     const authorNamesById = new Map<string, string>()
     if (hasAuthorNameField) {
-        const authorIds = Array.from(new Set(posts.map(post => post.blogAuthorId)))
-        const authors = authorIds.length ? await Promise.all(authorIds.map(fetchBlogAuthor)) : []
+        // Blog posts should have a blogAuthorId, but drafts or unexpected data may not.
+        // Gracefully fall back to the last updated author name in those cases.
+        const authorIds = Array.from(
+            new Set(
+                posts.map(post => post.blogAuthorId).filter((id): id is string => typeof id === "string" && id !== "")
+            )
+        )
+        const authors = authorIds.length ? (await Promise.all(authorIds.map(fetchBlogAuthor))).filter(isDefined) : []
 
         for (const author of authors) {
             authorNamesById.set(author.id, author.displayName)


### PR DESCRIPTION
### Description

This pull request gracefully handles invalid blog author references on a post and fallbacks to last updated by. According to HubSpot this shouldn't be possible and they enforce that a blog post must have a valid blog author. However, drafts are also synced and those might not have a valid blog author id.

### Changelog

<!-- Required when using the "Auto submit to Marketplace on merge" label. Describe user-facing changes in bullet points. -->

- Gracefully handles invalid or missing blog author references on a blog post and fallbacks to last updated by.

### Testing

<!-- List of steps to verify the code this pull request changed. If it is a Plugin additions, what are the core workflows to test. If it is a bug fix, what are the steps to verify it is fixed -->

- [x] Validate that triggering a 404 on getting a blog post author should no longer fail the sync, but fallbacks to last updated at (authorName)

<!-- Thank you for contributing! -->