### PR TITLE
chore(scripts): Submit plugin releases through FCS

### DIFF
--- a/.github/workflows/submit-on-merge.yml
+++ b/.github/workflows/submit-on-merge.yml
@@ -53,7 +53,6 @@ jobs:
           DEBUG: "1"
           PR_BODY_FILE: /tmp/pr-body.txt
           SESSION_TOKEN: ${{ secrets.SESSION_TOKEN }}
-          FRAMER_ADMIN_SECRET: ${{ secrets.FRAMER_ADMIN_SECRET }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_ERROR_WEBHOOK_URL: ${{ secrets.SLACK_ERROR_WEBHOOK_URL }}
           RETOOL_URL: ${{ secrets.RETOOL_URL }}

--- a/.github/workflows/submit-plugin.yml
+++ b/.github/workflows/submit-plugin.yml
@@ -55,9 +55,6 @@ on:
       SESSION_TOKEN:
         description: 'Framer session cookie'
         required: true
-      FRAMER_ADMIN_SECRET:
-        description: 'Framer admin API key'
-        required: true
       SLACK_WEBHOOK_URL:
         description: 'Slack webhook URL for notifications'
         required: false
@@ -146,7 +143,6 @@ jobs:
           CHANGELOG: ${{ inputs.changelog }}
           PR_BODY: ${{ inputs.pr_body }}
           SESSION_TOKEN: ${{ secrets.SESSION_TOKEN }}
-          FRAMER_ADMIN_SECRET: ${{ secrets.FRAMER_ADMIN_SECRET }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_ERROR_WEBHOOK_URL: ${{ secrets.SLACK_ERROR_WEBHOOK_URL }}
           RETOOL_URL: ${{ secrets.RETOOL_URL }}

--- a/scripts/lib/env.ts
+++ b/scripts/lib/env.ts
@@ -27,7 +27,6 @@ export const EnvSchema = v.object({
     DRY_RUN: BooleanEnvSchema,
     REPO_ROOT: v.optional(v.string()),
     SESSION_TOKEN: v.pipe(v.string(), v.minLength(1)),
-    FRAMER_ADMIN_SECRET: v.pipe(v.string(), v.minLength(1)),
 })
 
 export type FramerEnv = v.InferOutput<typeof FramerEnvSchema>
@@ -35,7 +34,6 @@ export type Environment = v.InferOutput<typeof EnvSchema>
 
 export interface EnvironmentUrls {
     apiBase: string
-    creatorsApiBase: string
     framerAppUrl: string
     marketplaceBaseUrl: string
 }
@@ -43,13 +41,11 @@ export interface EnvironmentUrls {
 export const ENVIRONMENT_URLS: Record<FramerEnv, EnvironmentUrls> = {
     production: {
         apiBase: "https://api.framer.com",
-        creatorsApiBase: "https://marketplace.framer.com",
         framerAppUrl: "https://framer.com",
         marketplaceBaseUrl: "https://framer.com/marketplace",
     },
     development: {
         apiBase: "https://api.development.framer.com",
-        creatorsApiBase: "https://marketplace.development.framer.com",
         framerAppUrl: "https://development.framer.com",
         marketplaceBaseUrl: "https://marketplace.development.framer.com/marketplace",
     },

--- a/scripts/lib/framer-api.ts
+++ b/scripts/lib/framer-api.ts
@@ -51,6 +51,11 @@ const SubmissionResponseSchema = v.object({
 })
 export type SubmissionResponse = v.InferOutput<typeof SubmissionResponseSchema>
 
+/** The Creators Service wraps every response, so the release details sit under `data`. */
+const ReleaseResponseSchema = v.object({
+    data: SubmissionResponseSchema,
+})
+
 export const FramerJsonSchema = v.object({
     id: v.string(),
     name: v.string(),
@@ -111,43 +116,86 @@ export function loadFramerJsonFile(pluginPath: string): FramerJson {
     return framerJson
 }
 
+/**
+ * Two calls, because the zip goes to the plugins API and only the resulting
+ * version id goes to the marketplace. The version is left pending for a human
+ * to approve.
+ */
 export async function submitPlugin(
     zipFilePath: string,
     plugin: Plugin,
     env: Environment,
     changelog: string
 ): Promise<SubmissionResponse> {
-    if (!env.SESSION_TOKEN || !env.FRAMER_ADMIN_SECRET) {
-        throw new Error("Session token and Framer admin secret are required for submission")
-    }
+    const accessToken = await getAccessToken(env)
+    const releaseNotes = await changelogToHtml(changelog)
 
-    const url = `${getURL(env, "creatorsApiBase")}/api/admin/plugin/${plugin.id}/versions/`
+    const versionId = await uploadPluginVersion(zipFilePath, plugin, env, accessToken, releaseNotes)
+    const result = await submitToMarketplace(plugin, env, accessToken, versionId)
 
-    log.info(`Submitting to: ${url}`)
+    log.success(`Submitted! Version: ${result.version}`)
+
+    return result
+}
+
+async function uploadPluginVersion(
+    zipFilePath: string,
+    plugin: Plugin,
+    env: Environment,
+    accessToken: string,
+    releaseNotes: string
+): Promise<string> {
+    const url = `${getURL(env, "apiBase")}/site/v1/plugins/${plugin.id}/versions`
+
+    log.info(`Uploading to: ${url}`)
 
     const zipBuffer = readFileSync(zipFilePath)
-    const blob = new Blob([zipBuffer], { type: "application/zip" })
-
     const formData = new FormData()
-    formData.append("file", blob, "plugin.zip")
-    formData.append("content", await changelogToHtml(changelog))
+    formData.append("file", new Blob([zipBuffer], { type: "application/zip" }), "plugin.zip")
+    formData.append("releaseNotes", releaseNotes)
 
     const response = await fetch(url, {
         method: "POST",
-        headers: {
-            Cookie: `session=${env.SESSION_TOKEN}`,
-            Authorization: `Bearer ${env.FRAMER_ADMIN_SECRET}`,
-        },
+        headers: { Authorization: `Bearer ${accessToken}` },
         body: formData,
     })
 
     if (!response.ok) {
         const errorText = await response.text()
-        throw new Error(`API submission failed: ${response.status} ${response.statusText}\n${errorText}`)
+        throw new Error(`Plugin upload failed: ${response.status} ${response.statusText}\n${errorText}`)
     }
 
-    const result = v.parse(SubmissionResponseSchema, await response.json())
-    log.success(`Submitted! Version: ${result.version}`)
+    const version = v.parse(PluginVersionSchema, await response.json())
 
-    return result
+    return version.id
+}
+
+async function submitToMarketplace(
+    plugin: Plugin,
+    env: Environment,
+    accessToken: string,
+    versionId: string
+): Promise<SubmissionResponse> {
+    const url = `${getURL(env, "apiBase")}/creators/v1/resources/plugin/${plugin.id}/release`
+
+    log.info(`Submitting to: ${url}`)
+
+    const response = await fetch(url, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+            "x-requested-by": "plugin-release-action",
+        },
+        body: JSON.stringify({ versionId }),
+    })
+
+    if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`Marketplace submission failed: ${response.status} ${response.statusText}\n${errorText}`)
+    }
+
+    const body = v.parse(ReleaseResponseSchema, await response.json())
+
+    return body.data
 }

--- a/scripts/submit-on-merge.ts
+++ b/scripts/submit-on-merge.ts
@@ -14,7 +14,7 @@
  *   REPO_ROOT      - Root of the git repository (optional, defaults to parent of scripts/)
  *
  * Plus all environment variables required by submit-plugin.ts:
- *   SESSION_TOKEN, FRAMER_ADMIN_SECRET, SLACK_WEBHOOK_URL, etc.
+ *   SESSION_TOKEN, SLACK_WEBHOOK_URL, etc.
  */
 
 import { execSync } from "node:child_process"

--- a/scripts/submit-plugin.ts
+++ b/scripts/submit-plugin.ts
@@ -12,7 +12,6 @@
  *   CHANGELOG           - Changelog text (required unless PR_BODY is set)
  *   PR_BODY             - Full PR body — changelog will be extracted (alternative to CHANGELOG)
  *   SESSION_TOKEN       - Framer session cookie (required unless DRY_RUN)
- *   FRAMER_ADMIN_SECRET - Framer admin API key (required unless DRY_RUN)
  *   SLACK_WEBHOOK_URL   - Slack workflow webhook for success notifications (optional)
  *   SLACK_ERROR_WEBHOOK_URL - Slack workflow webhook for error notifications (optional)
  *   RETOOL_URL          - Retool dashboard URL for Slack notifications (optional)
@@ -50,7 +49,7 @@ async function main(): Promise<void> {
     try {
         log.info(`Plugin path: ${env.PLUGIN_PATH}`)
         log.info(`Environment: ${env.FRAMER_ENV}`)
-        log.info(`API base: ${getURL(env, "creatorsApiBase")}`)
+        log.info(`API base: ${getURL(env, "apiBase")}`)
         log.info(`Dry run: ${String(env.DRY_RUN)}`)
 
         if (!existsSync(env.PLUGIN_PATH)) {


### PR DESCRIPTION
## Context

Releases used to go to `marketplace.framer.com`, which is behind bot protection and started blocking them. That part of a release now lives in the Creators Service, so the action posts there instead.

The zip still goes to the plugins API, same as before. The action uploads it, gets a version id back, and sends that id to the Creators Service. Releases still wait for a human to approve them.

The endpoint is already deployed (framer/FramerCreatorsService#857). framer/FramerCreatorsService#866 and framer/FramerAdminApi#1497 moved approving a version over too, which is what Retool uses now.

## Changes

- One call became two: upload the zip, then record the release.
- Stopped using `FRAMER_ADMIN_SECRET`. The old endpoint never read it, and the new one uses the access token the script already gets.
- Left that secret declared but optional. `framer/workshop` calls this workflow at `@main` and still passes it, so removing the declaration would break their releases before anything runs. Delete it once they stop.

## Tested in development

Ran the script by hand against `api.development.framer.com`, no dry run.

- The zip uploaded and the Creators Service saved the version. It was pending, as expected.
- Approving it in Retool marked it approved in both places, and the reviewer's email and note showed up in the plugins service.
- Both then agreed on which version the plugin ships.

### Output

```
============================================================
Submitting Plugin to Framer Marketplace
============================================================

=== Configuration ===
[INFO] Plugin path: /Users/xavi/projects/random-plugins/hippie-plugin/hippie-plugin
[INFO] Environment: development
[INFO] API base: https://api.development.framer.com
[INFO] Dry run: false

=== Resolving Changelog ===

=== Loading Plugin Info ===
[INFO] Name: Hippie Plugin
[INFO] Manifest ID: adf302

=== Fetching Plugin from Framer ===
[INFO] Found plugin with ID: xxxxxxxxxxxx

=== Changelog ===
[INFO] Changelog:
Testing the new release flow

=== Building & Packing Plugin ===
[INFO] Building plugin...
Detected package manager: npm

> hippie-plugin@0.0.1 build
> vite build

vite v8.2.2 building client environment for production...
transforming...
✓ 17 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                   1.66 kB │ gzip:  0.92 kB
dist/assets/index-C9WnqhgS.css   20.58 kB │ gzip:  6.80 kB
dist/index-BybadMkU.mjs         208.56 kB │ gzip: 62.08 kB

✓ built in 70ms
[INFO] Creating plugin.zip...

=== Submitting to Framer API ===
[INFO] Uploading to: https://api.development.framer.com/site/v1/plugins/xxxxxxxxxxxx/versions
[INFO] Submitting to: https://api.development.framer.com/creators/v1/resources/plugin/xxxxxxxxxxxx/release
[SUCCESS] Submitted! Version: 2
```

I verified in the DB that everything is correct. The plugin is listed and the proper version is loaded in Framer.


